### PR TITLE
Update trace function calls to refer to RuntimeData

### DIFF
--- a/src/Libraries/RevitServices/Persistence/ElementBinder.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementBinder.cs
@@ -384,7 +384,7 @@ namespace RevitServices.Persistence
                         || (n is CodeBlockNodeModel));
             }).Select((n) => n.GUID);
 
-            var nodeTraceDataList = core.GetCallsitesForNodes(nodeGuids);
+            var nodeTraceDataList = core.DSExecutable.RuntimeData.GetCallsitesForNodes(nodeGuids, core.DSExecutable);
 
             bool areElementsFoundForThisNode;
             foreach (Guid guid in nodeTraceDataList.Keys)

--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -127,7 +127,8 @@ namespace RevitSystemTests
         private ElementId GetBindingElementIdForNode(Guid guid)
         {
             ProtoCore.Core core = ViewModel.Model.EngineController.LiveRunnerCore;
-            var guidToCallSites = core.GetCallsitesForNodes(new []{guid});
+            var guidToCallSites = core.DSExecutable.RuntimeData.GetCallsitesForNodes(new[] { guid }, core.DSExecutable);
+
             var callSites = guidToCallSites[guid];
             if (!callSites.Any())
                 return null;


### PR DESCRIPTION
<h4>Summary</h4>

This is to merge Jun's fix to the Revit2014 branch.

@junmendoza 
@Benglin 