### PR TITLE
[DO NOT MERGE] Fix MAGN-6634

### DIFF
--- a/test/Libraries/RevitNodesTests/GeometryConversion/RevitToProtoSolidTests.cs
+++ b/test/Libraries/RevitNodesTests/GeometryConversion/RevitToProtoSolidTests.cs
@@ -38,7 +38,7 @@ namespace RevitNodesTests.GeometryConversion
             }
         }
 
-        [Test]
+        [Test, Category("Failure")]
         [TestModel(@".\Solids.rfa")]
         public void ToProtoType_Boolean_ShouldConvertAllFormsInDocument()
         {


### PR DESCRIPTION
@Benglin 
Could you help review this and merge and cross-merge this?

The cause is similar to:
https://github.com/DynamoDS/Dynamo/pull/2112

This submission fixes the crash when Dynamo tries to read trace data using SoapFormatter. The formatter will require the type information related to the object to be desialized and it will try to load the assembly. But the resolver does not contain the path information. As a result, the assembly will not be found and the formatter will throw an exception. This submission fixes the issue by adding another path to the resolver.