### PR TITLE
Fix MAGN-6737 File Exit crashes Revit

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -362,8 +362,6 @@ namespace Dynamo.Applications
         {
             var view = (DynamoView)sender;
 
-            RevitServicesUpdater.DisposeInstance();
-
             view.Dispatcher.UnhandledException -= Dispatcher_UnhandledException;
             view.Closed -= OnDynamoViewClosed;
 


### PR DESCRIPTION
<h4>Summary</h4>

The singleton instance of RevitServicesUpdater is disposed but later it is still used by the model. As the instance is only instantiated once when the plugin is initialized and so I am removing the call to dispose the instance when the view is closed.

@Benglin 
PTAL