### PR TITLE
MAGN-5891 At Dynamo 7.5 update, Revit 2016 erroneously prompts for File Save

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -95,6 +95,8 @@ namespace Dynamo.Applications
 
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
+            UpdateManager.UpdateManager.Instance.RegisterExternalApplicationProcessId(Process.GetCurrentProcess().Id);
+
             HandleDebug(commandData);
             
             InitializeCore(commandData);


### PR DESCRIPTION
This PR is required for https://github.com/DynamoDS/Dynamo/pull/3680. A description of the solution can be found there.