### PR TITLE
MAGN-6032 [CRASH] while placing Select Model Element node in Canvas while running Dynamo on top of Revit-2016 only. CONT.

### DIFF
--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -110,9 +110,14 @@ namespace Dynamo.Nodes
         public override void Dispose()
         {
             base.Dispose();
-            RevitServicesUpdater.Instance.ElementsDeleted -= Updater_ElementsDeleted;
-            RevitServicesUpdater.Instance.ElementsModified -= Updater_ElementsModified;
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -= Controller_RevitDocumentChanged;
+
+            DynamoRevit.AddIdleAction(
+                () =>
+                {
+                    RevitServicesUpdater.Instance.ElementsDeleted -= Updater_ElementsDeleted;
+                    RevitServicesUpdater.Instance.ElementsModified -= Updater_ElementsModified;
+                    DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -= Controller_RevitDocumentChanged;
+                });
         }
 
         public override void UpdateSelection(IEnumerable<TSelection> rawSelection)


### PR DESCRIPTION
FYI:
@jnealb @Randy-Ma 

This is a continuation of the work already merged for MAGN-6032.

If the unhooking of these handlers is not wrapped in an idle event, when
disposing a Select Model Element node, Dynamo will crash. This change is
required to comply with the increased strictness of "out of context"
calls to the Revit API.