### PR TITLE
Adjustment to the dispose of RevitServicesUpdater

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -416,7 +416,6 @@ namespace Dynamo.Applications
         {
             var view = (DynamoView)sender;
 
-            RevitServicesUpdater.DisposeInstance();
             DocumentManager.OnLogError -= revitDynamoModel.Logger.Log;
 
             view.Dispatcher.UnhandledException -= Dispatcher_UnhandledException;

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -96,6 +96,7 @@ namespace Dynamo.Applications
         {
             UnsubscribeAssemblyResolvingEvent();
             UnsubscribeDocumentChangedEvent();
+            RevitServicesUpdater.DisposeInstance();
 
             return Result.Succeeded;
         }


### PR DESCRIPTION
<h4>Summary</h4>

The singleton instance is to be disposed when the addin application is shutdown. If it is disposed when the Dynamo view is closed, the next time either an error will occur or the singleton instance need to be reinitialized.

@Benglin 
PTAL