### PR TITLE
Fix MAGN-6737 File Exit crashes Revit

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -342,8 +342,6 @@ namespace Dynamo.Applications
         {
             var view = (DynamoView)sender;
 
-            RevitServicesUpdater.DisposeInstance();
-
             view.Dispatcher.UnhandledException -= Dispatcher_UnhandledException;
             view.Closed -= OnDynamoViewClosed;
 

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -421,6 +421,8 @@ namespace Dynamo.Applications.Models
             UnsubscribeDocumentManagerEvents();
             UnsubscribeRevitServicesUpdaterEvents();
             UnsubscribeTransactionManagerEvents();
+
+            RevitServicesUpdater.DisposeInstance();
         }
 
         /// <summary>


### PR DESCRIPTION
<h4>Summary</h4>

The singleton instance of RevitServicesUpdater is disposed but later it is still used by the model. I am moving the disposing method call from where the view is closed to where the model is shutdown.

@Benglin 
PTAL