### PR TITLE
Removed "RevitTestConfiguration.DefinitionsPath" property

### DIFF
--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -42,11 +42,6 @@ namespace RevitTestServices
         public string SamplesPath { get; set; }
 
         /// <summary>
-        /// Directory where custom node definitions are kept
-        /// </summary>
-        public string DefinitionsPath { get; set; }
-
-        /// <summary>
         /// TestConfiguration file name
         /// </summary>
         private const string TEST_CONFIGURATION_FILE_S = "RevitTestConfiguration.xml";
@@ -106,16 +101,6 @@ namespace RevitTestServices
                 string samplesLoc = Path.Combine(assDir, @"..\..\..\..\doc\distrib\Samples\");
                 SamplesPath = Path.GetFullPath(samplesLoc);
             }
-
-            //set the custom node loader search path
-            if (string.IsNullOrEmpty(DefinitionsPath))
-            {
-                string defsLoc = Path.Combine(
-                    DynamoPathManager.Instance.Packages,
-                    "Dynamo Sample Custom Nodes",
-                    "dyf");
-                DefinitionsPath = Path.GetFullPath(defsLoc);
-            }
         }
 
         private void Save(string filePath)
@@ -145,7 +130,6 @@ namespace RevitTestServices
     public class RevitSystemTestBase : SystemTestBase
     {
         private string samplesPath;
-        private string defsPath;
         protected string emptyModelPath1;
         protected string emptyModelPath;
 
@@ -192,9 +176,6 @@ namespace RevitTestServices
 
             //get the samples path
             samplesPath = config.SamplesPath;
-
-            //set the custom node loader search path
-            defsPath = config.DefinitionsPath;
 
             emptyModelPath = Path.Combine(workingDirectory, "empty.rfa");
 


### PR DESCRIPTION
Hi @ikeough, please let me know what you think. `DefinitionsPath` makes use of `DynamoPathManager`, and since I'm removing `DynamoPathManager`, it needs to be reimplemented. Good thing though, it is not used anywhere, so I choose the easier way out -- to remove it entirely. Does this look okay to you?