### PR TITLE
Path Manager: Revit specific changes

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -87,9 +87,6 @@ namespace Dynamo.Applications
 
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            //Set the directory
-            SetupDynamoPaths();
-
             HandleDebug(commandData);
             
             InitializeCore(commandData);
@@ -170,7 +167,6 @@ namespace Dynamo.Applications
 
         private static RevitDynamoModel InitializeCoreModel(ExternalCommandData commandData)
         {
-            var prefs = PreferenceSettings.Load();
             var assemblyLocation = Assembly.GetExecutingAssembly().Location;
             var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
             var parentDirectory = Directory.GetParent(assemblyDirectory);
@@ -179,9 +175,8 @@ namespace Dynamo.Applications
             return RevitDynamoModel.Start(
                 new RevitDynamoModel.RevitStartConfiguration()
                 {
-                    Preferences = prefs,
-                    DynamoCorePath = corePath,
                     GeometryFactoryPath = GetGeometryFactoryPath(corePath),
+                    PathResolver = new RevitPathResolver(),
                     Context = GetRevitContext(commandData),
                     SchedulerThread = new RevitSchedulerThread(commandData.Application),
                     AuthProvider = new RevitOxygenProvider(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher)),
@@ -247,30 +242,6 @@ namespace Dynamo.Applications
         {
             if (DocumentManager.Instance.CurrentUIApplication == null)
                 DocumentManager.Instance.CurrentUIApplication = commandData.Application;
-        }
-
-        public static void SetupDynamoPaths()
-        {
-            // The executing assembly will be in Revit_20xx, so 
-            // we have to walk up one level. Unfortunately, we
-            // can't use DynamoPathManager here because those are not
-            // initialized until the DynamoModel is constructed.
-            string assDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-
-            // Add the Revit_20xx folder for assembly resolution
-            DynamoPathManager.Instance.AddResolutionPath(assDir);
-
-            // Setup the core paths
-            DynamoPathManager.Instance.InitializeCore(Path.GetFullPath(assDir + @"\.."));
-
-            // Add Revit-specific paths for loading.
-            DynamoPathManager.Instance.AddPreloadLibrary(Path.Combine(assDir, "RevitNodes.dll"));
-            DynamoPathManager.Instance.AddPreloadLibrary(Path.Combine(assDir, "SimpleRaaS.dll"));
-
-            //add an additional node processing folder
-            DynamoPathManager.Instance.Nodes.Add(Path.Combine(assDir, "nodes"));
-
-            // TODO(PATHMANAGER): Remove reference to DynamoUtilities.dll when this is done.
         }
 
         #endregion

--- a/src/DynamoRevit/DynamoRevit.csproj
+++ b/src/DynamoRevit/DynamoRevit.csproj
@@ -130,6 +130,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.en-US.resx</DependentUpon>
     </Compile>
+    <Compile Include="RevitPathResolver.cs" />
     <Compile Include="ViewModel\RevitWatchHandler.cs" />
     <Compile Include="ViewModel\RevitVisualizationManager.cs" />
     <Compile Include="Migration\WorkspaceMigrationsRevit.cs" />

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -45,6 +45,7 @@ namespace Dynamo.Applications.Models
         {
             public string Context { get; set; }
             public string DynamoCorePath { get; set; }
+            public IPathResolver PathResolver { get; set; }
             public IPreferences Preferences { get; set; }
             public bool StartInTestMode { get; set; }
             public IUpdateManager UpdateManager { get; set; }
@@ -98,14 +99,6 @@ namespace Dynamo.Applications.Models
             // where necessary, assign defaults
             if (string.IsNullOrEmpty(configuration.Context))
                 configuration.Context = Core.Context.REVIT_2015;
-            if (string.IsNullOrEmpty(configuration.DynamoCorePath))
-            {
-                var asmLocation = Assembly.GetExecutingAssembly().Location;
-                configuration.DynamoCorePath = Path.GetDirectoryName(asmLocation);
-            }
-
-            if (configuration.Preferences == null)
-                configuration.Preferences = new PreferenceSettings();
 
             return new RevitDynamoModel(configuration);
         }

--- a/src/DynamoRevit/RevitPathResolver.cs
+++ b/src/DynamoRevit/RevitPathResolver.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Dynamo.Interfaces;
+
+namespace Dynamo.Applications
+{
+    class RevitPathResolver : IPathResolver
+    {
+        private readonly List<string> preloadLibraryPaths;
+        private readonly List<string> additionalNodeDirectories;
+        private readonly List<string> additionalResolutionPaths;
+
+        internal RevitPathResolver()
+        {
+            // The executing assembly will be in Revit_20xx folder,
+            // so we have to walk up one level.
+            var currentAssemblyPath = Assembly.GetExecutingAssembly().Location;
+            var currentAssemblyDir = Path.GetDirectoryName(currentAssemblyPath);
+
+            var nodesDirectory = Path.Combine(currentAssemblyDir, "nodes");
+            var revitNodesDll = Path.Combine(currentAssemblyDir, "RevitNodes.dll");
+            var simpleRaaSDll = Path.Combine(currentAssemblyDir, "SimpleRaaS.dll");
+
+            // Just making sure we are looking at the right level of nesting.
+            if (!Directory.Exists(nodesDirectory))
+                throw new DirectoryNotFoundException(nodesDirectory);
+            if (!File.Exists(revitNodesDll))
+                throw new FileNotFoundException(revitNodesDll);
+            if (!File.Exists(simpleRaaSDll))
+                throw new FileNotFoundException(simpleRaaSDll);
+
+            // Add Revit-specific library paths for preloading.
+            preloadLibraryPaths = new List<string> { revitNodesDll, simpleRaaSDll };
+
+            // Add an additional node processing folder
+            additionalNodeDirectories = new List<string> { nodesDirectory };
+
+            // Add the Revit_20xx folder for assembly resolution
+            additionalResolutionPaths = new List<string> { currentAssemblyDir };
+        }
+
+        public IEnumerable<string> AdditionalNodeDirectories
+        {
+            get { return additionalNodeDirectories; }
+        }
+
+        public IEnumerable<string> AdditionalResolutionPaths
+        {
+            get { return additionalResolutionPaths; }
+        }
+
+        public IEnumerable<string> PreloadedLibraryPaths
+        {
+            get { return preloadLibraryPaths; }
+        }
+    }
+}

--- a/test/Libraries/RevitIntegrationTests/RegressionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RegressionTests.cs
@@ -44,7 +44,11 @@ namespace RevitSystemTests
                 SwapCurrentModel(revitFilePath);
 
                 //Set the directory
-                DynamoRevit.SetupDynamoPaths();
+                var assemblyPath = Assembly.GetExecutingAssembly().Location;
+                var assemblyDir = Path.GetDirectoryName(assemblyPath);
+
+                //Ensure SystemTestBase picks it up.
+                pathResolver = new RevitTestPathResolver(assemblyDir);
 
                 //Setup should be called after swapping document, so that RevitDynamoModel 
                 //is now associated with swapped model.
@@ -92,8 +96,7 @@ namespace RevitSystemTests
         {
             var testParameters = new List<RegressionTestData>();
 
-            DynamoRevit.SetupDynamoPaths();
-			var config = RevitTestConfiguration.LoadConfiguration();
+            var config = RevitTestConfiguration.LoadConfiguration();
             string testsLoc = Path.Combine(config.WorkingDirectory, "Regression");
             var regTestPath = Path.GetFullPath(testsLoc);
 

--- a/test/Libraries/RevitTestServices/RevitNodeTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitNodeTestBase.cs
@@ -18,11 +18,18 @@ namespace RevitTestServices
     /// </summary>
     public class RevitNodeTestBase : GeometricTestBase
     {
+        private AssemblyResolver assemblyResolver;
         protected const string ANALYSIS_DISPLAY_TESTS = "AnalysisDisplayTests";
 
         [SetUp]
         public override void Setup()
         {
+            if (assemblyResolver == null)
+            {
+                assemblyResolver = new AssemblyResolver();
+                assemblyResolver.Setup();
+            }
+
             DocumentManager.Instance.CurrentUIApplication =
                 RTF.Applications.RevitTestExecutive.CommandData.Application;
             DocumentManager.Instance.CurrentUIDocument =
@@ -66,6 +73,12 @@ namespace RevitTestServices
             // run the test framework without running Dynamo, so
             // we ensure that the transaction is closed here.
             TransactionManager.Instance.ForceCloseTransaction();
+
+            if (assemblyResolver != null)
+            {
+                assemblyResolver.TearDown();
+                assemblyResolver = null;
+            }
         }
 
         private static void SetUpHostUnits()

--- a/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
+++ b/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Dynamo.Interfaces;
+
+namespace RevitTestServices
+{
+    public class RevitTestPathResolver : IPathResolver
+    {
+        private readonly HashSet<string> additionalResolutionPaths;
+        private readonly HashSet<string> additionalNodeDirectories;
+        private readonly HashSet<string> preloadedLibraryPaths;
+
+        public RevitTestPathResolver()
+        {
+            additionalResolutionPaths = new HashSet<string>();
+            additionalNodeDirectories = new HashSet<string>();
+            preloadedLibraryPaths = new HashSet<string>();
+        }
+
+        public RevitTestPathResolver(string assemblyDirectory) : this()
+        {
+            var nodesDirectory = Path.Combine(assemblyDirectory, "nodes");
+            var revitNodesDll = Path.Combine(assemblyDirectory, "RevitNodes.dll");
+            var simpleRaaSDll = Path.Combine(assemblyDirectory, "SimpleRaaS.dll");
+
+            if (!Directory.Exists(nodesDirectory))
+                throw new DirectoryNotFoundException(nodesDirectory);
+            if (!File.Exists(revitNodesDll))
+                throw new FileNotFoundException(revitNodesDll);
+            if (!File.Exists(simpleRaaSDll))
+                throw new FileNotFoundException(simpleRaaSDll);
+
+            AddResolutionPath(assemblyDirectory);
+            AddNodeDirectory(nodesDirectory);
+            AddPreloadLibraryPath(revitNodesDll);
+            AddPreloadLibraryPath(simpleRaaSDll);
+        }
+
+        public IEnumerable<string> AdditionalResolutionPaths
+        {
+            get { return additionalResolutionPaths; }
+        }
+
+        public IEnumerable<string> AdditionalNodeDirectories
+        {
+            get { return additionalNodeDirectories; }
+        }
+
+        public IEnumerable<string> PreloadedLibraryPaths
+        {
+            get { return preloadedLibraryPaths; }
+        }
+
+        public void AddNodeDirectory(string nodeDirectory)
+        {
+            if (!additionalNodeDirectories.Contains(nodeDirectory))
+                additionalNodeDirectories.Add(nodeDirectory);
+        }
+
+        public void AddResolutionPath(string resolutionPath)
+        {
+            if (!additionalResolutionPaths.Contains(resolutionPath))
+                additionalResolutionPaths.Add(resolutionPath);
+        }
+
+        public void AddPreloadLibraryPath(string preloadLibraryPath)
+        {
+            if (!preloadedLibraryPaths.Contains(preloadLibraryPath))
+                preloadedLibraryPaths.Add(preloadLibraryPath);
+        }
+    }
+}

--- a/test/Libraries/RevitTestServices/RevitTestServices.csproj
+++ b/test/Libraries/RevitTestServices/RevitTestServices.csproj
@@ -72,6 +72,7 @@
     <Compile Include="RevitSystemTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RevitNodeTestBase.cs" />
+    <Compile Include="RevitTestPathResolver.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="DynamoCore">


### PR DESCRIPTION
Background
-----
`DynamoPathManager` has been [completely removed in `DynamoDS/Dynamo:master` branch](https://github.com/DynamoDS/Dynamo/pull/3934), this pull request updates Revit side of things to make use of the new path management system.

Changes
-----
1. References to `DynamoPathManager` are now removed.

2. `class RevitPathResolver : IPathResolver` interface implementation is introduced. Its job is to add `Revit_20xx` into additional resolution path collection, and to include both `RevitNodes.dll` and `SimpleRaaS.dll` for preloading.

3. `DynamoRevit.InitializeCoreModel` now supplies a `RevitPathResolver` object to `RevitDynamoModel`. Its job is to provide additional information about resolution path and preloaded node assemblies.

4. We no longer create a `PreferenceSettings` object and hand it off to `RevitDynamoModel` at start up. The `Preferences` reference is left as `null` so that an instance is created within `DynamoModel` constructor.

5. `class RevitTestPathResolver : IPathResolver` class is introduced. It is equivalent to `RevitPathResolver`, except that it is meant for Revit test cases. In addition to that, it also allows assembly directory (the one that contains `RevitNodes.dll` and `SimpleRaaS.dll`) to be specified.

Notes to Reviewer
-----
Hi @ikeough, please have a look. Note that `AssemblyResolver` is no longer a `static` class. Based on your recent experience with Revit test failures, could you please suggest any particular tests to run in Revit Test Framework? Thanks!

Hi @Randy-Ma, this is for your information, thanks again for the help along the way!