### PR TITLE
Hanlding exceptions when construcing elements

### DIFF
--- a/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
+++ b/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
@@ -31,6 +31,51 @@ namespace Revit.Elements
         /// <param name="fs">FamilySymbol to place</param>
         private AdaptiveComponent(Point[] pts, FamilySymbol fs)
         {
+            SafeInit(() => InitAdaptiveComponent(pts, fs));
+        }
+
+        /// <summary>
+        /// Internal constructor for the AdaptiveComponent wrapper
+        /// </summary>
+        /// <param name="pts">Points to use as reference</param>
+        /// <param name="f">Face to use as reference</param>
+        /// <param name="fs">FamilySymbol to place</param>
+        private AdaptiveComponent(double[][] pts, ElementFaceReference f, FamilySymbol fs)
+        {
+            SafeInit(() => InitAdaptiveComponent(pts, f, fs));
+        }
+
+        /// <summary>
+        /// Internal constructor for the AdaptiveComponent wrapper
+        /// </summary>
+        /// <param name="params">Params on curve to reference</param>
+        /// <param name="c">Curve to use as reference</param>
+        /// <param name="fs">FamilySymbol to place</param>
+        private AdaptiveComponent(double[] parms, Reference c, FamilySymbol fs)
+        {
+            SafeInit(() => InitAdaptiveComponent(parms, c, fs));
+        }
+
+        /// <summary>
+        /// Internal constructor for existing Elements.
+        /// </summary>
+        /// <param name="familyInstance"></param>
+        private AdaptiveComponent(Autodesk.Revit.DB.FamilyInstance familyInstance)
+        {
+            SafeInit(() => InitAdaptiveComponent(familyInstance));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize an AdaptiveComponent element
+        /// </summary>
+        /// <param name="pts">Points to use as reference</param>
+        /// <param name="fs">FamilySymbol to place</param>
+        private void InitAdaptiveComponent(Point[] pts, FamilySymbol fs)
+        {
 
             // if the family instance is present in trace...
             var oldFam =
@@ -39,9 +84,9 @@ namespace Revit.Elements
             // just mutate it...
             if (oldFam != null)
             {
-               InternalSetFamilyInstance(oldFam);
+                InternalSetFamilyInstance(oldFam);
                 if (fs.InternalFamilySymbol.Id != oldFam.Symbol.Id)
-                   InternalSetFamilySymbol(fs);
+                    InternalSetFamilySymbol(fs);
                 InternalSetPositions(pts.ToXyzs());
                 return;
             }
@@ -64,12 +109,12 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Internal constructor for the AdaptiveComponent wrapper
+        /// Initialize an AdaptiveComponent element
         /// </summary>
         /// <param name="pts">Points to use as reference</param>
         /// <param name="f">Face to use as reference</param>
         /// <param name="fs">FamilySymbol to place</param>
-        private AdaptiveComponent(double[][] pts, ElementFaceReference f, FamilySymbol fs)
+        private void InitAdaptiveComponent(double[][] pts, ElementFaceReference f, FamilySymbol fs)
         {
             // if the family instance is present in trace...
             var oldFam =
@@ -80,8 +125,8 @@ namespace Revit.Elements
             {
                 InternalSetFamilyInstance(oldFam);
                 if (fs.InternalFamilySymbol.Id != oldFam.Symbol.Id)
-                   InternalSetFamilySymbol(fs);
-                InternalSetUvsAndFace(pts.ToUvs(), f.InternalReference );
+                    InternalSetFamilySymbol(fs);
+                InternalSetUvsAndFace(pts.ToUvs(), f.InternalReference);
                 return;
             }
 
@@ -94,19 +139,19 @@ namespace Revit.Elements
                 throw new Exception("An adaptive component could not be found or created.");
 
             InternalSetFamilyInstance(fam);
-            InternalSetUvsAndFace(pts.ToUvs(), f.InternalReference );
+            InternalSetUvsAndFace(pts.ToUvs(), f.InternalReference);
 
             TransactionManager.Instance.TransactionTaskDone();
 
         }
 
         /// <summary>
-        /// Internal constructor for the AdaptiveComponent wrapper
+        /// Initialize an AdaptiveComponent element
         /// </summary>
         /// <param name="parms">Params on curve to reference</param>
         /// <param name="c">Curve to use as reference</param>
         /// <param name="fs">FamilySymbol to place</param>
-        private AdaptiveComponent(double[] parms, Reference c, FamilySymbol fs)
+        private void InitAdaptiveComponent(double[] parms, Reference c, FamilySymbol fs)
         {
             // if the family instance is present in trace...
             var oldFam =
@@ -117,7 +162,7 @@ namespace Revit.Elements
             {
                 InternalSetFamilyInstance(oldFam);
                 if (fs.InternalFamilySymbol.Id != oldFam.Symbol.Id)
-                   InternalSetFamilySymbol(fs);
+                    InternalSetFamilySymbol(fs);
                 InternalSetParamsAndCurve(parms, c);
                 return;
             }
@@ -138,10 +183,10 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Internal constructor for existing Elements.
+        /// Initialize an AdaptiveComponent element
         /// </summary>
         /// <param name="familyInstance"></param>
-        private AdaptiveComponent(Autodesk.Revit.DB.FamilyInstance familyInstance)
+        private void InitAdaptiveComponent(Autodesk.Revit.DB.FamilyInstance familyInstance)
         {
             InternalSetFamilyInstance(familyInstance);
         }
@@ -150,7 +195,7 @@ namespace Revit.Elements
 
         #region Internal mutators
 
-       /// <summary>
+        /// <summary>
        /// Set the family symbol for the internal family instance 
        /// </summary>
        /// <param name="fs"></param>

--- a/src/Libraries/RevitNodes/Elements/Category.cs
+++ b/src/Libraries/RevitNodes/Elements/Category.cs
@@ -8,6 +8,15 @@ namespace Revit.Elements
 {
     public class Category
     {
+        #region private constructors
+
+        private Category(Autodesk.Revit.DB.Category category)
+        {
+            internalCategory = category;
+        }
+
+        #endregion
+
         #region private members
 
         private readonly Autodesk.Revit.DB.Category internalCategory;
@@ -70,15 +79,6 @@ namespace Revit.Elements
             }
 
             return new Category(category);
-        }
-
-        #endregion
-
-        #region private constructors
-
-        private Category(Autodesk.Revit.DB.Category category)
-        {
-            internalCategory = category;
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/CurtainGrid.cs
+++ b/src/Libraries/RevitNodes/Elements/CurtainGrid.cs
@@ -185,25 +185,47 @@ namespace Revit.Elements
       /// <param name="curtainHolderElement"></param>
       private CurtainGrid(Autodesk.Revit.DB.Element curtainHolderElement)
       {
-          InternalCurtainHolderElement = curtainHolderElement;
-          InternalGridReference = null; //compute from faceReference  
+          SafeInit(() => InitCurtainGrid(curtainHolderElement));
       }
 
       private CurtainGrid(Autodesk.Revit.DB.Element curtainHolderElement, Autodesk.Revit.DB.Reference faceReference)
       {
-         InternalCurtainHolderElement = curtainHolderElement;
-         if (faceReference == null)
-            InternalGridReference = null;
-         else
-         {
+          SafeInit(() => InitCurtainGrid(curtainHolderElement, faceReference));
+      }
 
-            var faceObject =
-               InternalCurtainHolderElement.GetGeometryObjectFromReference(InternalGridReference);
-            if (!(faceObject is Autodesk.Revit.DB.Face))
-               throw new Exception("Reference should be to Face of the Element.");
+      #endregion
 
-            InternalGridReference = faceReference; //compute from faceReference  
-         }
+      #region Helpers for private constructors
+      /// <summary>
+      /// Initialize a curtain grid
+      /// </summary>
+      /// <param name="curtainHolderElement"></param>
+      private void InitCurtainGrid(Autodesk.Revit.DB.Element curtainHolderElement)
+      {
+          InternalCurtainHolderElement = curtainHolderElement;
+          InternalGridReference = null; //compute from faceReference  
+      }
+
+      /// <summary>
+      /// Initialize a CurtainGrid element
+      /// </summary>
+      /// <param name="curtainHolderElement"></param>
+      /// <param name="faceReference"></param>
+      private void InitCurtainGrid(Autodesk.Revit.DB.Element curtainHolderElement, Autodesk.Revit.DB.Reference faceReference)
+      {
+          InternalCurtainHolderElement = curtainHolderElement;
+          if (faceReference == null)
+              InternalGridReference = null;
+          else
+          {
+
+              var faceObject =
+                 InternalCurtainHolderElement.GetGeometryObjectFromReference(InternalGridReference);
+              if (!(faceObject is Autodesk.Revit.DB.Face))
+                  throw new Exception("Reference should be to Face of the Element.");
+
+              InternalGridReference = faceReference; //compute from faceReference  
+          }
       }
 
       #endregion

--- a/src/Libraries/RevitNodes/Elements/CurtainPanel.cs
+++ b/src/Libraries/RevitNodes/Elements/CurtainPanel.cs
@@ -310,8 +310,21 @@ namespace Revit.Elements
       /// <param name="panelElement"></param>
       protected CurtainPanel(Autodesk.Revit.DB.Panel panelElement)
       {
-         InternalSetFamilyInstance(panelElement);
-         boundsCache = null;
+          SafeInit(() => InitCurtainPanel(panelElement));
+      }
+
+      #endregion
+
+      #region Helper for private constructors
+
+      /// <summary>
+      /// Initialize a CurtainPanel element
+      /// </summary>
+      /// <param name="panelElement"></param>
+      private void InitCurtainPanel(Autodesk.Revit.DB.Panel panelElement)
+      {
+          InternalSetFamilyInstance(panelElement);
+          boundsCache = null;
       }
 
       #endregion

--- a/src/Libraries/RevitNodes/Elements/CurveByPoints.cs
+++ b/src/Libraries/RevitNodes/Elements/CurveByPoints.cs
@@ -40,10 +40,27 @@ namespace Revit.Elements
         /// <param name="curveByPoints"></param>
         private CurveByPoints(Autodesk.Revit.DB.CurveByPoints curveByPoints)
         {
-            InternalSetCurveElement(curveByPoints);
+            SafeInit(() => InitCurveByPoints(curveByPoints));
         }
 
         private CurveByPoints(IEnumerable<Autodesk.Revit.DB.ReferencePoint> refPoints, bool isReferenceLine)
+        {
+            SafeInit(() => InitCurveByPoints(refPoints, isReferenceLine));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// </summary>
+        /// <param name="curveByPoints"></param>
+        private void InitCurveByPoints(Autodesk.Revit.DB.CurveByPoints curveByPoints)
+        {
+            InternalSetCurveElement(curveByPoints);
+        }
+
+        private void InitCurveByPoints(IEnumerable<Autodesk.Revit.DB.ReferencePoint> refPoints, bool isReferenceLine)
         {
             //Add all of the elements in the sequence to a ReferencePointArray.
             var refPtArr = new ReferencePointArray();

--- a/src/Libraries/RevitNodes/Elements/DividedPath.cs
+++ b/src/Libraries/RevitNodes/Elements/DividedPath.cs
@@ -70,7 +70,7 @@ namespace Revit.Elements
         /// <param name="divPath"></param>
         private DividedPath(Autodesk.Revit.DB.DividedPath divPath)
         {
-            InternalSetDividedPath(divPath);
+            SafeInit(() => InitDividedPath(divPath));
         }
 
         /// <summary>
@@ -79,6 +79,29 @@ namespace Revit.Elements
         /// <param name="c">Host curves</param>
         /// <param name="divs">Number of divisions</param>
         private DividedPath(ElementCurveReference[] c, int divs)
+        {
+            SafeInit(() => InitDividedPath(c, divs));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a DividedPath element  
+        /// </summary>
+        /// <param name="divPath"></param>
+        private void InitDividedPath(Autodesk.Revit.DB.DividedPath divPath)
+        {
+            InternalSetDividedPath(divPath);
+        }
+
+        /// <summary>
+        /// Initialize a DividedPath element
+        /// </summary>
+        /// <param name="c">Host curves</param>
+        /// <param name="divs">Number of divisions</param>
+        private void InitDividedPath(ElementCurveReference[] c, int divs)
         {
             // PB: This constructor always *recreates* the divided path.
             // Mutating the divided path would require obtaining the referenced 
@@ -91,7 +114,7 @@ namespace Revit.Elements
             TransactionManager.Instance.EnsureInTransaction(Document);
 
             // build the divided path
-            var divPath = Autodesk.Revit.DB.DividedPath.Create( Document, curveRefs );
+            var divPath = Autodesk.Revit.DB.DividedPath.Create(Document, curveRefs);
             divPath.FixedNumberOfPoints = divs;
 
             // set internally

--- a/src/Libraries/RevitNodes/Elements/DividedSurface.cs
+++ b/src/Libraries/RevitNodes/Elements/DividedSurface.cs
@@ -45,7 +45,7 @@ namespace Revit.Elements
         /// <param name="divSurf"></param>
         private DividedSurface(Autodesk.Revit.DB.DividedSurface divSurf)
         {
-            InternalSetDividedSurface(divSurf);
+            SafeInit(() => InitDividedSurface(divSurf));
         }
 
         /// <summary>
@@ -56,6 +56,31 @@ namespace Revit.Elements
         /// <param name="vDivs"></param>
         /// <param name="rotation"></param>
         private DividedSurface(ElementFaceReference elementFace, int uDivs, int vDivs, double rotation)
+        {
+            SafeInit(() => InitDividedSurface(elementFace, uDivs, vDivs, rotation));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a DividedSurface element
+        /// </summary>
+        /// <param name="divSurf"></param>
+        private void InitDividedSurface(Autodesk.Revit.DB.DividedSurface divSurf)
+        {
+            InternalSetDividedSurface(divSurf);
+        }
+
+        /// <summary>
+        /// Initialize a DividedSurface element
+        /// </summary>
+        /// <param name="elementFace"></param>
+        /// <param name="uDivs"></param>
+        /// <param name="vDivs"></param>
+        /// <param name="rotation"></param>
+        private void InitDividedSurface(ElementFaceReference elementFace, int uDivs, int vDivs, double rotation)
         {
             // if the family instance is present in trace...
             var oldEle =

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -27,6 +27,26 @@ namespace Revit.Elements
     public abstract class Element : IDisposable, IGraphicItem, IFormattable
     {
         /// <summary>
+        /// Handling exceptions when calling the initializing function
+        /// </summary>
+        /// <param name="init"></param>
+        protected void SafeInit(Action init)
+        {
+            var elementManager = ElementIDLifecycleManager<int>.GetInstance();
+            int count = elementManager.GetRegisteredCount(Id);
+            try
+            {
+                init();
+            }
+            catch (Exception e)
+            {
+                if (elementManager.GetRegisteredCount(Id) == count + 1)
+                    elementManager.UnRegisterAssociation(Id, this);
+                throw e;
+            }
+        }
+
+        /// <summary>
         /// A reference to the current Document.
         /// </summary>
         internal static Document Document

--- a/src/Libraries/RevitNodes/Elements/Family.cs
+++ b/src/Libraries/RevitNodes/Elements/Family.cs
@@ -32,6 +32,15 @@ namespace Revit.Elements
 
         private Family(Autodesk.Revit.DB.Family family)
         {
+            SafeInit(() => InitFamily(family));
+        }
+
+        #endregion
+
+        #region Helper for private constructors
+
+        private void InitFamily(Autodesk.Revit.DB.Family family)
+        {
             InternalSetFamily(family);
         }
 

--- a/src/Libraries/RevitNodes/Elements/FamilySymbol.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilySymbol.cs
@@ -42,6 +42,19 @@ namespace Revit.Elements
         /// <param name="symbol"></param>
         private FamilySymbol(Autodesk.Revit.DB.FamilySymbol symbol)
         {
+            SafeInit(() => InitFamilySymbol(symbol));
+        }
+
+        #endregion
+
+        #region Helper for private constructors
+
+        /// <summary>
+        /// Initialize a FamilySymbol element
+        /// </summary>
+        /// <param name="symbol"></param>
+        private void InitFamilySymbol(Autodesk.Revit.DB.FamilySymbol symbol)
+        {
             InternalSetFamilySymbol(symbol);
         }
 

--- a/src/Libraries/RevitNodes/Elements/Floor.cs
+++ b/src/Libraries/RevitNodes/Elements/Floor.cs
@@ -41,13 +41,33 @@ namespace Revit.Elements
         /// </summary>
         private Floor(Autodesk.Revit.DB.Floor floor)
         {
-            InternalSetFloor(floor);
+            SafeInit(() => InitFloor(floor));
         }
       
         /// <summary>
         /// Private constructor
         /// </summary>
         private Floor(CurveArray curveArray, Autodesk.Revit.DB.FloorType floorType, Autodesk.Revit.DB.Level level)
+        {
+            SafeInit(() => InitFloor(curveArray, floorType, level));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a floor element
+        /// </summary>
+        private void InitFloor(Autodesk.Revit.DB.Floor floor)
+        {
+            InternalSetFloor(floor);
+        }
+
+        /// <summary>
+        /// Initialize a floor element
+        /// </summary>
+        private void InitFloor(CurveArray curveArray, Autodesk.Revit.DB.FloorType floorType, Autodesk.Revit.DB.Level level)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
@@ -62,7 +82,7 @@ namespace Revit.Elements
                 floor = Document.Create.NewFloor(curveArray, floorType, level, false);
             }
 
-            InternalSetFloor( floor );
+            InternalSetFloor(floor);
 
             TransactionManager.Instance.TransactionTaskDone();
 

--- a/src/Libraries/RevitNodes/Elements/FloorType.cs
+++ b/src/Libraries/RevitNodes/Elements/FloorType.cs
@@ -38,6 +38,19 @@ namespace Revit.Elements
         /// <param name="floorType"></param>
         private FloorType(Autodesk.Revit.DB.FloorType floorType)
         {
+            SafeInit(() => InitFloorType(floorType));
+        }
+
+        #endregion
+
+        #region Private constructors
+
+        /// <summary>
+        /// Initialize a FloorType element
+        /// </summary>
+        /// <param name="floorType"></param>
+        private void InitFloorType(Autodesk.Revit.DB.FloorType floorType)
+        {
             InternalSetFloorType(floorType);
         }
 

--- a/src/Libraries/RevitNodes/Elements/Form.cs
+++ b/src/Libraries/RevitNodes/Elements/Form.cs
@@ -43,7 +43,7 @@ namespace Revit.Elements
         /// <param name="form"></param>
         private Form(Autodesk.Revit.DB.Form form)
         {
-            InternalSetForm(form);
+            SafeInit(() => InitForm(form));
         }
 
         /// <summary>
@@ -52,6 +52,29 @@ namespace Revit.Elements
         /// <param name="isSolid"></param>
         /// <param name="curves"></param>
         private Form(bool isSolid, ReferenceArrayArray curves)
+        {
+            SafeInit(() => InitForm(isSolid, curves));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a form element
+        /// </summary>
+        /// <param name="form"></param>
+        private void InitForm(Autodesk.Revit.DB.Form form)
+        {
+            InternalSetForm(form);
+        }
+
+        /// <summary>
+        /// Initialize a form element
+        /// </summary>
+        /// <param name="isSolid"></param>
+        /// <param name="curves"></param>
+        private void InitForm(bool isSolid, ReferenceArrayArray curves)
         {
             // clean it up
             TransactionManager.Instance.EnsureInTransaction(Document);

--- a/src/Libraries/RevitNodes/Elements/FreeForm.cs
+++ b/src/Libraries/RevitNodes/Elements/FreeForm.cs
@@ -50,7 +50,7 @@ namespace Revit.Elements
         [SupressImportIntoVM]
         private FreeForm(Autodesk.Revit.DB.FreeFormElement ele)
         {
-            InternalSetFreeFormElement(ele);
+            SafeInit(() => InitFreeForm(ele));
         }
 
         /// <summary>
@@ -59,6 +59,28 @@ namespace Revit.Elements
         /// </summary>
         /// <param name="solid"></param>
         private FreeForm(Autodesk.Revit.DB.Solid solid)
+        {
+            SafeInit(() => InitFreeForm(solid));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a FreeForm element
+        /// </summary>
+        /// <param name="ele"></param>
+        private void InitFreeForm(Autodesk.Revit.DB.FreeFormElement ele)
+        {
+            InternalSetFreeFormElement(ele);
+        }
+
+        /// <summary>
+        /// Initialize a FreeForm element
+        /// </summary>
+        /// <param name="solid"></param>
+        private void InitFreeForm(Autodesk.Revit.DB.Solid solid)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var ele =

--- a/src/Libraries/RevitNodes/Elements/Grid.cs
+++ b/src/Libraries/RevitNodes/Elements/Grid.cs
@@ -45,7 +45,7 @@ namespace Revit.Elements
         /// <param name="grid"></param>
         private Grid(Autodesk.Revit.DB.Grid grid)
         {
-            InternalSetGrid(grid);
+            SafeInit(() => InitGrid(grid));
         }
 
         /// <summary>
@@ -54,10 +54,42 @@ namespace Revit.Elements
         /// <param name="line"></param>
         private Grid(Autodesk.Revit.DB.Line line)
         {
+            SafeInit(() => InitGrid(line));
+        }
+
+        /// <summary>
+        /// Private constructor that creates a new Element every time
+        /// </summary>
+        /// <param name="arc"></param>
+        private Grid(Autodesk.Revit.DB.Arc arc)
+        {
+            SafeInit(() => InitGrid(arc));
+        }
+
+        #endregion
+
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a Grid element
+        /// </summary>
+        /// <param name="grid"></param>
+        private void InitGrid(Autodesk.Revit.DB.Grid grid)
+        {
+            InternalSetGrid(grid);
+        }
+
+        /// <summary>
+        /// Initialize a Grid element
+        /// </summary>
+        /// <param name="line"></param>
+        private void InitGrid(Autodesk.Revit.DB.Line line)
+        {
             // Changing the underlying curve requires destroying the Grid
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            Autodesk.Revit.DB.Grid g = Document.Create.NewGrid( line );
+            Autodesk.Revit.DB.Grid g = Document.Create.NewGrid(line);
             InternalSetGrid(g);
 
             TransactionManager.Instance.TransactionTaskDone();
@@ -66,10 +98,10 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Private constructor that creates a new Element every time
+        /// Initialize a Grid element
         /// </summary>
         /// <param name="arc"></param>
-        private Grid(Autodesk.Revit.DB.Arc arc)
+        private void InitGrid(Autodesk.Revit.DB.Arc arc)
         {
             // Changing the underlying curve requires destroying the Grid
             TransactionManager.Instance.EnsureInTransaction(Document);

--- a/src/Libraries/RevitNodes/Elements/ImportInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/ImportInstance.cs
@@ -28,7 +28,26 @@ namespace Revit.Elements
 
         internal Autodesk.Revit.DB.ImportInstance InternalImportInstance { get; private set; }
 
+        #region Private constructor
+
+        /// <summary>
+        /// Constructor for ImportInstance
+        /// </summary>
+        /// <param name="satPath"></param>
+        /// <param name="translation"></param>
         internal ImportInstance(string satPath, XYZ translation = null)
+        {
+            SafeInit(() => InitImportInstance(satPath, translation));
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Initialize an ImportInstance element
+        /// </summary>
+        /// <param name="satPath"></param>
+        /// <param name="translation"></param>
+        private void InitImportInstance(string satPath, XYZ translation = null)
         {
             var instance = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.ImportInstance>(Document);
             if (null != instance)

--- a/src/Libraries/RevitNodes/Elements/Level.cs
+++ b/src/Libraries/RevitNodes/Elements/Level.cs
@@ -45,6 +45,29 @@ namespace Revit.Elements
         /// <param name="name"></param>
         private Level(double elevation, string name)
         {
+            SafeInit(() => InitLevel(elevation, name));
+        }
+
+        /// <summary>
+        /// Private constructor for Level
+        /// </summary>
+        /// <param name="level"></param>
+        private Level(Autodesk.Revit.DB.Level level)
+        {
+            SafeInit(() => InitLevel(level));
+        }
+
+        #endregion
+
+        #region Private constructor
+
+        /// <summary>
+        /// Initialize a Level element
+        /// </summary>
+        /// <param name="elevation"></param>
+        /// <param name="name"></param>
+        private void InitLevel(double elevation, string name)
+        {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldEle =
                 ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.Level>(Document);
@@ -81,7 +104,7 @@ namespace Revit.Elements
 
         }
 
-        private Level(Autodesk.Revit.DB.Level level)
+        private void InitLevel(Autodesk.Revit.DB.Level level)
         {
             this.InternalSetLevel(level);
         }

--- a/src/Libraries/RevitNodes/Elements/Material.cs
+++ b/src/Libraries/RevitNodes/Elements/Material.cs
@@ -41,6 +41,19 @@ namespace Revit.Elements
         /// <param name="material"></param>
         private Material(Autodesk.Revit.DB.Material material)
         {
+            SafeInit(() => InitMaterial(material));
+        }
+
+        #endregion
+
+        #region Helper for private constructors
+
+        /// <summary>
+        /// Initialize a Material element
+        /// </summary>
+        /// <param name="material"></param>
+        private void InitMaterial(Autodesk.Revit.DB.Material material)
+        {
             InternalSetMaterial(material);
         }
 

--- a/src/Libraries/RevitNodes/Elements/ModelCurve.cs
+++ b/src/Libraries/RevitNodes/Elements/ModelCurve.cs
@@ -31,7 +31,7 @@ namespace Revit.Elements
         /// <param name="curve"></param>
         private ModelCurve(Autodesk.Revit.DB.ModelCurve curve)
         {
-            InternalSetCurveElement(curve);
+            SafeInit(() => InitModelCurve(curve));
         }
 
         // PB: This implementation borrows the somewhat risky notions from the original Dynamo
@@ -44,6 +44,33 @@ namespace Revit.Elements
         /// <param name="crv"></param>
         /// <param name="makeReferenceCurve"></param>
         private ModelCurve(Autodesk.Revit.DB.Curve crv, bool makeReferenceCurve)
+        {
+            SafeInit(() => InitModelCurve(crv, makeReferenceCurve));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a ModelCurve element
+        /// </summary>
+        /// <param name="curve"></param>
+        private void InitModelCurve(Autodesk.Revit.DB.ModelCurve curve)
+        {
+            InternalSetCurveElement(curve);
+        }
+
+        // PB: This implementation borrows the somewhat risky notions from the original Dynamo
+        // implementation.  In short, it has the ability to infer a sketch plane,
+        // which might also mean deleting the original one.
+
+        /// <summary>
+        /// Initialize a ModelCurve element
+        /// </summary>
+        /// <param name="crv"></param>
+        /// <param name="makeReferenceCurve"></param>
+        private void InitModelCurve(Autodesk.Revit.DB.Curve crv, bool makeReferenceCurve)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var mc =

--- a/src/Libraries/RevitNodes/Elements/ModelText.cs
+++ b/src/Libraries/RevitNodes/Elements/ModelText.cs
@@ -52,7 +52,7 @@ namespace Revit.Elements
         /// <param name="element"></param>
         private ModelText(Autodesk.Revit.DB.ModelText element)
         {
-            InternalSetModelText(element);
+            SafeInit(() => InitModelText(element));
         }
 
         /// <summary>
@@ -64,7 +64,37 @@ namespace Revit.Elements
         /// <param name="yCoordinateInPlane"></param>
         /// <param name="textDepth"></param>
         /// <param name="modelTextType"></param>
-        private ModelText(string text, Autodesk.Revit.DB.SketchPlane sketchPlane, double xCoordinateInPlane, double yCoordinateInPlane, double textDepth, Autodesk.Revit.DB.ModelTextType modelTextType)
+        private ModelText(string text, Autodesk.Revit.DB.SketchPlane sketchPlane, double xCoordinateInPlane,
+            double yCoordinateInPlane, double textDepth, Autodesk.Revit.DB.ModelTextType modelTextType)
+        {
+            SafeInit(() => InitModelText(text, sketchPlane, xCoordinateInPlane, yCoordinateInPlane, textDepth, modelTextType));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a ModelText element
+        /// </summary>
+        /// <param name="element"></param>
+        private void InitModelText(Autodesk.Revit.DB.ModelText element)
+        {
+            InternalSetModelText(element);
+        }
+
+        /// <summary>
+        /// Initialize a ModelText element
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="sketchPlane"></param>
+        /// <param name="xCoordinateInPlane"></param>
+        /// <param name="yCoordinateInPlane"></param>
+        /// <param name="textDepth"></param>
+        /// <param name="modelTextType"></param>
+        private void InitModelText(string text, Autodesk.Revit.DB.SketchPlane sketchPlane, 
+            double xCoordinateInPlane, double yCoordinateInPlane, double textDepth,
+            Autodesk.Revit.DB.ModelTextType modelTextType)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldEle =
@@ -74,7 +104,7 @@ namespace Revit.Elements
             // Note: not sure if there's a way to mutate the sketchPlane for a ModelText, so we need
             // to insure the Element hasn't changed position, otherwise, we destroy and rebuild the Element
             if (oldEle != null && PositionUnchanged(oldEle, sketchPlane, xCoordinateInPlane, yCoordinateInPlane))
-            {            
+            {
                 // There was an element and it's position hasn't changed
                 InternalSetModelText(oldEle);
                 InternalSetText(text);

--- a/src/Libraries/RevitNodes/Elements/ModelTextType.cs
+++ b/src/Libraries/RevitNodes/Elements/ModelTextType.cs
@@ -41,6 +41,19 @@ namespace Revit.Elements
         /// <param name="type"></param>
         private ModelTextType(Autodesk.Revit.DB.ModelTextType type)
         {
+            SafeInit(() => InitModelTextType(type));
+        }
+
+        #endregion
+
+        #region Helper for private constructors
+
+        /// <summary>
+        /// Initialize a ModelTextType element
+        /// </summary>
+        /// <param name="type"></param>
+        private void InitModelTextType(Autodesk.Revit.DB.ModelTextType type)
+        {
             InternalSetModelTextType(type);
         }
 

--- a/src/Libraries/RevitNodes/Elements/Mullion.cs
+++ b/src/Libraries/RevitNodes/Elements/Mullion.cs
@@ -41,7 +41,19 @@ namespace Revit.Elements
       /// <param name="mullionElement"></param>
       protected Mullion(Autodesk.Revit.DB.Mullion mullionElement)
       {
-         InternalSetFamilyInstance(mullionElement);
+          SafeInit(() => InitMullion(mullionElement));
+      }
+      #endregion
+
+      #region Helper for private constructors
+
+      /// <summary>
+      /// Initialize a Mullion element
+      /// </summary>
+      /// <param name="mullionElement"></param>
+      protected void InitMullion(Autodesk.Revit.DB.Mullion mullionElement)
+      {
+          InternalSetFamilyInstance(mullionElement);
       }
       #endregion
 

--- a/src/Libraries/RevitNodes/Elements/ReferencePlane.cs
+++ b/src/Libraries/RevitNodes/Elements/ReferencePlane.cs
@@ -48,7 +48,7 @@ namespace Revit.Elements
         /// <param name="referencePlane"></param>
         private ReferencePlane( Autodesk.Revit.DB.ReferencePlane referencePlane)
         {
-            InternalSetReferencePlane(referencePlane);
+            SafeInit(() => InitReferencePlane(referencePlane));
         }
 
         /// <summary>
@@ -59,6 +59,31 @@ namespace Revit.Elements
         /// <param name="normal"></param>
         /// <param name="view"></param>
         private ReferencePlane(XYZ bubbleEnd, XYZ freeEnd, XYZ normal, View view )
+        {
+            SafeInit(() => InitReferencePlane(bubbleEnd, freeEnd, normal, view));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a ReferencePlane element
+        /// </summary>
+        /// <param name="referencePlane"></param>
+        private void InitReferencePlane(Autodesk.Revit.DB.ReferencePlane referencePlane)
+        {
+            InternalSetReferencePlane(referencePlane);
+        }
+
+        /// <summary>
+        /// Initialize a ReferencePlane element
+        /// </summary>
+        /// <param name="bubbleEnd"></param>
+        /// <param name="freeEnd"></param>
+        /// <param name="normal"></param>
+        /// <param name="view"></param>
+        private void InitReferencePlane(XYZ bubbleEnd, XYZ freeEnd, XYZ normal, View view)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldEle =
@@ -87,8 +112,8 @@ namespace Revit.Elements
                 refPlane = Document.FamilyCreate.NewReferencePlane(
                     bubbleEnd,
                     freeEnd,
-                    normal, 
-                    view );
+                    normal,
+                    view);
             }
             else
             {
@@ -96,7 +121,7 @@ namespace Revit.Elements
                     bubbleEnd,
                     freeEnd,
                     normal,
-                    view );
+                    view);
             }
 
             InternalSetReferencePlane(refPlane);

--- a/src/Libraries/RevitNodes/Elements/ReferencePoint.cs
+++ b/src/Libraries/RevitNodes/Elements/ReferencePoint.cs
@@ -49,7 +49,7 @@ namespace Revit.Elements
         /// <param name="refPt"></param>
         private ReferencePoint(Autodesk.Revit.DB.ReferencePoint refPt)
         {
-            InternalSetReferencePoint(refPt);
+            SafeInit(() => InitReferencePoint(refPt));
         }
 
         /// <summary>
@@ -58,6 +58,51 @@ namespace Revit.Elements
         /// <param name="faceReference"></param>
         /// <param name="uv"></param>
         private ReferencePoint(Reference faceReference, UV uv)
+        {
+            SafeInit(() => InitReferencePoint(faceReference, uv));
+        }
+
+        /// <summary>
+        /// Internal constructor for ReferencePoint Elements that a persistent relationship to a Curve
+        /// </summary>
+        /// <param name="curveReference"></param>
+        /// <param name="parameter"></param>
+        /// <param name="measurementType"></param>
+        /// <param name="measureFrom"></param>
+        private ReferencePoint(Reference curveReference, double parameter, PointOnCurveMeasurementType measurementType,
+            PointOnCurveMeasureFrom measureFrom)
+        {
+            SafeInit(() => InitReferencePoint(curveReference, parameter, measurementType, measureFrom));
+        }
+
+        /// <summary>
+        /// Internal constructor for the ReferencePoint
+        /// </summary>
+        /// <param name="xyz"></param>
+        private ReferencePoint(XYZ xyz)
+        {
+            SafeInit(() => InitReferencePoint(xyz));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a ReferencePoint element
+        /// </summary>
+        /// <param name="refPt"></param>
+        private void InitReferencePoint(Autodesk.Revit.DB.ReferencePoint refPt)
+        {
+            InternalSetReferencePoint(refPt);
+        }
+
+        /// <summary>
+        /// Initialize a ReferencePoint element
+        /// </summary>
+        /// <param name="faceReference"></param>
+        /// <param name="uv"></param>
+        private void InitReferencePoint(Reference faceReference, UV uv)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldRefPt =
@@ -86,13 +131,13 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Internal constructor for ReferencePoint Elements that a persistent relationship to a Curve
+        /// Initialize a ReferencePoint element
         /// </summary>
         /// <param name="curveReference"></param>
         /// <param name="parameter"></param>
         /// <param name="measurementType"></param>
         /// <param name="measureFrom"></param>
-        private ReferencePoint(Reference curveReference, double parameter, PointOnCurveMeasurementType measurementType,
+        private void InitReferencePoint(Reference curveReference, double parameter, PointOnCurveMeasurementType measurementType,
             PointOnCurveMeasureFrom measureFrom)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
@@ -120,10 +165,10 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Internal constructor for the ReferencePoint
+        /// Initialize a ReferencePoint element
         /// </summary>
         /// <param name="xyz"></param>
-        private ReferencePoint(XYZ xyz)
+        private void InitReferencePoint(XYZ xyz)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldRefPt =

--- a/src/Libraries/RevitNodes/Elements/SketchPlane.cs
+++ b/src/Libraries/RevitNodes/Elements/SketchPlane.cs
@@ -45,7 +45,7 @@ namespace Revit.Elements
         /// <param name="existingSketchPlane"></param>
         private SketchPlane(Autodesk.Revit.DB.SketchPlane existingSketchPlane)
         {
-            InternalSetSketchPlane(existingSketchPlane);
+            SafeInit(() => InitSketchPlane(existingSketchPlane));
         }
 
         /// <summary>
@@ -53,6 +53,28 @@ namespace Revit.Elements
         /// </summary>
         /// <param name="p"></param>
         private SketchPlane(Autodesk.Revit.DB.Plane p)
+        {
+            SafeInit(() => InitSketchPlane(p));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a SketchPlane element
+        /// </summary>
+        /// <param name="existingSketchPlane"></param>
+        private void InitSketchPlane(Autodesk.Revit.DB.SketchPlane existingSketchPlane)
+        {
+            InternalSetSketchPlane(existingSketchPlane);
+        }
+
+        /// <summary>
+        /// Initialize a SketchPlane element
+        /// </summary>
+        /// <param name="p"></param>
+        private void InitSketchPlane(Autodesk.Revit.DB.Plane p)
         {
 
             //Phase 1 - Check to see if the object exists and should be rebound

--- a/src/Libraries/RevitNodes/Elements/StucturalFraming.cs
+++ b/src/Libraries/RevitNodes/Elements/StucturalFraming.cs
@@ -29,13 +29,45 @@ namespace Revit.Elements
         /// <param name="instance"></param>
         private StructuralFraming(Autodesk.Revit.DB.FamilyInstance instance)
         {
-            InternalSetFamilyInstance(instance);
+            SafeInit(() => InitStructuralFraming(instance));
         }
 
         /// <summary>
         /// Internal constructor - creates a single StructuralFraming instance
         /// </summary>
-        internal StructuralFraming(Autodesk.Revit.DB.Curve curve, Autodesk.Revit.DB.XYZ upVector, Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.Structure.StructuralType structuralType, Autodesk.Revit.DB.FamilySymbol symbol)
+        internal StructuralFraming(Autodesk.Revit.DB.Curve curve, Autodesk.Revit.DB.XYZ upVector, 
+            Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.Structure.StructuralType structuralType, 
+            Autodesk.Revit.DB.FamilySymbol symbol)
+        {
+            SafeInit(() => InitStructuralFraming(curve, upVector, level, structuralType, symbol));
+        }
+
+        /// <summary>
+        /// Internal constructor - creates a single StructuralFraming instance
+        /// </summary>
+        internal StructuralFraming(Autodesk.Revit.DB.Curve curve, Autodesk.Revit.DB.Level level,
+            Autodesk.Revit.DB.Structure.StructuralType structuralType, Autodesk.Revit.DB.FamilySymbol symbol)
+        {
+            SafeInit(() => InitStructuralFraming(curve, level, structuralType, symbol));
+        }
+        
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a StructuralFraming element
+        /// </summary>
+        /// <param name="instance"></param>
+        private void InitStructuralFraming(Autodesk.Revit.DB.FamilyInstance instance)
+        {
+            InternalSetFamilyInstance(instance);
+        }
+
+        /// <summary>
+        /// Initialize a StructuralFraming element
+        /// </summary>
+        private void InitStructuralFraming(Autodesk.Revit.DB.Curve curve, Autodesk.Revit.DB.XYZ upVector, Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.Structure.StructuralType structuralType, Autodesk.Revit.DB.FamilySymbol symbol)
         {
 
             //Phase 1 - Check to see if the object exists and should be rebound
@@ -55,7 +87,7 @@ namespace Revit.Elements
             TransactionManager.Instance.EnsureInTransaction(Document);
 
             var creationData = GetCreationData(curve, upVector, level, structuralType, symbol);
-            
+
             Autodesk.Revit.DB.FamilyInstance fi;
             if (Document.IsFamilyDocument)
             {
@@ -77,7 +109,7 @@ namespace Revit.Elements
                     throw new Exception("Could not create the FamilyInstance");
                 }
 
-                fi = (Autodesk.Revit.DB.FamilyInstance) Document.GetElement(elementIds.First());
+                fi = (Autodesk.Revit.DB.FamilyInstance)Document.GetElement(elementIds.First());
             }
 
             InternalSetFamilyInstance(fi);
@@ -88,9 +120,9 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Internal constructor - creates a single StructuralFraming instance
+        /// Initialize a StructuralFraming element
         /// </summary>
-        internal StructuralFraming(Autodesk.Revit.DB.Curve curve, Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.Structure.StructuralType structuralType, Autodesk.Revit.DB.FamilySymbol symbol)
+        private void InitStructuralFraming(Autodesk.Revit.DB.Curve curve, Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.Structure.StructuralType structuralType, Autodesk.Revit.DB.FamilySymbol symbol)
         {
 
             //Phase 1 - Check to see if the object exists and should be rebound
@@ -147,7 +179,7 @@ namespace Revit.Elements
 
             ElementBinder.SetElementForTrace(this.InternalElement);
         }
-        
+
         #endregion
 
         #region Private helper methods

--- a/src/Libraries/RevitNodes/Elements/SunSettings.cs
+++ b/src/Libraries/RevitNodes/Elements/SunSettings.cs
@@ -20,6 +20,11 @@ namespace Revit.Elements
 
         private SunSettings(SunAndShadowSettings settings)
         {
+            SafeInit(() => InitSunSettings(settings));
+        }
+
+        private void InitSunSettings(SunAndShadowSettings settings)
+        {
             InternalSunAndShadowSettings = settings;
             InternalElementId = settings.Id;
             InternalUniqueId = settings.UniqueId;

--- a/src/Libraries/RevitNodes/Elements/Topography.cs
+++ b/src/Libraries/RevitNodes/Elements/Topography.cs
@@ -61,6 +61,25 @@ namespace Revit.Elements
 
         private Topography(IList<XYZ> points)
         {
+            SafeInit(() => InitTopography(points));
+        }
+
+        [SupressImportIntoVM]
+        private Topography(TopographySurface topoSurface)
+        {
+            SafeInit(() => InitTopography(topoSurface));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a Topography element
+        /// </summary>
+        /// <param name="points"></param>
+        private void InitTopography(IList<XYZ> points)
+        {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldSurf =
                 ElementBinder.GetElementFromTrace<TopographySurface>(Document);
@@ -81,15 +100,19 @@ namespace Revit.Elements
             }
             else
             {
-                ElementBinder.SetElementForTrace(this.InternalElement);  
+                ElementBinder.SetElementForTrace(this.InternalElement);
             }
 
             // necessary so the points in the topography are valid
             DocumentManager.Regenerate();
         }
 
+        /// <summary>
+        /// Initialize a Topography element
+        /// </summary>
+        /// <param name="topoSurface"></param>
         [SupressImportIntoVM]
-        private Topography(TopographySurface topoSurface)
+        private void InitTopography(TopographySurface topoSurface)
         {
             InternalSetTopographySurface(topoSurface);
         }

--- a/src/Libraries/RevitNodes/Elements/UnknownElement.cs
+++ b/src/Libraries/RevitNodes/Elements/UnknownElement.cs
@@ -24,6 +24,15 @@ namespace Revit.Elements
         /// <param name="element"></param>
         private UnknownElement(Autodesk.Revit.DB.Element element)
         {
+            SafeInit(() => InitUnknownElement(element));
+        }
+
+        /// <summary>
+        /// Initialize an UnknownElement element
+        /// </summary>
+        /// <param name="element"></param>
+        private void InitUnknownElement(Autodesk.Revit.DB.Element element)
+        {
             InternalSetElement(element);
         }
 

--- a/src/Libraries/RevitNodes/Elements/Views/AxonometricView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/AxonometricView.cs
@@ -25,13 +25,42 @@ namespace Revit.Elements.Views
         /// </summary>
         private AxonometricView(Autodesk.Revit.DB.View3D view)
         {
-            InternalSetView3D(view);
+            SafeInit(() => InitAxonometricView(view));
         }
 
         /// <summary>
         /// Private constructor
         /// </summary>
-        private AxonometricView(XYZ eye, XYZ target, BoundingBoxXYZ bbox, string name = DEFAULT_VIEW_NAME, bool isolate = false)
+        private AxonometricView(XYZ eye, XYZ target, BoundingBoxXYZ bbox, string name = DEFAULT_VIEW_NAME,
+            bool isolate = false)
+        {
+            SafeInit(() => InitAxonometricView(eye, target, bbox, name, isolate));
+        }
+
+        /// <summary>
+        /// Private constructor
+        /// </summary>
+        private AxonometricView(XYZ eye, XYZ target, string name = DEFAULT_VIEW_NAME, Autodesk.Revit.DB.Element element = null, bool isolate = false)
+        {
+            SafeInit(() => InitAxonometricView(eye, target, name, element, isolate));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize an AxonometricView element
+        /// </summary>
+        private void InitAxonometricView(Autodesk.Revit.DB.View3D view)
+        {
+            InternalSetView3D(view);
+        }
+
+        /// <summary>
+        /// Initialize an AxonometricView element
+        /// </summary>
+        private void InitAxonometricView(XYZ eye, XYZ target, BoundingBoxXYZ bbox, string name = DEFAULT_VIEW_NAME, bool isolate = false)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldEle =
@@ -61,9 +90,9 @@ namespace Revit.Elements.Views
         }
 
         /// <summary>
-        /// Private constructor
+        /// Initialize an AxonometricView element
         /// </summary>
-        private AxonometricView(XYZ eye, XYZ target, string name = DEFAULT_VIEW_NAME, Autodesk.Revit.DB.Element element = null, bool isolate = false)
+        private void InitAxonometricView(XYZ eye, XYZ target, string name = DEFAULT_VIEW_NAME, Autodesk.Revit.DB.Element element = null, bool isolate = false)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldEle =
@@ -92,6 +121,8 @@ namespace Revit.Elements.Views
             ElementBinder.SetElementForTrace(this.InternalElement);
         }
 
+        #endregion
+
         private void InternalSetIsolation(Autodesk.Revit.DB.Element element, bool isolate)
         {
             if (isolate && element != null)
@@ -107,8 +138,6 @@ namespace Revit.Elements.Views
             else
                 InternalRemoveIsolation();
         }
-
-        #endregion
 
         #region Public static constructors
 

--- a/src/Libraries/RevitNodes/Elements/Views/CeilingPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/CeilingPlanView.cs
@@ -23,13 +23,33 @@ namespace Revit.Elements.Views
         /// </summary>
         private CeilingPlanView(Autodesk.Revit.DB.ViewPlan view)
         {
-            InternalSetPlanView(view);
+            SafeInit(() => InitCeilingPlanView(view));
         }
 
         /// <summary>
         /// Private constructor
         /// </summary>
         private CeilingPlanView(Autodesk.Revit.DB.Level level)
+        {
+            SafeInit(() => InitCeilingPlanView(level));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a CeilingPlanView element
+        /// </summary>
+        private void InitCeilingPlanView(Autodesk.Revit.DB.ViewPlan view)
+        {
+            InternalSetPlanView(view);
+        }
+
+        /// <summary>
+        /// Initialize a CeilingPlanView element
+        /// </summary>
+        private void InitCeilingPlanView(Autodesk.Revit.DB.Level level)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 

--- a/src/Libraries/RevitNodes/Elements/Views/DraftingView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/DraftingView.cs
@@ -44,13 +44,33 @@ namespace Revit.Elements.Views
         /// </summary>
         private DraftingView(Autodesk.Revit.DB.ViewDrafting view)
         {
-            InternalSetDraftingView(view);
+            SafeInit(() => InitDraftingView(view));
         }
       
         /// <summary>
         /// Private constructor
         /// </summary>
         private DraftingView(string name)
+        {
+            SafeInit(() => InitDraftingView(name));
+        }
+
+        #endregion
+
+        #region Private constructors
+
+        /// <summary>
+        /// Initialize a DraftingView element
+        /// </summary>
+        private void InitDraftingView(Autodesk.Revit.DB.ViewDrafting view)
+        {
+            InternalSetDraftingView(view);
+        }
+
+        /// <summary>
+        /// Initialize a DraftingView element
+        /// </summary>
+        private void InitDraftingView(string name)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 

--- a/src/Libraries/RevitNodes/Elements/Views/FloorPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/FloorPlanView.cs
@@ -24,13 +24,33 @@ namespace Revit.Elements.Views
         /// </summary>
         private FloorPlanView(Autodesk.Revit.DB.ViewPlan view)
         {
-            InternalSetPlanView(view);
+            SafeInit(() => InitFloorPlanView(view));
         }
 
         /// <summary>
         /// Private constructor
         /// </summary>
         private FloorPlanView(Autodesk.Revit.DB.Level level)
+        {
+            SafeInit(() => InitFloorPlanView(level));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a FloorPlanView element
+        /// </summary>
+        private void InitFloorPlanView(Autodesk.Revit.DB.ViewPlan view)
+        {
+            InternalSetPlanView(view);
+        }
+
+        /// <summary>
+        /// Initialize a FloorPlanView element
+        /// </summary>
+        private void InitFloorPlanView(Autodesk.Revit.DB.Level level)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 

--- a/src/Libraries/RevitNodes/Elements/Views/PerspectiveView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/PerspectiveView.cs
@@ -26,13 +26,41 @@ namespace Revit.Elements.Views
         /// </summary>
         private PerspectiveView(Autodesk.Revit.DB.View3D view)
         {
-            InternalSetView3D(view);
+            SafeInit(() => InitPerspectiveView(view));
         }
 
         /// <summary>
         /// Private constructor
         /// </summary>
         private PerspectiveView(XYZ eye, XYZ target, BoundingBoxXYZ bbox, string name, bool isolate)
+        {
+            SafeInit(() => InitPerspectiveView(eye, target, bbox, name, isolate));
+        }
+
+        /// <summary>
+        /// Private constructor
+        /// </summary>
+        private PerspectiveView(XYZ eye, XYZ target, Autodesk.Revit.DB.Element element, string name, bool isolate)
+        {
+            SafeInit(() => InitPerspectiveView(eye, target, element, name, isolate));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a PerspectiveView element
+        /// </summary>
+        private void InitPerspectiveView(Autodesk.Revit.DB.View3D view)
+        {
+            InternalSetView3D(view);
+        }
+
+        /// <summary>
+        /// Initialize a PerspectiveView element
+        /// </summary>
+        private void InitPerspectiveView(XYZ eye, XYZ target, BoundingBoxXYZ bbox, string name, bool isolate)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldEle =
@@ -76,9 +104,9 @@ namespace Revit.Elements.Views
         }
 
         /// <summary>
-        /// Private constructor
+        /// Initialize a PerspectiveView element
         /// </summary>
-        private PerspectiveView(XYZ eye, XYZ target, Autodesk.Revit.DB.Element element, string name, bool isolate)
+        private void InitPerspectiveView(XYZ eye, XYZ target, Autodesk.Revit.DB.Element element, string name, bool isolate)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldEle =
@@ -88,7 +116,7 @@ namespace Revit.Elements.Views
             if (oldEle != null)
             {
                 InternalSetView3D(oldEle);
-                InternalSetOrientation( BuildOrientation3D(eye, target) );
+                InternalSetOrientation(BuildOrientation3D(eye, target));
                 if (isolate)
                 {
                     InternalIsolateInView(element);

--- a/src/Libraries/RevitNodes/Elements/Views/SectionView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/SectionView.cs
@@ -46,13 +46,33 @@ namespace Revit.Elements.Views
         /// </summary>
         private SectionView(Autodesk.Revit.DB.ViewSection view)
         {
-            InternalSetSectionView(view);
+            SafeInit(() => InitSectionView(view));
         }
 
         /// <summary>
         /// Private constructor
         /// </summary>
         private SectionView( BoundingBoxXYZ bbox )
+        {
+            SafeInit(() => InitSectionView(bbox));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a SectionView element
+        /// </summary>
+        private void InitSectionView(Autodesk.Revit.DB.ViewSection view)
+        {
+            InternalSetSectionView(view);
+        }
+
+        /// <summary>
+        /// Initialize a SectionView element
+        /// </summary>
+        private void InitSectionView(BoundingBoxXYZ bbox)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 

--- a/src/Libraries/RevitNodes/Elements/Views/Sheet.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/Sheet.cs
@@ -47,13 +47,45 @@ namespace Revit.Elements.Views
         /// </summary>
         private Sheet(Autodesk.Revit.DB.ViewSheet view)
         {
-            InternalSetViewSheet(view);
+            SafeInit(() => InitSheet(view));
         }
 
         /// <summary>
         /// Private constructor
         /// </summary>
         private Sheet(string nameOfSheet, string numberOfSheet, IEnumerable<Autodesk.Revit.DB.View> views)
+        {
+            SafeInit(() => InitSheet(nameOfSheet, numberOfSheet, views));
+        }
+
+        /// <summary>
+        /// Private constructor.
+        /// </summary>
+        /// <param name="sheetName"></param>
+        /// <param name="sheetNumber"></param>
+        /// <param name="titleBlockFamilySymbol"></param>
+        /// <param name="views"></param>
+        private Sheet(string sheetName, string sheetNumber, Autodesk.Revit.DB.FamilySymbol titleBlockFamilySymbol, IEnumerable<Autodesk.Revit.DB.View> views)
+        {
+            SafeInit(() => InitSheet(sheetName, sheetNumber, titleBlockFamilySymbol, views));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a Sheet element
+        /// </summary>
+        private void InitSheet(Autodesk.Revit.DB.ViewSheet view)
+        {
+            InternalSetViewSheet(view);
+        }
+
+        /// <summary>
+        /// Initialize a Sheet element
+        /// </summary>
+        private void InitSheet(string nameOfSheet, string numberOfSheet, IEnumerable<Autodesk.Revit.DB.View> views)
         {
 
             //Phase 1 - Check to see if the object exists and should be rebound
@@ -76,7 +108,7 @@ namespace Revit.Elements.Views
             // create sheet without title block
             var sheet = Autodesk.Revit.DB.ViewSheet.Create(Document, ElementId.InvalidElementId);
 
-            InternalSetViewSheet( sheet );
+            InternalSetViewSheet(sheet);
             InternalSetSheetName(nameOfSheet);
             InternalSetSheetNumber(numberOfSheet);
             InternalAddViewsToSheetView(views);
@@ -87,13 +119,13 @@ namespace Revit.Elements.Views
         }
 
         /// <summary>
-        /// Private constructor.
+        /// Initialize a Sheet element
         /// </summary>
         /// <param name="sheetName"></param>
         /// <param name="sheetNumber"></param>
         /// <param name="titleBlockFamilySymbol"></param>
         /// <param name="views"></param>
-        private Sheet(string sheetName, string sheetNumber, Autodesk.Revit.DB.FamilySymbol titleBlockFamilySymbol, IEnumerable<Autodesk.Revit.DB.View> views)
+        private void InitSheet(string sheetName, string sheetNumber, Autodesk.Revit.DB.FamilySymbol titleBlockFamilySymbol, IEnumerable<Autodesk.Revit.DB.View> views)
         {
 
             //Phase 1 - Check to see if the object exists

--- a/src/Libraries/RevitNodes/Elements/WallType.cs
+++ b/src/Libraries/RevitNodes/Elements/WallType.cs
@@ -40,6 +40,19 @@ namespace Revit.Elements
         /// <param name="type"></param>
         private WallType(Autodesk.Revit.DB.WallType type)
         {
+            SafeInit(() => InitWallType(type));
+        }
+
+        #endregion
+
+        #region Helper for private constructors
+
+        /// <summary>
+        /// Initialize a WallType element
+        /// </summary>
+        /// <param name="type"></param>
+        private void InitWallType(Autodesk.Revit.DB.WallType type)
+        {
             InternalSetWallType(type);
         }
 


### PR DESCRIPTION
<h4>Summary</h4>


When constructing elements, there may be exceptions thrown and then the half-constructed elements may be registered with the life cycle manager. This will cause:
1). The half-constructed elements will never be disposed by us because they are half-constructed;
2). In the case, the element ID is registered with the life cycle manager, the related Revit element will not be deleted.

In this submission, I am making the fix by implement a SafeInit method in the Element class to run an action and catch possible exceptions thrown. If there are any exceptions and if the object has been registered with the life cycle manager, the object will be unregisted.

Then in the derived classes, I am separating the constructors into init functions which take the same parameters as the constructors, and the constructors will call the SafeInit method which will take the init functions as input.

@pboyer 
PTAL
