### PR TITLE
Fix the build error and the failing test cases

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -179,7 +179,7 @@ namespace Dynamo.Applications
         /// located.</param>
         /// <returns>Returns the full path to geometry factory assembly.</returns>
         /// 
-        private static string GetGeometryFactoryPath(string corePath)
+        public static string GetGeometryFactoryPath(string corePath)
         {
             var dynamoAsmPath = Path.Combine(corePath, "DynamoShapeManager.dll");
             var assembly = Assembly.LoadFrom(dynamoAsmPath);

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -170,8 +170,6 @@ namespace RevitTestServices
                 workingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             }
 
-            DynamoPathManager.PreloadAsmVersion("221", DynamoPathManager.Instance);
-
             CreateTemporaryFolder();
 
             // Setup Temp PreferenceSetting Location for testing

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -243,10 +243,16 @@ namespace RevitTestServices
 
                 DynamoRevit.InitializeUnits();
 
+                var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+                var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
+                var parentDirectory = Directory.GetParent(assemblyDirectory);
+                var corePath = parentDirectory.FullName;
+
                 DynamoRevit.RevitDynamoModel = RevitDynamoModel.Start(
                     new DynamoModel.StartConfiguration()
                     {
                         StartInTestMode = true,
+                        GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(corePath),
                         DynamoCorePath = Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"\..\"),
                         Context = "Revit 2014",
                         SchedulerThread = new TestSchedulerThread()


### PR DESCRIPTION
This is to merge the following pull request to fix the failing test cases:
https://github.com/DynamoDS/DynamoRevit/pull/187

It also makes some changes to remove the line that is causing the compiling errors because it is not required to preload. I have verified one geometry test cases in SampleTests.

@Benglin 

