### PR TITLE
Units fixes

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -404,7 +404,7 @@ namespace Revit.Elements
             var paramType = param.Definition.ParameterType;
 
             if (IsConvertableParameterType(paramType))
-                valueToSet = param.AsDouble() * UnitConverter.DynamoToHostFactor(
+                valueToSet = value * UnitConverter.DynamoToHostFactor(
                     ParameterTypeToUnitType(paramType));
             
             param.Set(valueToSet);

--- a/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
@@ -156,8 +156,8 @@ namespace RevitNodesTests.Elements
 
             var bbox = BoundingBox.ByGeometry(solids);
 
-            bbox.MaxPoint.ShouldBeApproximately(-64.266, -7.999, 60.693, 1e-3);
-            bbox.MinPoint.ShouldBeApproximately(-92.708, -38.479, 0, 1e-3);
+            bbox.MaxPoint.ShouldBeApproximately(-210.846457, -26.243438, 199.124016, 1e-2);
+            bbox.MinPoint.ShouldBeApproximately(-304.160105, -126.243438, 0, 1e-2);
         }
         
         [Test]

--- a/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
@@ -191,8 +191,8 @@ namespace RevitNodesTests.Elements
 
             var bbox = BoundingBox.ByGeometry(crvs);
 
-            bbox.MinPoint.ShouldBeApproximately(-31.607, -26.870, 0, 1e-3);
-            bbox.MaxPoint.ShouldBeApproximately(25.434, 33.212, 0, 1e-3);
+            bbox.MinPoint.ShouldBeApproximately(-103.697, -88.156, 0, 1e-2);
+            bbox.MaxPoint.ShouldBeApproximately(83.445, 108.963, 0, 1e-2);
 
             var refs = crvs.Select(x => ElementCurveReference.TryGetCurveReference(x));
 

--- a/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
@@ -117,8 +117,8 @@ namespace RevitNodesTests.Elements
 
             var bbox = BoundingBox.ByGeometry(solids);
 
-            bbox.MaxPoint.ShouldBeApproximately(-64.266, -7.999, 60.693, 1e-3);
-            bbox.MinPoint.ShouldBeApproximately(-92.708, -38.479, 0, 1e-3);
+            bbox.MaxPoint.ShouldBeApproximately(-210.846457, -26.243438, 199.124016, 1e-2);
+            bbox.MinPoint.ShouldBeApproximately(-304.160105, -126.243438, 0, 1e-2);
         }
 
         [Test]

--- a/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
@@ -2,10 +2,13 @@
 using System.Linq;
 
 using Autodesk.DesignScript.Geometry;
+using Autodesk.Revit.Creation;
+using Autodesk.Revit.DB;
 
 using NUnit.Framework;
 
 using Revit.Elements;
+using Revit.GeometryConversion;
 using Revit.GeometryReferences;
 
 using RevitServices.Persistence;
@@ -13,6 +16,9 @@ using RevitServices.Persistence;
 using RevitTestServices;
 
 using RTF.Framework;
