### PR TITLE
Kill Infinite Loops

### DIFF
--- a/src/Libraries/RevitNodes/Elements/AbstractFamilyInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/AbstractFamilyInstance.cs
@@ -51,7 +51,13 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            InternalFamilyInstance.Symbol = fs;
+            // Don't attempt to set the symbol if it is the same.
+            // Doing so will raise a document modification event which
+            // will, in turn, be responded to by this node causing an infinite loop.
+            if (InternalFamilyInstance.Symbol.UniqueId != fs.UniqueId)
+            {
+                InternalFamilyInstance.Symbol = fs;
+            }
 
             TransactionManager.Instance.TransactionTaskDone();
         }

--- a/src/Libraries/RevitNodes/Elements/CurveElement.cs
+++ b/src/Libraries/RevitNodes/Elements/CurveElement.cs
@@ -56,9 +56,12 @@ namespace Revit.Elements
         /// Set the geometry curve used by the ModelCurve
         /// </summary>
         /// <param name="c"></param>
-        protected void InternalSetCurve(Autodesk.Revit.DB.Curve c)
+        protected void InternalSetCurve(Curve c)
         {
-            if (!this.InternalCurveElement.GeometryCurve.IsBound && c.IsBound)
+            if (!CurveUtils.CurvesAreSimilar(InternalCurveElement.GeometryCurve, c))
+                return;
+
+            if (!InternalCurveElement.GeometryCurve.IsBound && c.IsBound)
             {
                 c = c.Clone();
                 c.MakeUnbound();

--- a/src/Libraries/RevitNodes/Elements/DividedSurface.cs
+++ b/src/Libraries/RevitNodes/Elements/DividedSurface.cs
@@ -2,6 +2,8 @@
 
 using Autodesk.DesignScript.Runtime;
 
+using DynamoUnits;
+
 using Revit.GeometryReferences;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
@@ -186,7 +188,8 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            InternalDividedSurface.AllGridRotation = rotation;
+            if(!InternalDividedSurface.AllGridRotation.AlmostEquals(rotation, 1.0e-6))
+                InternalDividedSurface.AllGridRotation = rotation;
 
             TransactionManager.Instance.TransactionTaskDone();
         }

--- a/src/Libraries/RevitNodes/Elements/Level.cs
+++ b/src/Libraries/RevitNodes/Elements/Level.cs
@@ -5,6 +5,8 @@ using Autodesk.Revit.DB;
 
 using DynamoServices;
 
+using DynamoUnits;
+
 using Revit.GeometryConversion;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
@@ -133,7 +135,8 @@ namespace Revit.Elements
         private void InternalSetElevation(double elevation)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
-            this.InternalLevel.Elevation = elevation;
+            if(!InternalLevel.Elevation.AlmostEquals(elevation, 1.0e-6))
+                InternalLevel.Elevation = elevation;
             TransactionManager.Instance.TransactionTaskDone();
         }
 

--- a/src/Libraries/RevitNodes/Elements/ModelText.cs
+++ b/src/Libraries/RevitNodes/Elements/ModelText.cs
@@ -4,6 +4,8 @@ using Autodesk.Revit.DB;
 
 using DynamoServices;
 
+using DynamoUnits;
+
 using Revit.GeometryConversion;
 
 using RevitServices.Persistence;
@@ -138,7 +140,8 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            InternalModelText.Depth = depth;
+            if(!InternalModelText.Depth.AlmostEquals(depth, 1.0e-6))
+                InternalModelText.Depth = depth;
 
             TransactionManager.Instance.TransactionTaskDone();
         }
@@ -151,7 +154,8 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            InternalModelText.Text = text;
+            if(InternalModelText.Text != text)
+                InternalModelText.Text = text;
 
             TransactionManager.Instance.TransactionTaskDone();
         }
