### PR TITLE
MAGN-6582 Switching Workspaces in Run Auto all connectors become invisible, locks workspace

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -240,22 +240,6 @@ namespace Dynamo.Applications.Models
         }
 
         /// <summary>
-        /// This method is typically called when a new workspace is opened or
-        /// when user forcefully resets the engine in the event of an error.
-        /// </summary>
-        /// <param name="markNodesAsDirty">RequiresRecalc property of all nodes
-        /// in the home workspace will be set to 'true' if this parameter is 
-        /// true.</param>
-        /// 
-        public override void ResetEngine(bool markNodesAsDirty = false)
-        {
-            AsyncTaskCompletedHandler handler =
-                _ => OnResetMarkNodesAsDirty(markNodesAsDirty);
-
-            IdlePromise.ExecuteOnIdleAsync(ResetEngineInternal, handler);
-        }
-
-        /// <summary>
         /// This event handler is called if 'markNodesAsDirty' in a 
         /// prior call to RevitDynamoModel.ResetEngine was set to 'true'.
         /// </summary>
@@ -503,6 +487,11 @@ namespace Dynamo.Applications.Models
             {
                 node.OnNodeModified(forceExecute:true);
             }
+        }
+
+        protected override void OpenFileImpl(OpenFileCommand command)
+        {
+            IdlePromise.ExecuteOnIdleAsync(() => base.OpenFileImpl(command));
         }
 
         #endregion


### PR DESCRIPTION
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6582

Previously we were only wrapping the call to ResetEngine in a scheduler task. This meant that when a workspace was opened, the task went off for processing and the UI tried to update immediately. Wrapping the entire file opening process in a scheduler task means that resetting of the engine controller and population of the UI are properly ordered and called in Revit's "API Context".

PTAL:
@pboyer 

Requires Merge:
- [ ] Revit2014