### PR TITLE
MAGN-6032 [CRASH] while placing Select Model Element node in Canvas while running Dynamo on top of Revit-2016 only.

### DIFF
--- a/src/Libraries/RevitNodes/Elements/ReferencePlane.cs
+++ b/src/Libraries/RevitNodes/Elements/ReferencePlane.cs
@@ -73,7 +73,7 @@ namespace Revit.Elements
         /// <param name="referencePlane"></param>
         private void InitReferencePlane(Autodesk.Revit.DB.ReferencePlane referencePlane)
         {
-            InternalReferencePlane = referencePlane;
+            InternalSetReferencePlane(referencePlane);
         }
 
         /// <summary>

--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -5,6 +5,8 @@ using System.Linq;
 
 using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
+
+using Dynamo.Applications;
 using Dynamo.Controls;
 using Dynamo.Interfaces;
 
@@ -83,10 +85,13 @@ namespace Dynamo.Nodes
             SelectionObjectType selectionObjectType, string message, string prefix)
             : base(selectionType, selectionObjectType, message, prefix)
         {
-            RevitServicesUpdater.Instance.ElementsDeleted += Updater_ElementsDeleted;
-            RevitServicesUpdater.Instance.ElementsModified += Updater_ElementsModified;
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened += Controller_RevitDocumentChanged;
-            //revMod.PropertyChanged += revMod_PropertyChanged;
+            DynamoRevit.AddIdleAction(
+                () =>
+                {
+                    RevitServicesUpdater.Instance.ElementsDeleted += Updater_ElementsDeleted;
+                    RevitServicesUpdater.Instance.ElementsModified += Updater_ElementsModified;
+                    DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened += Controller_RevitDocumentChanged;
+                });
         }
 
         #endregion


### PR DESCRIPTION
This PR addresses [MAGN-6032](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6032).

## What
When placing a Select Model Element(s) node in Revit, a crash would occur.

## How
- Wraps the event hooks in the RevitSelection constructor in an Idle action in order to avoid the Revit API warning that calls are being made outside the Revit context.
- Fixes an issue when selecting reference planes where the InternalUniqueId was not set.

PTAL:
- [x] @Randy-Ma 

Merge:
- [ ] Revit2015