### PR TITLE
Categorize one test case to the Failure category

### DIFF
--- a/test/Libraries/RevitNodesTests/GeometryConversion/RevitToProtoSolidTests.cs
+++ b/test/Libraries/RevitNodesTests/GeometryConversion/RevitToProtoSolidTests.cs
@@ -38,7 +38,7 @@ namespace RevitNodesTests.GeometryConversion
             }
         }
 
-        [Test]
+        [Test, Category("Failure")]
         [TestModel(@".\Solids.rfa")]
         public void ToProtoType_Boolean_ShouldConvertAllFormsInDocument()
         {


### PR DESCRIPTION
There is one test case which is failing because of other component. Before the conclusion is made, I am temporarily marking this test case as Failure.

@ke-yu 
PTAL