### PR TITLE
Updated batch file to include VS2013 location

### DIFF
--- a/src/transform_all.bat
+++ b/src/transform_all.bat
@@ -24,6 +24,8 @@ set file_name=!file_name:~0,-3!.%extension%
 echo:  \--^> !file_name!    
 echo "%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\11.0\TextTransform.exe" -out !file_name! %%d
 "%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\11.0\TextTransform.exe" -out !file_name! %%d
+echo "%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\12.0\TextTransform.exe" -out !file_name! %%d
+"%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\12.0\TextTransform.exe" -out !file_name! %%d
 )
 
 :: delete T4 list and return to previous directory


### PR DESCRIPTION
**Issue**: 
Running the batch file - transform_all.bat does not create RevitTestConfiguration.xml file in VS2013.

**Cause**:
TextTransform.exe which creates the xml file from the template is in different location for VS2013. For VS2012 this exe is in C:\Program Files (x86)\Common Files\microsoft shared\TextTemplating\11.0 and for VS2013 this file is in C:\Program Files (x86)\Common Files\microsoft shared\TextTemplating\12.0 folder.

**Fix**:
Updated the batch file to look for TextTransform.exe in both folders.

- [ ] @ikeough 