### PR TITLE
Fix one failing test case

### DIFF
--- a/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
@@ -36,9 +36,9 @@ namespace RevitNodesTests.Elements
 
             DocumentManager.Regenerate();
 
-            var elemId1 = ele.GetParameterValueByName(paramName);
+            var elemId1 = ele.GetParameterValueByName(paramName) as Element;
 
-            Assert.AreEqual(mat.InternalElement.Id, elemId1);
+            Assert.AreEqual(mat.InternalElement.Id, elemId1.InternalElement.Id);
 
         }
 


### PR DESCRIPTION
<h4>Summary</h4>

In a recent change, GetParameterValueByName will return Element other than an element id. Consequently, the related test case need to be changed.

This submission fixes one failing test case by getting the id from the returned element.

@Benglin 
PTAL