### PR TITLE
Fix MAGN-940 [Localization] user gets exception in sample on OverrideColorInView node

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -340,7 +340,7 @@ namespace Revit.Elements
 
             var patternCollector = new FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument);
             patternCollector.OfClass(typeof(FillPatternElement));
-            FillPatternElement solidFill = patternCollector.ToElements().Cast<FillPatternElement>().First(x => x.GetFillPattern().Name == "Solid fill");
+            FillPatternElement solidFill = patternCollector.ToElements().Cast<FillPatternElement>().First(x => x.GetFillPattern().IsSolidFill);
 
             ogs.SetProjectionFillColor(new Autodesk.Revit.DB.Color(color.Red, color.Green, color.Blue));
             ogs.SetProjectionFillPatternId(solidFill.Id);


### PR DESCRIPTION
<h4>Summary</h4>

The original implementation is trying to compare the pattern name with a string in English. But as the name will be different in different localization versions, which will not always be "Solid Fill", the obtained pattern element may be null. Then an exception will be thrown later if it is null and used.

This submission fixes the issue by using the IsSolidFill property to check whether the pattern element is a kind of solid fill.

@ke-yu 
PTAL

