### PR TITLE
Set up the paths when launching the application

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -92,6 +92,9 @@ namespace Dynamo.Applications
 
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
+            //Set the directory
+            SetupDynamoPaths();
+
             HandleDebug(commandData);
             
             InitializeCore(commandData);
@@ -276,6 +279,30 @@ namespace Dynamo.Applications
         {
             if (DocumentManager.Instance.CurrentUIApplication == null)
                 DocumentManager.Instance.CurrentUIApplication = commandData.Application;
+        }
+
+        private static void SetupDynamoPaths()
+        {
+            // The executing assembly will be in Revit_20xx, so 
+            // we have to walk up one level. Unfortunately, we
+            // can't use DynamoPathManager here because those are not
+            // initialized until the DynamoModel is constructed.
+            string assDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            // Add the Revit_20xx folder for assembly resolution
+            DynamoPathManager.Instance.AddResolutionPath(assDir);
+
+            // Setup the core paths
+            DynamoPathManager.Instance.InitializeCore(Path.GetFullPath(assDir + @"\.."));
+
+            // Add Revit-specific paths for loading.
+            DynamoPathManager.Instance.AddPreloadLibrary(Path.Combine(assDir, "RevitNodes.dll"));
+            DynamoPathManager.Instance.AddPreloadLibrary(Path.Combine(assDir, "SimpleRaaS.dll"));
+
+            //add an additional node processing folder
+            DynamoPathManager.Instance.Nodes.Add(Path.Combine(assDir, "nodes"));
+
+            // TODO(PATHMANAGER): Remove reference to DynamoUtilities.dll when this is done.
         }
 
         #endregion

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -42,8 +42,6 @@ namespace Dynamo.Applications
         {
             try
             {
-                SetupDynamoPaths(application);
-
                 SubscribeAssemblyResolvingEvent();
 
                 ControlledApplication = application.ControlledApplication;
@@ -120,38 +118,47 @@ namespace Dynamo.Applications
             Updaters.Add(sunUpdater);
         }
 
-        private static void SetupDynamoPaths(UIControlledApplication application)
-        {
-            // The executing assembly will be in Revit_20xx, so 
-            // we have to walk up one level. Unfortunately, we
-            // can't use DynamoPathManager here because those are not
-            // initialized until the DynamoModel is constructed.
-            string assDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-
-            // Add the Revit_20xx folder for assembly resolution
-            DynamoPathManager.Instance.AddResolutionPath(assDir);
-
-            // Setup the core paths
-            DynamoPathManager.Instance.InitializeCore(Path.GetFullPath(assDir + @"\.."));
-
-            // Add Revit-specific paths for loading.
-            DynamoPathManager.Instance.AddPreloadLibrary(Path.Combine(assDir, "RevitNodes.dll"));
-            DynamoPathManager.Instance.AddPreloadLibrary(Path.Combine(assDir, "SimpleRaaS.dll"));
-
-            //add an additional node processing folder
-            DynamoPathManager.Instance.Nodes.Add(Path.Combine(assDir, "nodes"));
-
-            // TODO(PATHMANAGER): Remove reference to DynamoUtilities.dll when this is done.
-        }
-
         private void SubscribeAssemblyResolvingEvent()
         {
-            AppDomain.CurrentDomain.AssemblyResolve += AssemblyHelper.ResolveAssembly;
+            AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
         }
 
         private void UnsubscribeAssemblyResolvingEvent()
         {
-            AppDomain.CurrentDomain.AssemblyResolve -= AssemblyHelper.ResolveAssembly;
+            AppDomain.CurrentDomain.AssemblyResolve -= ResolveAssembly;
+        }
+
+        /// <summary>
+        /// Handler to the ApplicationDomain's AssemblyResolve event.
+        /// If an assembly's location cannot be resolved, an exception is
+        /// thrown. Failure to resolve an assembly will leave Dynamo in 
+        /// a bad state, so we should throw an exception here which gets caught 
+        /// by our unhandled exception handler and presents the crash dialogue.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static Assembly ResolveAssembly(object sender, ResolveEventArgs args)
+        {
+            string assemblyPath = string.Empty;
+            try
+            {
+                var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+                var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
+                var parentDirectory = Directory.GetParent(assemblyDirectory);
+
+                // First check the core path
+                assemblyPath = Path.Combine(parentDirectory.FullName, new AssemblyName(args.Name).Name + ".dll");
+                if (File.Exists(assemblyPath))
+                {
+                    return Assembly.LoadFrom(assemblyPath);
+                }
+                return null;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(string.Format("There location of the assembly, {0} could not be resolved for {1loading.", assemblyPath), ex);
+            }
         }
     }
 }


### PR DESCRIPTION
There are two changes here:
1).  An specific assembly resolver is created which will not depend on the path manager. This is in line with the ongoing changes with the path manager. The changes here is to make sure RTF will run correctly with a correct resolver.
2). SetupDynamoPaths() is moved from DynamoRevitApp to DynamoRevit so that the second time the plugin is started, the path manager will be created correctly. This is also in line with the ongoing changes with the path manager.

@ikeough 
@Benglin 
PTAL