### PR TITLE
"DynamoPathManager" related update for Revit 2016

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -85,6 +85,7 @@ namespace Dynamo.Applications
     public class DynamoRevit : IExternalCommand
     {
         private static readonly List<Action> idleActions = new List<Action>();
+        enum Versions { ShapeManager = 221 }
 
         private static ExternalCommandData extCommandData;
         private static DynamoViewModel dynamoViewModel;
@@ -167,18 +168,45 @@ namespace Dynamo.Applications
 
         #region Initialization
 
+        /// <summary>
+        /// DynamoShapeManager.dll is a companion assembly of Dynamo core components,
+        /// we do not want a static reference to it (since the Revit add-on can be 
+        /// installed anywhere that's outside of Dynamo), we do not want a duplicated 
+        /// reference to it. Here we use reflection to obtain GetGeometryFactoryPath
+        /// method, and call it to get the geometry factory assembly path.
+        /// </summary>
+        /// <param name="corePath">The path where DynamoShapeManager.dll can be 
+        /// located.</param>
+        /// <returns>Returns the full path to geometry factory assembly.</returns>
+        /// 
+        private static string GetGeometryFactoryPath(string corePath)
+        {
+            var dynamoAsmPath = Path.Combine(corePath, "DynamoShapeManager.dll");
+            var assembly = Assembly.LoadFrom(dynamoAsmPath);
+            if (assembly == null)
+                throw new FileNotFoundException("File not found", dynamoAsmPath);
+
+            var utilities = assembly.GetType("DynamoShapeManager.Utilities");
+            var getGeometryFactoryPath = utilities.GetMethod("GetGeometryFactoryPath");
+
+            return (getGeometryFactoryPath.Invoke(null,
+                new object[] { corePath, Versions.ShapeManager }) as string);
+        }
+
         private static RevitDynamoModel InitializeCoreModel(ExternalCommandData commandData)
         {
             var prefs = PreferenceSettings.Load();
-            var corePath =
-                Path.GetFullPath(
-                    Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"\..\");
+            var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+            var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
+            var parentDirectory = Directory.GetParent(assemblyDirectory);
+            var corePath = parentDirectory.FullName;
 
             return RevitDynamoModel.Start(
                 new RevitDynamoModel.StartConfiguration()
                 {
                     Preferences = prefs,
                     DynamoCorePath = corePath,
+                    GeometryFactoryPath = GetGeometryFactoryPath(corePath),
                     Context = GetRevitContext(commandData),
                     SchedulerThread = new RevitSchedulerThread(commandData.Application),
                     AuthProvider = new RevitOxygenProvider(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher))

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -146,21 +146,7 @@ namespace Dynamo.Applications
             //add an additional node processing folder
             DynamoPathManager.Instance.Nodes.Add(Path.Combine(assDir, "nodes"));
 
-            // Set the LibG folder based on the context.
-            // LibG is set to reference the libg_219 folder by default.
-            var versionInt = int.Parse(application.ControlledApplication.VersionNumber);
-            switch (versionInt)
-            {
-                case 2016:
-                    DynamoPathManager.Instance.SetLibGPath("221");
-                    break;
-                case 2015:
-                    DynamoPathManager.Instance.SetLibGPath("220");
-                    break;
-                default:
-                    DynamoPathManager.Instance.SetLibGPath("219");
-                    break;
-            }
+            // TODO(PATHMANAGER): Remove reference to DynamoUtilities.dll when this is done.
         }
 
         private void SubscribeAssemblyResolvingEvent()


### PR DESCRIPTION
These changes in `Revit` are required for `DynamoPathManager` changes made in [another pull request](https://github.com/DynamoDS/Dynamo/pull/3824).

Hi @ikeough, I believe all the necessary parts in Revit add-on side have been updated. The logic around test for `Revit 2016` is a little unique (that it has to preload 221 ASM), I think the build around that area fails as of right now. I'll get that fixed tomorrow morning when I get into the office. This PR should have fixed the main build errors.