### PR TITLE
Fix one failing test case

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -69,6 +69,10 @@ namespace Revit.Elements
                     ElementBinder.SetRawDataForTrace(null);
                     SafeInit(init);
                 }
+                else
+                {
+                    throw e;
+                }
             }
         }
 


### PR DESCRIPTION
<h4>Summary</h4>


When an exception is thrown the first time an element is created, the exception should be thrown so that the error can be notified.

This submission makes the change to throw the exception.

@Benglin 
PTAL