+
+using Element = Revit.Elements.Element;
+using FamilySymbol = Revit.Elements.FamilySymbol;
 
 namespace RevitNodesTests.Elements
 {
@@ -63,16 +69,31 @@ namespace RevitNodesTests.Elements
         {
             var wall = ElementSelector.ByElementId(184176, true);
 
-            var newHeight = 45.5;
+            SetExpectedWallHeight(wall, 45.5);
+            GetExpectedWallHeight(wall, 45.5);
 
+            // Change project to meters
+            var units = DocumentManager.Instance.CurrentDBDocument.GetUnits();
+            units.SetFormatOptions(UnitType.UT_Length, new FormatOptions(DisplayUnitType.DUT_METERS));
+            DocumentManager.Instance.CurrentDBDocument.SetUnits(units);
+
+            SetExpectedWallHeight(wall, 45.5);
+            GetExpectedWallHeight(wall, 45.5);
+        }
+
+        private static void SetExpectedWallHeight(Element wall, double value)
+        {
             var name = "Unconnected Height";
-            wall.SetParameterByName(name, newHeight);
+            wall.SetParameterByName(name, value);
+        }
 
+        private static void GetExpectedWallHeight(Element wall, double value)
+        {
+            var name = "Unconnected Height";
             var height = (double)(wall.GetParameterValueByName(name));
 
             Assert.NotNull(height);
-
-            height.ShouldBeApproximately(newHeight);
+            height.ShouldBeApproximately(value);
         }
 
         [Test]
@@ -80,13 +101,7 @@ namespace RevitNodesTests.Elements
         public void CanSuccessfullyGetElementParamWithUnitType()
         {
             var wall = ElementSelector.ByElementId(184176, true);
-
-            var name = "Unconnected Height";
-            var height = (double)(wall.GetParameterValueByName(name));
-
-            Assert.NotNull(height);
-
-            height.ShouldBeApproximately(20.0);
+            GetExpectedWallHeight(wall, 20);
         }
 
         #region Face/Solid Extraction

--- a/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
@@ -214,8 +214,8 @@ namespace RevitNodesTests.Elements
 
             var bbox = BoundingBox.ByGeometry(crvs);
 
-            bbox.MaxPoint.ShouldBeApproximately(15.240, 0, 0, 1e-3);
-            bbox.MinPoint.ShouldBeApproximately(0, -30.480, 0, 1e-3);
+            bbox.MaxPoint.ShouldBeApproximately(50.0, 0, 0, 1e-3);
+            bbox.MinPoint.ShouldBeApproximately(0, -100.0, 0, 1e-3);
 
             var refs = crvs.Select(x => ElementCurveReference.TryGetCurveReference(x));
 

--- a/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ElementTests.cs
@@ -132,8 +132,8 @@ namespace RevitNodesTests.Elements
 
             var bbox = BoundingBox.ByGeometry(faces);
 
-            bbox.MaxPoint.ShouldBeApproximately(-64.266, -7.999, 60.693, 1e-3);
-            bbox.MinPoint.ShouldBeApproximately(-92.708, -38.479, 0, 1e-3);
+            bbox.MaxPoint.ShouldBeApproximately(-210.846457, -26.243438, 199.124016, 1e-2);
+            bbox.MinPoint.ShouldBeApproximately(-304.160105, -126.243438, 0, 1e-2);
 
             var refs = faces.Select(x => ElementFaceReference.TryGetFaceReference(x));
 

--- a/test/Libraries/RevitNodesTests/Elements/FloorTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/FloorTests.cs
@@ -38,7 +38,7 @@ namespace RevitNodesTests.Elements
 
             var floor = Floor.ByOutlineTypeAndLevel(outline, floorType, level);
 
-            BoundingBoxVolume(floor.BoundingBox).ShouldBeApproximately(100 * 100 * 0.3048, 1e-3);
+            BoundingBoxVolume(floor.BoundingBox).ShouldBeApproximately(100 * 100, 1e-3);
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace RevitNodesTests.Elements
 
             var floor = Floor.ByOutlineTypeAndLevel(polyCurveOutline, floorType, level);
 
-            BoundingBoxVolume(floor.BoundingBox).ShouldBeApproximately(100 * 100 * 0.3048, 1e-3);
+            BoundingBoxVolume(floor.BoundingBox).ShouldBeApproximately(100 * 100, 1e-3);
         }
 
         [Test]

--- a/test/Libraries/RevitNodesTests/Elements/ReferencePointTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ReferencePointTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 using Revit.GeometryConversion;
 
+using RevitServices.Persistence;
+
 using RevitTestServices;
 
 using RTF.Framework;
@@ -67,7 +69,7 @@ namespace RevitNodesTests
             InternalPosition(rp).ShouldBeApproximately(pt.InHostUnits());
         }
 
-        [Test, Category("Failure")]
+        [Test]
         [TestModel(@".\empty.rfa")]
         public void ByLengthOnCurveReference_ShouldPlaceReferencePointCorrectly()
         {
@@ -75,19 +77,23 @@ namespace RevitNodesTests
             var modelCurve = ModelCurve.ByCurve(l);
             var rp = ReferencePoint.ByLengthOnCurveReference(modelCurve.ElementCurveReference, 0.5);
 
+            DocumentManager.Instance.CurrentDBDocument.Regenerate();
+
             var pt = Point.ByCoordinates(0.5, 0, 0);
 
             rp.Point.ShouldBeApproximately(pt);
             InternalPosition(rp).ShouldBeApproximately(pt.InHostUnits());
         }
 
