### PR TITLE
RemoteTestSessionConfig

### DIFF
--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -27,6 +27,8 @@ using RevitServices.Persistence;
 using RevitServices.Threading;
 using RevitServices.Transactions;
 
+using TestServices;
+
 namespace RevitTestServices
 {
     public class RevitTestConfiguration
@@ -220,19 +222,22 @@ namespace RevitTestServices
 
                 DynamoRevit.InitializeUnits();
 
-                var assemblyLocation = Assembly.GetExecutingAssembly().Location;
-                var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
-                var parentDirectory = Directory.GetParent(assemblyDirectory);
-                var corePath = parentDirectory.FullName;
+                // Create a remote test config option specifying a fallback path
+                // one directory above the executing assembly. If the core path is not
+                // specified in the config, or the config is not present, it is assumed
+                // that the executing assembly's directory will be a Revit sub-folder, so
+                // we need to set core to the parent directory.
+                var remoteConfig = new RemoteTestSessionConfig(Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"\..\"));
 
                 DynamoRevit.RevitDynamoModel = RevitDynamoModel.Start(
                     new DynamoModel.StartConfiguration()
                     {
                         StartInTestMode = true,
-                        GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(corePath),
-                        DynamoCorePath = Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"\..\"),
+                        GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(remoteConfig.DynamoCorePath),
+                        DynamoCorePath = remoteConfig.DynamoCorePath,
                         Context = "Revit 2014",
-                        SchedulerThread = new TestSchedulerThread()
+                        SchedulerThread = new TestSchedulerThread(),
+                        PackageManagerAddress = "https://www.dynamopackages.com"
                     });
 
                 Model = DynamoRevit.RevitDynamoModel;


### PR DESCRIPTION
This PR adapts RevitSystemTestBase to use the RemoteTestSessionConfig to set the core path.

This PR requires https://github.com/DynamoDS/Dynamo/pull/3891.

PTAL:
@Benglin - Because you know what I'm talkin' about.