### PR TITLE
update PathResolver classes to new interface R2015

### DIFF
--- a/src/DynamoRevit/RevitPathResolver.cs
+++ b/src/DynamoRevit/RevitPathResolver.cs
@@ -54,5 +54,15 @@ namespace Dynamo.Applications
         {
             get { return preloadLibraryPaths; }
         }
+
+        public string UserDataRootFolder
+        {
+            get { return string.Empty; }
+        }
+
+        public string CommonDataRootFolder
+        {
+            get { return string.Empty; }
+        }
     }
 }

--- a/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
+++ b/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
@@ -62,5 +62,15 @@ namespace RevitTestServices
             if (!preloadedLibraryPaths.Contains(preloadLibraryPath))
                 preloadedLibraryPaths.Add(preloadLibraryPath);
         }
+
+        public string UserDataRootFolder
+        {
+            get { return string.Empty; }
+        }
+
+        public string CommonDataRootFolder
+        {
+            get { return string.Empty; }
+        }
     }
 }


### PR DESCRIPTION
Related to [4019](https://github.com/DynamoDS/Dynamo/pull/4019)
Update to classes to new IPathResolver interface
The paths are still the default path

@Benglin PTAL