@@ -164,7 +168,8 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            InternalModelText.ModelTextType = modelTextType;
+            if(InternalModelText.ModelTextType.UniqueId != modelTextType.UniqueId)
+                InternalModelText.ModelTextType = modelTextType;
 
             TransactionManager.Instance.TransactionTaskDone();
         }

--- a/src/Libraries/RevitNodes/Elements/ReferencePlane.cs
+++ b/src/Libraries/RevitNodes/Elements/ReferencePlane.cs
@@ -160,22 +160,28 @@ namespace Revit.Elements
 
             XYZ oldBubbleEnd = refPlane.BubbleEnd;
             XYZ oldFreeEnd = refPlane.FreeEnd;
-            XYZ midPointOld = 0.5 * (oldBubbleEnd + oldFreeEnd);
 
-            XYZ midPoint = 0.5 * (bubbleEnd + freeEnd);
-            XYZ moveVec = XYZ.BasisZ.DotProduct(midPoint - midPointOld) * XYZ.BasisZ;
-
-            // (sic) From Dynamo Legacy
             var success = true;
-            try
+
+            if (!refPlane.FreeEnd.IsAlmostEqualTo(oldFreeEnd) ||
+                !refPlane.BubbleEnd.IsAlmostEqualTo(oldBubbleEnd))
             {
-                ElementTransformUtils.MoveElement(Document, refPlane.Id, moveVec);
-                refPlane.BubbleEnd = bubbleEnd;
-                refPlane.FreeEnd = freeEnd;
-            }
-            catch
-            {
-                success = false;
+                XYZ midPointOld = 0.5 * (oldBubbleEnd + oldFreeEnd);
+
+                XYZ midPoint = 0.5 * (bubbleEnd + freeEnd);
+                XYZ moveVec = XYZ.BasisZ.DotProduct(midPoint - midPointOld) * XYZ.BasisZ;
+
+                // (sic) From Dynamo Legacy
+                try
+                {
+                    ElementTransformUtils.MoveElement(Document, refPlane.Id, moveVec);
+                    refPlane.BubbleEnd = bubbleEnd;
+                    refPlane.FreeEnd = freeEnd;
+                }
+                catch
+                {
+                    success = false;
+                }
             }
 
             TransactionManager.Instance.TransactionTaskDone();

--- a/src/Libraries/RevitNodes/Elements/ReferencePoint.cs
+++ b/src/Libraries/RevitNodes/Elements/ReferencePoint.cs
@@ -202,7 +202,8 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            InternalReferencePoint.Position = xyz;
+            if(!InternalReferencePoint.Position.IsAlmostEqualTo(xyz))
+                InternalReferencePoint.Position = xyz;
 
             TransactionManager.Instance.TransactionTaskDone();
         }
@@ -221,7 +222,7 @@ namespace Revit.Elements
             PointOnCurveMeasurementType measurementType, PointOnCurveMeasureFrom measureFrom)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
-
+            
             var plc = new PointLocationOnCurve(measurementType, parameter, measureFrom);
             var edgePoint = Document.Application.Create.NewPointOnEdge(curveReference, plc);
             InternalReferencePoint.SetPointElementReference(edgePoint);

--- a/src/Libraries/RevitNodes/Elements/StucturalFraming.cs
+++ b/src/Libraries/RevitNodes/Elements/StucturalFraming.cs
@@ -227,9 +227,16 @@ namespace Revit.Elements
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            //update the curve
+            // Updating the curve will cause a document modification event
+            // which will be handled by this node and could cause an 
+            // infinite loop. Check the framing's curve for similarity to the 
+            // provided curve and update only if the two are different.
+
             var locCurve = InternalFamilyInstance.Location as LocationCurve;
-            locCurve.Curve = crv;
+            if (!CurveUtils.CurvesAreSimilar(locCurve.Curve, crv))
+            {
+                locCurve.Curve = crv;
+            }
 
             TransactionManager.Instance.TransactionTaskDone();
         }

