### PR TITLE
Rename icon dlls to *.customization.dll in Revit 2016.

### DIFF
--- a/src/DynamoRevitIcons/DynamoRevitIcons.csproj
+++ b/src/DynamoRevitIcons/DynamoRevitIcons.csproj
@@ -40,11 +40,11 @@
       <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FrameworkAssembliesPath" />
     </GetReferenceAssemblyPaths>
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)RevitNodesImages.resx" OutputResources="$(ProjectDir)RevitNodesImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)RevitNodesImages.resources" OutputAssembly="$(OutputPath)RevitNodes.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)RevitNodesImages.resources" OutputAssembly="$(OutputPath)RevitNodes.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DSRevitNodesUIImages.resx" OutputResources="$(ProjectDir)DSRevitNodesUIImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)DSRevitNodesUIImages.resources" OutputAssembly="$(OutputPath)DSRevitNodesUI.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DSRevitNodesUIImages.resources" OutputAssembly="$(OutputPath)DSRevitNodesUI.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)SimpleRaaSImages.resx" OutputResources="$(ProjectDir)SimpleRaaSImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
-    <AL TargetType="library" EmbedResources="$(ProjectDir)SimpleRaaSImages.resources" OutputAssembly="$(OutputPath)SimpleRaaS.resources.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)SimpleRaaSImages.resources" OutputAssembly="$(OutputPath)SimpleRaaS.customization.dll" />
   </Target>
   <Target Name="AfterBuild">
     <ItemGroup>


### PR DESCRIPTION
To avoid confusion of users icon dlls are renamed from *.resources.dll to *.customization.dll. Revit specific icons.

The same PR as https://github.com/DynamoDS/DynamoRevit/pull/156 but for Revit 2016 branch.

Reviewers
@Benglin, please, take a look.

[MAGN-6554](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6554) [DUI] All Revit icons gone missing again.