### PR TITLE
Fix the failed test cases

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -157,7 +157,7 @@ namespace Dynamo.Applications
         /// located.</param>
         /// <returns>Returns the full path to geometry factory assembly.</returns>
         /// 
-        private static string GetGeometryFactoryPath(string corePath)
+        public static string GetGeometryFactoryPath(string corePath)
         {
             var dynamoAsmPath = Path.Combine(corePath, "DynamoShapeManager.dll");
             var assembly = Assembly.LoadFrom(dynamoAsmPath);

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -220,10 +220,16 @@ namespace RevitTestServices
 
                 DynamoRevit.InitializeUnits();
 
+                var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+                var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
+                var parentDirectory = Directory.GetParent(assemblyDirectory);
+                var corePath = parentDirectory.FullName;
+
                 DynamoRevit.RevitDynamoModel = RevitDynamoModel.Start(
                     new DynamoModel.StartConfiguration()
                     {
                         StartInTestMode = true,
+                        GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(corePath),
                         DynamoCorePath = Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"\..\"),
                         Context = "Revit 2014",
                         SchedulerThread = new TestSchedulerThread()


### PR DESCRIPTION
As there are changes to set the path, we need to update our test framework to set the path correctly as well.
The test cases are failing because the geometry factory path is not set at all in the test framework.

@Benglin 