### PR TITLE
Fixed issue with "SoapFormatter.Deserialize" exception

### DIFF
--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -140,20 +140,24 @@ namespace Dynamo.Applications
         /// <returns></returns>
         public static Assembly ResolveAssembly(object sender, ResolveEventArgs args)
         {
-            string assemblyPath = string.Empty;
+            var assemblyPath = string.Empty;
+            var assemblyName = new AssemblyName(args.Name).Name + ".dll";
+
             try
             {
                 var assemblyLocation = Assembly.GetExecutingAssembly().Location;
                 var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
-                var parentDirectory = Directory.GetParent(assemblyDirectory);
 
-                // First check the core path
-                assemblyPath = Path.Combine(parentDirectory.FullName, new AssemblyName(args.Name).Name + ".dll");
-                if (File.Exists(assemblyPath))
+                // Try "Dynamo 0.x\Revit_20xx" folder first...
+                assemblyPath = Path.Combine(assemblyDirectory, assemblyName);
+                if (!File.Exists(assemblyPath))
                 {
-                    return Assembly.LoadFrom(assemblyPath);
+                    // If assembly cannot be found, try in "Dynamo 0.x" folder.
+                    var parentDirectory = Directory.GetParent(assemblyDirectory);
+                    assemblyPath = Path.Combine(parentDirectory.FullName, assemblyName);
                 }
-                return null;
+
+                return (File.Exists(assemblyPath) ? Assembly.LoadFrom(assemblyPath) : null);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This fixes [an internally tracked defect](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6634).

When `SoapFormatter.Deserialize` tries to load `RevitServices.dll`. The assembly resolution logic in `DynamoRevitApp.ResolveAssembly` was called, but it attempts to load the said assembly from:

    C:\Program Files\Dynamo 0.8

That itself is insufficient, the `RevitServices.dll` resides in the same folder where `DynamoRevitDS.dll` resides, which is the following folder:

    C:\Program Files\Dynamo 0.8\Revit_2014

This pull request enhances the logic by first checking to see if `RevitServices.dll` can be found alongside `DynamoRevitDS.dll`.

@Randy-Ma, I'm going to merge this in to stabilize the build, but please have a look afterwards, thanks :)