--- a/src/Libraries/RevitNodes/Elements/Wall.cs
+++ b/src/Libraries/RevitNodes/Elements/Wall.cs
@@ -101,7 +101,8 @@ namespace Revit.Elements
                 if ((wallLocation.Curve is Autodesk.Revit.DB.Line == curve is Autodesk.Revit.DB.Line) ||
                     (wallLocation.Curve is Autodesk.Revit.DB.Arc == curve is Autodesk.Revit.DB.Arc))
                 {
-                    wallLocation.Curve = curve;
+                    if(!CurveUtils.CurvesAreSimilar(wallLocation.Curve, curve))
+                        wallLocation.Curve = curve;
 
                     Autodesk.Revit.DB.Parameter baseLevelParameter =
                        wallElem.get_Parameter(Autodesk.Revit.DB.BuiltInParameter.WALL_BASE_CONSTRAINT);

--- a/src/Libraries/RevitNodes/GeometryConversion/CurveUtils.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/CurveUtils.cs
@@ -79,6 +79,17 @@ namespace Revit.GeometryConversion
             return false;
         }
 
+        /// <summary>
+        /// This method uses basic checks to compare curves for similarity.
+        /// It starts by comparing the curves' end points. Curves which have similar
+        /// end points but different directions will not be regarded as similar,
+        /// because directionality is important in Revit for other purposes. 
+        /// Depending on the curve type, other comparisons are then performed. 
+        /// </summary>
+        /// <param name="a">The first curve.</param>
+        /// <param name="b">The second curve.</param>
+        /// <returns>Returns true if the curves are similar within Tolerance, and 
+        /// false if they are not.</returns>
         public static bool CurvesAreSimilar(Curve a, Curve b)
         {
             if (a.GetType() != b.GetType())

--- a/src/Libraries/RevitNodes/GeometryConversion/CurveUtils.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/CurveUtils.cs
@@ -79,18 +79,18 @@ namespace Revit.GeometryConversion
             return false;
         }
 
-        public static bool CurvesAreSimilar(Curve a, Curve b, double tolerance = 1.0e-6)
+        public static bool CurvesAreSimilar(Curve a, Curve b)
         {
             if (a.GetType() != b.GetType())
                 return false;
 
-            if (!CurvesHaveSameEndpoints(a, b, tolerance))
+            if (!CurvesHaveSameEndpoints(a, b, Tolerance))
                 return false;
 
             dynamic ad = a;
             dynamic bd = b;
 
-            return AreSimilar(ad, bd, tolerance);
+            return AreSimilar(ad, bd, Tolerance);
         }
 
         #region IsLineLike Helpers
