### PR TITLE
MAGN-6033 Exception on opening Revit Samples files on Revit 2016.

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -495,5 +495,10 @@ namespace Dynamo.Applications.Models
         }
 
         #endregion
+
+        protected override void OpenFileImpl(OpenFileCommand command)
+        {
+            IdlePromise.ExecuteOnIdleAsync(() => base.OpenFileImpl(command));
+        }
     }
 }

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -498,7 +498,7 @@ namespace Dynamo.Applications.Models
 
         protected override void OpenFileImpl(OpenFileCommand command)
         {
-            IdlePromise.ExecuteOnIdleAsync(() => base.OpenFileImpl(command));
+            DynamoRevit.AddIdleAction(() => base.OpenFileImpl(command));
         }
     }
 }

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -32,6 +32,8 @@ namespace Revit.Elements
         /// <param name="init"></param>
         protected void SafeInit(Action init)
         {
+            TransactionManager.Instance.EnsureInTransaction(DocumentManager.Instance.CurrentDBDocument);
+
             var elementManager = ElementIDLifecycleManager<int>.GetInstance();
             var element = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.Element>(Document);
             int count = 0;

--- a/src/Libraries/RevitServices/Transactions/TransactionManager.cs
+++ b/src/Libraries/RevitServices/Transactions/TransactionManager.cs
@@ -199,19 +199,19 @@ namespace RevitServices.Transactions
     {
         public TransactionHandle EnsureInTransaction(TransactionWrapper wrapper, Document document)
         {
-            TransactionManager.Log("EnsureInTransaction - AUTO STRAT: Starting new Transaction");
+            TransactionManager.Log("EnsureInTransaction - AUTO START: Starting new Transaction");
             return !wrapper.TransactionActive ? wrapper.StartTransaction(document) : wrapper.Handle;
         }
 
         public void TransactionTaskDone(TransactionHandle handle)
         {
-            TransactionManager.Log("TransactionTaskDone - AUTO STRAT: Preserving Transaction");
+            TransactionManager.Log("TransactionTaskDone - AUTO START: Preserving Transaction");
             //Do nothing in automatic, continue using the same transaction.
         }
 
         public void ForceCloseTransaction(TransactionHandle handle)
         {
-            TransactionManager.Log("ForceCloseTransaction - AUTO STRAT: Ending Transaction");
+            TransactionManager.Log("ForceCloseTransaction - AUTO START: Ending Transaction");
             if (handle != null && handle.Status == TransactionStatus.Started)
                 handle.CommitTransaction();
         }
@@ -295,7 +295,9 @@ namespace RevitServices.Transactions
                 
                 // Dispose the old transaction so that it won't impact the new transaction
                 if (null != Transaction && Transaction.IsValidObject)
+                {
                     Transaction.Dispose();
+                }
 
                 Transaction = new Transaction(document, "Dynamo Script");
                 Transaction.Start();


### PR DESCRIPTION
Revit 2016 is much more stringent about calling API methods outside of an "API context." File opening was not being handled inside a Transaction, and the API was throwing an exception at the first Revit API call inside the file opening operation. This PR does the following:

- Wraps the DynamoModel's OpenFileImpl method in an IdlePromise to ensure that file opening is done in the "API context."

- Adds an EnsureInTransaction call to the Element.SafeInit method. Although not the focus of this PR, i could not test any Revit element creation through Dynamo as all element creation failed due to the out-of-context InvalidOperation exception when attempting to create elements.

This PR requires:
https://github.com/DynamoDS/Dynamo/pull/3672

PTAL:
- [x] @Randy-Ma 
