### PR TITLE
Move one test case out of the Failure category

### DIFF
--- a/test/Libraries/RevitNodesTests/GeometryConversion/RevitToProtoSolidTests.cs
+++ b/test/Libraries/RevitNodesTests/GeometryConversion/RevitToProtoSolidTests.cs
@@ -38,7 +38,7 @@ namespace RevitNodesTests.GeometryConversion
             }
         }
 
-        [Test, Category("Failure")]
+        [Test]
         [TestModel(@".\Solids.rfa")]
         public void ToProtoType_Boolean_ShouldConvertAllFormsInDocument()
         {


### PR DESCRIPTION
<h4>Summary</h4>
As the test case which is temporarily marked as failure has been fixed, I am moving this test case out of the Failure category.

@junmendoza 
PTAL