@@ -189,7 +189,7 @@ namespace Revit.GeometryConversion
         private static bool CompareRandomParameterLocationDistances(
             Curve a, Curve b, double tolerance)
         {
-            for (var i = 10; i < 10; i++)
+            for (var i = 0; i < 10; i++)
             {
                 var rand = new Random();
                 var t = rand.NextDouble();

--- a/src/Libraries/RevitNodes/GeometryConversion/CurveUtils.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/CurveUtils.cs
@@ -165,8 +165,9 @@ namespace Revit.GeometryConversion
         private static bool AreSimilar(Arc a, Arc b, double tolerance)
         {
             return a.Center.IsAlmostEqualTo(b.Center) && 
-                a.Radius.AlmostEquals(b.Radius, 1.0e-6) && 
-                a.IsCyclic == b.IsCyclic;
+                a.Radius.AlmostEquals(b.Radius, Tolerance) && 
+                a.IsCyclic == b.IsCyclic &&
+                a.Normal.IsAlmostEqualTo(b.Normal);
         }
 
         private static bool AreSimilar(HermiteSpline a, HermiteSpline b, double tolerance)
@@ -183,7 +184,8 @@ namespace Revit.GeometryConversion
         {
             return a.Center.IsAlmostEqualTo(b.Center, tolerance) &&
                 a.RadiusX.AlmostEquals(b.RadiusX, tolerance) &&
-                a.RadiusY.AlmostEquals(b.RadiusY, tolerance);
+                a.RadiusY.AlmostEquals(b.RadiusY, tolerance) && 
+                a.Normal.IsAlmostEqualTo(b.Normal);
         }
 
         private static bool AreSimilar(CylindricalHelix a, CylindricalHelix b, double tolerance)
@@ -200,7 +202,7 @@ namespace Revit.GeometryConversion
         private static bool CompareRandomParameterLocationDistances(
             Curve a, Curve b, double tolerance)
         {
-            for (var i = 0; i < 10; i++)
+            for (var i = 0; i < 20; i++)
             {
                 var rand = new Random();
                 var t = rand.NextDouble();

--- a/test/Libraries/RevitNodesTests/GeometryConversion/CurveUtilsTests.cs
+++ b/test/Libraries/RevitNodesTests/GeometryConversion/CurveUtilsTests.cs
@@ -116,5 +116,21 @@ namespace RevitNodesTests.GeometryConversion
             Assert.False(CurveUtils.IsLineLike(arc.ToRevitType(false)));
         }
 
+        [Test]
+        [TestModel(@".\empty.rfa")]
+        public void CurvesAreSimilar_Lines()
+        {
+            var a = Point.ByCoordinates(0, 0);
+            var b = Point.ByCoordinates(1, 1);
+            
+            var line1 = Line.ByStartPointEndPoint(a, b);
+            var line2 = Line.ByStartPointEndPoint(b, a);
+
+            var revitLine1 = line1.ToRevitType();
+            var revitLine2 = line2.ToRevitType();
+
+            Assert.True(CurveUtils.CurvesAreSimilar(revitLine1, revitLine1));
+            Assert.False(CurveUtils.CurvesAreSimilar(revitLine1, revitLine2));
+        }
     }
 }

--- a/test/Libraries/RevitNodesTests/GeometryConversion/CurveUtilsTests.cs
+++ b/test/Libraries/RevitNodesTests/GeometryConversion/CurveUtilsTests.cs
@@ -122,15 +122,86 @@ namespace RevitNodesTests.GeometryConversion
         {
             var a = Point.ByCoordinates(0, 0);
             var b = Point.ByCoordinates(1, 1);
-            
+            var c = Point.ByCoordinates(2, 2);
+
             var line1 = Line.ByStartPointEndPoint(a, b);
             var line2 = Line.ByStartPointEndPoint(b, a);
+            var line3 = Line.ByStartPointEndPoint(a, c);
 
             var revitLine1 = line1.ToRevitType();
             var revitLine2 = line2.ToRevitType();
+            var revitLine3 = line3.ToRevitType();
 
             Assert.True(CurveUtils.CurvesAreSimilar(revitLine1, revitLine1));
             Assert.False(CurveUtils.CurvesAreSimilar(revitLine1, revitLine2));
+            Assert.False(CurveUtils.CurvesAreSimilar(revitLine1, revitLine3));
         }
+
+        [Test]
+        [TestModel(@".\empty.rfa")]
+        public void CurvesAreSimilar_Arcs()
+        {
+            var a = Arc.ByCenterPointRadiusAngle(Point.ByCoordinates(0, 0, 0), 1.0, 0, 90, Vector.ZAxis());
+            var b = Arc.ByCenterPointRadiusAngle(Point.ByCoordinates(1, 1, 1), 1.0, 0, 90, Vector.ZAxis());
+            var c = Arc.ByCenterPointRadiusAngle(Point.ByCoordinates(0, 0, 0), 2.0, 0, 90, Vector.ZAxis());
+            var d = Arc.ByCenterPointRadiusAngle(Point.ByCoordinates(0, 0, 0), 2.0, 20, 90, Vector.ZAxis());
+
+            var revitArc1 = a.ToRevitType();
+            var revitArc2 = b.ToRevitType();
+            var revitArc3 = c.ToRevitType();
+            var revitArc4 = d.ToRevitType();
+
+            Assert.True(CurveUtils.CurvesAreSimilar(revitArc1, revitArc1));
+            Assert.False(CurveUtils.CurvesAreSimilar(revitArc1, revitArc2));
+            Assert.False(CurveUtils.CurvesAreSimilar(revitArc1, revitArc3));
+            Assert.False(CurveUtils.CurvesAreSimilar(revitArc1, revitArc4));
+        }
+
+        [Test]
+        [TestModel(@".\empty.rfa")]
+        public void CurvesAreSimilar_NurbsCurve()
+        {
+            var a1 = Point.ByCoordinates(0, 0);
+            var a2 = Point.ByCoordinates(1, 1);
+            var a3 = Point.ByCoordinates(2, -1);
+            var a4 = Point.ByCoordinates(3, 0);
+
+            var b1 = Point.ByCoordinates(0, 0);
+            var b2 = Point.ByCoordinates(1, -1);
+            var b3 = Point.ByCoordinates(2, 1);
+            var b4 = Point.ByCoordinates(3, 0);
+
+            var c1 = Point.ByCoordinates(3, 0);
+            var c2 = Point.ByCoordinates(2, 1);
+            var c3 = Point.ByCoordinates(1, -1);
+            var c4 = Point.ByCoordinates(0, 0);
+
+            var nurbs1 = NurbsCurve.ByPoints(new[] { a1, a2, a3, a4});
+            var nurbs2 = NurbsCurve.ByPoints(new[] { b1, b2, b3, b4 });
+            var nurbs3 = NurbsCurve.ByPoints(new[] { c1, c2, c3, c4 });
+
+            var revitNurbs1 = nurbs1.ToRevitType();
+            var revitNurbs2 = nurbs2.ToRevitType();
+            var revitNurbs3 = nurbs3.ToRevitType();
+
+            Assert.True(CurveUtils.CurvesAreSimilar(revitNurbs1, revitNurbs1));
+            Assert.False(CurveUtils.CurvesAreSimilar(revitNurbs1, revitNurbs2));
+            Assert.False(CurveUtils.CurvesAreSimilar(revitNurbs2, revitNurbs3));
+        }
+
+        [Test]
+        [TestModel(@".\empty.rfa")]
+        public void CurvesAreSimilar_Ellipse()
+        {
+            var a = Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii(Point.ByCoordinates(0, 0, 0), 1.0, 2.0);
+            var b = Autodesk.DesignScript.Geometry.Ellipse.ByOriginRadii(Point.ByCoordinates(0, 0, 0), 2.0, 1.0);
+
+            var revitEllipse1 = a.ToRevitType();
+            var revitEllipse2 = b.ToRevitType();
+
+            Assert.True(CurveUtils.CurvesAreSimilar(revitEllipse1, revitEllipse1));
+            Assert.False(CurveUtils.CurvesAreSimilar(revitEllipse1, revitEllipse2));
+        }
+
     }
 }


### PR DESCRIPTION
This PR fixes an issue described in [MAGN-6360](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-6360), where certain `Revit.Element` types would cause infinite looping when they set property values on Revit elements and subsequently responded to the document modification events which those editions caused.

Here we do two things to "cut the loop":
- We introduce the `CurveUtilities.AreCurvesSimilar` method which compares two curves for similarity. For `Revit.Element` types where we set a curve on an internal Revit element, this allows us to check the curves for similarity before setting to avoid causing a document modification.
- We add checks at a number of locations in the code for curve similarity or object value to avoid setting a property on a revit element if it's not absolutely necessary.

PTAL:
- [x] @Randy-Ma (because you investigated for me)

Requires Merge:
- [ ] Revit2015
- [ ] Revit2016
- [ ] RC0.8.0_Revit2014
- [ ] RC0.8.0_Revit2015
- [ ] RC0.8.0_Revit2016