### PR TITLE
Build fix for compiling error in RevitDropDown.cs

### DIFF
--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -33,7 +33,7 @@ namespace DSRevitNodesUI
     {
         protected RevitDropDownBase(string value) : base(value)
         {
-            DynamoRevit.AddIdleAction(()=>DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened += Controller_RevitDocumentChanged);
+           DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened += Controller_RevitDocumentChanged;
         }
 
         void Controller_RevitDocumentChanged(object sender, EventArgs e)


### PR DESCRIPTION
It seem method AddIdleAction in DynanoRevit was somehow not committed.

Currently, I just revert the change RevitDropDownBase() to the one before AddIdleAction was committed.

@ikeough @Randy-Ma please help review.
