### PR TITLE
Adding one used namespace

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -24,6 +24,8 @@ using Dynamo.Models;
 using Dynamo.Services;
 using Dynamo.ViewModels;
 
+using DynamoUtilities;
+
 using RevitServices.Persistence;
 using RevitServices.Transactions;
 using RevitServices.Threading;


### PR DESCRIPTION
This is to add one missing namespace used by the path manager.

@Benglin 
PTAL