### PR TITLE
Set up paths for the test cases

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -267,7 +267,7 @@ namespace Dynamo.Applications
                 DocumentManager.Instance.CurrentUIApplication = commandData.Application;
         }
 
-        private static void SetupDynamoPaths()
+        public static void SetupDynamoPaths()
         {
             // The executing assembly will be in Revit_20xx, so 
             // we have to walk up one level. Unfortunately, we

--- a/test/Libraries/RevitIntegrationTests/RegressionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RegressionTests.cs
@@ -8,6 +8,7 @@ using DynamoUtilities;
 using NUnit.Framework;
 using RevitServices.Elements;
 using RevitTestServices;
+using Dynamo.Applications;
 
 namespace RevitSystemTests
 {
@@ -43,13 +44,7 @@ namespace RevitSystemTests
                 SwapCurrentModel(revitFilePath);
 
                 //Set the directory
-                string assDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                DynamoPathManager.Instance.AddResolutionPath(assDir);
-                DynamoPathManager.Instance.Nodes.Add(Path.Combine(assDir, "nodes"));
-                string mainPath = Path.GetFullPath(Path.Combine(assDir, @"..\"));
-                DynamoPathManager.Instance.InitializeCore(mainPath);
-                DynamoPathManager.Instance.AddPreloadLibrary(Path.Combine(assDir, "RevitNodes.dll"));
-                DynamoPathManager.Instance.AddPreloadLibrary(Path.Combine(assDir, "SimpleRaaS.dll"));
+                DynamoRevit.SetupDynamoPaths();
 
                 //Setup should be called after swapping document, so that RevitDynamoModel 
                 //is now associated with swapped model.
@@ -97,6 +92,7 @@ namespace RevitSystemTests
         {
             var testParameters = new List<RegressionTestData>();
 
+            DynamoRevit.SetupDynamoPaths();
 			var config = RevitTestConfiguration.LoadConfiguration();
             string testsLoc = Path.Combine(config.WorkingDirectory, "Regression");
             var regTestPath = Path.GetFullPath(testsLoc);

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -187,6 +187,8 @@ namespace RevitTestServices
             DocumentManager.Instance.CurrentUIDocument =
                 RTF.Applications.RevitTestExecutive.CommandData.Application.ActiveUIDocument;
 
+            DynamoRevit.SetupDynamoPaths();
+
             var config = RevitTestConfiguration.LoadConfiguration();
 
             //get the test path


### PR DESCRIPTION
For the test cases, we also need to set up the paths before running them. The paths won't be set because right now we have moved the setting logic to DynamoRevit.

This is pretty much similar to what is done by Ben right now.

@Benglin 
PTAL