### PR TITLE
Override the configuration file to fix the failing test cases

### DIFF
--- a/test/Libraries/RevitTestServices/RevitTestServices.csproj
+++ b/test/Libraries/RevitTestServices/RevitTestServices.csproj
@@ -110,6 +110,9 @@
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /R $(ProjectDir)TestServices.dll.config $(TestOutputPath)\..\</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/Libraries/RevitTestServices/TestServices.dll.config
+++ b/test/Libraries/RevitTestServices/TestServices.dll.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="DynamoBasePath" value=""/>
+    <add key="RequestedLibraryVersion" value="220"/>
+  </appSettings>
+</configuration>


### PR DESCRIPTION
Right now the configuration file - "TestServices.dll.config" is used but the RequestedLibraryVersion property is not set. As a result, libg_219 will always be used. In a computer where Revit 2014 is not installed, it will not work.

This fix overrides this configuration file so that the libg library of a correct version is used.

@ikeough 
PTAL