### PR TITLE
Fix failing test cases

### DIFF
--- a/src/Libraries/RevitNodesUI/Elements.cs
+++ b/src/Libraries/RevitNodesUI/Elements.cs
@@ -53,13 +53,6 @@ namespace DSRevitNodesUI
             u.ElementsDeleted -= Updater_ElementsDeleted;
         }
 
-        private bool forceReExecuteOfNode;
-
-        public override bool ForceReExecuteOfNode
-        {
-            get { return forceReExecuteOfNode; }
-        }
-
         protected virtual void Updater_ElementsAdded(IEnumerable<string> updated)
         {
             if (!updated.Any()) return;
@@ -68,7 +61,7 @@ namespace DSRevitNodesUI
             Debug.WriteLine("There are {0} updated elements", updated.Count());
             DebugElements(updated);
 #endif
-            forceReExecuteOfNode = true;
+            ForceReExecuteOfNode = true;
             OnAstUpdated();
         }
 
@@ -80,7 +73,7 @@ namespace DSRevitNodesUI
             Debug.WriteLine("There are {0} modified elements", updated.Count());
             DebugElements(updated);
 #endif
-            forceReExecuteOfNode = true;
+            ForceReExecuteOfNode = true;
             OnAstUpdated();
 
         }
@@ -92,7 +85,7 @@ namespace DSRevitNodesUI
             Debug.WriteLine("There are {0} deleted elements", deleted.Count());
             DebugElements(deleted);
 #endif
-            forceReExecuteOfNode = true;
+            ForceReExecuteOfNode = true;
             OnAstUpdated();
 
         }


### PR DESCRIPTION
<h4>Summary</h4>

For nodes derived from ElementsQueryBase, the first time the nodes are read in from .dyn files. The ForceReExecuteOfNode is set to false which is not correct as at this time, because the nodes are new and need to be executed. 

This submission makes the change to use the base class property.

@Benglin 
PTAL