### PR TITLE
MAGN-6649 File Save prompt at Dynamo exit crashes with Revit 2016

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -363,9 +363,6 @@ namespace Dynamo.Applications
             view.Dispatcher.UnhandledException -= Dispatcher_UnhandledException;
             view.Closed -= OnDynamoViewClosed;
 
-            AddIdleAction(() => DocumentManager.Instance.CurrentUIApplication.ViewActivating -=
-            revitDynamoModel.OnApplicationViewActivating);
-
             AppDomain.CurrentDomain.AssemblyResolve -=
                 Analyze.Render.AssemblyHelper.ResolveAssemblies;
 

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -358,20 +358,13 @@ namespace Dynamo.Applications
         {
             var view = (DynamoView)sender;
 
-            DocumentManager.OnLogError -= revitDynamoModel.Logger.Log;
-
             view.Dispatcher.UnhandledException -= Dispatcher_UnhandledException;
             view.Closed -= OnDynamoViewClosed;
 
             AppDomain.CurrentDomain.AssemblyResolve -=
                 Analyze.Render.AssemblyHelper.ResolveAssemblies;
 
-            // KILLDYNSETTINGS - this is suspect
-            revitDynamoModel.Logger.Dispose();
-
             DynamoRevitApp.DynamoButton.Enabled = true;
-
-            revitDynamoModel = null;
         }
 
         private static void DeleteKeeperElementOnce(object sender, IdlingEventArgs idlingEventArgs)


### PR DESCRIPTION
This PR fixes a crash that resulted from attempting unhook an event handler from an event on a null instance of `RevitDynamoModel`.  Because this event unhooking was called from an idle action, the `RevitDynamoModel` to which that method referred was already disposed. 

Additionally, this PR removes several redundant event unhookings and object nullifications. `RevitDynamoModel` now handles these things much more cleanly through its subscribe and unsubscribe methods. And disposing of things like the logger are now handled in `DynamoModel.Dispose()`.

Requires cherry-pick:
- [ ] Revit2015
- [ ] Revit2014

PTAL:
- [ ] @pboyer 