### PR TITLE
DUI: Rename icon resource files

### DIFF
--- a/src/DynamoRevitIcons/DynamoRevitIcons.csproj
+++ b/src/DynamoRevitIcons/DynamoRevitIcons.csproj
@@ -40,11 +40,11 @@
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
     </GetReferenceAssemblyPaths>
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)RevitNodesImages.resx" OutputResources="$(ProjectDir)RevitNodesImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)RevitNodesImages.resources" OutputAssembly="$(OutputPath)RevitNodes.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)RevitNodesImages.resources" OutputAssembly="$(OutputPath)RevitNodes.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DSRevitNodesUIImages.resx" OutputResources="$(ProjectDir)DSRevitNodesUIImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)DSRevitNodesUIImages.resources" OutputAssembly="$(OutputPath)DSRevitNodesUI.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DSRevitNodesUIImages.resources" OutputAssembly="$(OutputPath)DSRevitNodesUI.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)SimpleRaaSImages.resx" OutputResources="$(ProjectDir)SimpleRaaSImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)SimpleRaaSImages.resources" OutputAssembly="$(OutputPath)SimpleRaaS.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)SimpleRaaSImages.resources" OutputAssembly="$(OutputPath)SimpleRaaS.customization.dll" />
   </Target>
   <Target Name="AfterBuild">
     <ItemGroup>


### PR DESCRIPTION
#### Purpose

To avoid confusion of users icon dlls are renamed from `*.resources.dll` to `*.customization.dll`. Revit specific icons.

#### Additional references 

[MAGN-6310](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6310) DUI: Rename icon resource files 

This PR should be merged after https://github.com/DynamoDS/Dynamo/pull/3739.

#### Reviewers

@Benglin, please, take a look. And cross-merge to `Revit2015`, `Revit2016` if no merge conflicts appeared.