-        [Test, Category("Failure")]
+        [Test]
         [TestModel(@".\empty.rfa")]
         public void ByParameterOnCurveReference_ShouldPlaceReferencePointCorrectly()
         {
             var l = Line.ByStartPointEndPoint(Point.ByCoordinates(0, 0, 0), Point.ByCoordinates(1, 0, 0));
             var modelCurve = ModelCurve.ByCurve(l);
             var rp = ReferencePoint.ByParameterOnCurveReference(modelCurve.ElementCurveReference, 0.5);
+
+            DocumentManager.Instance.CurrentDBDocument.Regenerate();
 
             var pt = Point.ByCoordinates(0.5, 0, 0);
 

--- a/test/Libraries/RevitNodesTests/GeometryConversion/ProtoToRevitCurveTests.cs
+++ b/test/Libraries/RevitNodesTests/GeometryConversion/ProtoToRevitCurveTests.cs
@@ -30,10 +30,6 @@ namespace RevitNodesTests.GeometryConversion
 
             var bspline = NurbsCurve.ByControlPoints(pts, 3);
 
-            // do scaling for check
-            var metersToFeet = 1/0.3048;
-            var bsplineScaled = (NurbsCurve)bspline.Scale(metersToFeet);
-
             // by default, performs conversion
             var revitCurve = bspline.ToRevitType();
 
@@ -42,18 +38,15 @@ namespace RevitNodesTests.GeometryConversion
 
             var revitSpline = (Autodesk.Revit.DB.NurbSpline)revitCurve;
 
-            Assert.AreEqual(bsplineScaled.Degree, revitSpline.Degree);
-            Assert.AreEqual(bsplineScaled.ControlPoints().Count(), revitSpline.CtrlPoints.Count);
+            Assert.AreEqual(bspline.Degree, revitSpline.Degree);
+            Assert.AreEqual(bspline.ControlPoints().Count(), revitSpline.CtrlPoints.Count);
 
-            // We tesselate but not convert units. We are trying to find out if
-            // ToRevitType did the conversion properly by comparing to a scaled
-            // version of the original bspline (bsplineScaled)
             var tessPts = revitSpline.Tessellate().Select(x => x.ToPoint(false));
 
             //assert the tesselation is very close to original curve
             foreach (var pt in tessPts)
             {
-                var closestPt = bsplineScaled.ClosestPointTo(pt);
+                var closestPt = bspline.ClosestPointTo(pt);
                 Assert.Less(closestPt.DistanceTo(pt), 1e-6);
             }
         }

--- a/test/Libraries/RevitNodesTests/GeometryConversion/RevitToProtoCurveTests.cs
+++ b/test/Libraries/RevitNodesTests/GeometryConversion/RevitToProtoCurveTests.cs
@@ -46,9 +46,7 @@ namespace RevitNodesTests.GeometryConversion
             Assert.AreEqual(revitSpline.CtrlPoints.Count, protoSpline.ControlPoints().Count());
             Assert.AreEqual(revitSpline.Weights.Cast<double>().Count(), protoSpline.Weights().Length);
 
-            // We scale the tesselation for comparison
-            var feetToMeters = 0.3048;
-            var tessPtsProto = revitSpline.Tessellate().Select(x => x.ToPoint(false).Scale(feetToMeters)).Cast<Autodesk.DesignScript.Geometry.Point>();
+            var tessPtsProto = revitSpline.Tessellate().Select(x => x.ToPoint(false));
 
             // assert the tesselation is very close to original curve
             foreach (var pt in tessPtsProto)

--- a/test/Libraries/RevitNodesTests/GeometryConversion/RevitToProtoMeshTests.cs
+++ b/test/Libraries/RevitNodesTests/GeometryConversion/RevitToProtoMeshTests.cs
@@ -41,9 +41,9 @@ namespace RevitNodesTests.GeometryConversion
             var bbmin = bb.MinPoint;
             var bbmax = bb.MaxPoint;
 
-            bbvol.ShouldBeApproximately(560845.185, 1e-2);
-            bbmin.X.ShouldBeApproximately(-114.688, 1e-2);
-            bbmax.X.ShouldBeApproximately(204.378, 1e-2);
+            bbvol.ShouldBeApproximately(19806060.78503, 1e-1);
+            bbmin.X.ShouldBeApproximately(-376.2729659, 1e-2);
+            bbmax.X.ShouldBeApproximately(670.5314961, 1e-2);
 
             convertedMesh.Dispose();
         }


### PR DESCRIPTION
This PR introduces test fixes to remove scaling factors in tests that are no longer necessary after the merge of the Units work. As an added bonus, it fixes two tests previously marked as failures.

Requires Merge:
- [ ] Revit2014
- [ ] Revit2015