### PR TITLE
Fix MAGN-6738  Dynamo 0.8.0 throws error while launching Dynamo ...

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -147,8 +147,6 @@ namespace Dynamo.Applications.Models
         {
             externalCommandData = configuration.ExternalCommandData;
 
-            RevitServicesUpdater.Initialize(DynamoRevitApp.Updaters);
-
             SubscribeRevitServicesUpdaterEvents();
 
             SubscribeApplicationEvents(configuration.ExternalCommandData);


### PR DESCRIPTION
<h6>Summary</h6>

The error is thrown because RevitServiceUpdater is initialized twice. I am removing one because the RevitServiceUpdater has been changed in: https://github.com/DynamoDS/Dynamo/pull/3554. In this pull request, the initialization is done when the application plugin starts.

@sharadkjaiswal 
PTAL