### PR TITLE
MAGN-5850 Element Binding / Dynamo not properly deleting Revit Elements created in previous Dynamo session by same file

### DIFF
--- a/src/DynamoRevit/DynamoRevit.csproj
+++ b/src/DynamoRevit/DynamoRevit.csproj
@@ -100,6 +100,7 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.Serialization.Formatters.Soap" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Soap;
 using System.Windows.Forms;
 
 using Autodesk.Revit.DB;
@@ -20,6 +23,8 @@ using Dynamo.Utilities;
 using DynamoServices;
 
 using Greg;
+
+using ProtoCore;
 
 using Revit.Elements;
 
@@ -163,6 +168,60 @@ namespace Dynamo.Applications.Models
             MigrationManager.MigrationTargets.Add(typeof(WorkspaceMigrationsRevit));
 
             SetupPython();
+
+            WorkspaceEvents.WorkspaceAdded += WorkspaceEvents_WorkspaceAdded;
+        }
+
+        /// <summary>
+        /// A map of historical element ids associated with a workspace.
+        /// </summary>
+        private Dictionary<Guid, Dictionary<Guid, List<int>>> historicalElementData = new Dictionary<Guid, Dictionary<Guid, List<int>>>();
+
+        private bool isFirstEvaluation = true;
+
+        void WorkspaceEvents_WorkspaceAdded(WorkspacesModificationEventArgs args)
+        {
+            // The workspace's PreloadedTraceData should be available here
+            // before the workspace has been run. We use this trace data to
+            // get a dictionary, keyed by node guid, of element ids which
+            // have been saved to the file. This dictionary will be used only
+            // once, after the first run of the graph to reconcile elements that 
+            // are newly created with what had been created previously, removing
+            // any elements from the model that were pre-existing and associated
+            // with Dynamo, but no longer created by Dynamo.
+            
+            var hws = Workspaces.FirstOrDefault(ws => ws is HomeWorkspaceModel) as HomeWorkspaceModel;
+            if (hws == null) return;
+
+            var serializedTraceData = hws.PreloadedTraceData;
+            if (serializedTraceData == null) return;
+
+            historicalElementData.Add(args.Id, new Dictionary<Guid, List<int>>());
+
+            foreach (var kvp in serializedTraceData)
+            {
+                var idList = new List<int>();
+
+                historicalElementData[args.Id].Add(kvp.Key, idList);
+
+                foreach (var callSiteData in kvp.Value)
+                {
+                    var serializables = DeserializeCallsiteData(callSiteData);
+                    idList.AddRange(serializables.Select(ser => ((SerializableId)ser).IntID));
+                }
+            }
+        }
+
+        private static IEnumerable<ISerializable> DeserializeCallsiteData(string callSiteData)
+        {
+            Validity.Assert(!String.IsNullOrEmpty(callSiteData));
+            var data = Convert.FromBase64String(callSiteData);
+            var formatter = new SoapFormatter();
+            var s = new MemoryStream(data);
+            var helper = (CallSite.TraceSerialiserHelper)formatter.Deserialize(s);
+
+            var serializables = helper.TraceData.SelectMany(std => std.RecursiveGetNestedData());
+            return serializables;
         }
 
         #endregion
@@ -360,10 +419,99 @@ namespace Dynamo.Applications.Models
 
         public override void OnEvaluationCompleted(object sender, EvaluationCompletedEventArgs e)
         {
+            Debug.WriteLine(ElementIDLifecycleManager<int>.GetInstance());
+
+            if (historicalElementData.ContainsKey(CurrentWorkspace.Guid))
+            {
+                ReconcileHistoricalElements();
+            }
+
             // finally close the transaction!
             TransactionManager.Instance.ForceCloseTransaction();
 
             base.OnEvaluationCompleted(sender, e);
+        }
+
+        private void ReconcileHistoricalElements()
+        {
+            // Read the current run's trace data into a dictionary which matches
+            // the layout of our historical element data. 
+
+            var traceData = EngineController.LiveRunnerCore.RuntimeData.GetTraceDataForNodes(
+                CurrentWorkspace.Nodes.Select(n => n.GUID),
+                EngineController.LiveRunnerCore.DSExecutable);
+
+            var currentRunData = new Dictionary<Guid, List<int>>();
+            foreach (var kvp in traceData)
+            {
+                var idList = new List<int>();
+                currentRunData.Add(kvp.Key, idList);
+
+                foreach (var serializables in kvp.Value.Select(DeserializeCallsiteData)) {
+                    idList.AddRange(serializables.Select(ser => ((SerializableId)ser).IntID));
+                }
+            }
+
+            // Compare the historical element data and the current run
+            // data to see whether there are elements that had been
+            // created by nodes previously, which were not created in 
+            // this run. Store the elements ids of all the elements that
+            // can't be found in the orphans collection.
+
+            var workspaceHistory = historicalElementData[CurrentWorkspace.Guid];
+            var orphanedIds = new List<int>();
+
+            foreach (var kvp in workspaceHistory)
+            {
+                var nodeGuid = kvp.Key;
+
+                // If the current run doesn't have a key for 
+                // this guid, then all of these elements are 
+                // orphaned.
+
+                if (!currentRunData.ContainsKey(nodeGuid))
+                {
+                    orphanedIds.AddRange(kvp.Value);
+                    continue;
+                }
+
+                var currentRunNodeGuids = currentRunData[nodeGuid];
+
+                // If the current run didn't create an element
+                // in the current run, then add an orphan.
+
+                orphanedIds.AddRange(kvp.Value.Where(id => !currentRunNodeGuids.Contains(id)));
+            }
+
+            // Delete all the orphans.
+            IdlePromise.ExecuteOnIdleAsync(
+                () =>
+                {
+                    var toDelete = new List<ElementId>();
+                    foreach (var id in orphanedIds)
+                    {
+                        // Check whether the element is valid before attempting to delete.
+                        Element el;
+                        if (DocumentManager.Instance.CurrentDBDocument.TryGetElement(new ElementId(id), out el))
+                        {
+                            toDelete.Add(el.Id);
+                        }
+                    }
+
+                    using (var trans = new Transaction(DocumentManager.Instance.CurrentDBDocument))
+                    {
+                        trans.Start("Dynamo element reconciliation.");
+                        DocumentManager.Instance.CurrentDBDocument.Delete(toDelete);
+                        trans.Commit();
+                    }
+                });
+
+            Debug.WriteLine("ELEMENT RECONCILIATION: {0} elements were orphaned.", orphanedIds.Count);
+
+            // When reconciliation is complete, wipe the historical data.
+            // At this point, element binding is as up to date as it's going to get.
+
+            historicalElementData.Remove(CurrentWorkspace.Guid);
         }
 
         protected override void PreShutdownCore(bool shutdownHost)
@@ -399,6 +547,7 @@ namespace Dynamo.Applications.Models
             UnsubscribeTransactionManagerEvents();
 
             RevitServicesUpdater.DisposeInstance();
+            ElementIDLifecycleManager<int>.DisposeInstance();
         }
 
         /// <summary>

--- a/src/Libraries/RevitServices/Persistence/ElementIDLifecycleManager.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementIDLifecycleManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 using DynamoServices;
 
@@ -23,6 +24,17 @@ namespace RevitServices.Persistence
         {
             wrappers = new Dictionary<T, List<object>>();
             revitDeleted = new Dictionary<T, bool>();
+        }
+
+        public static void DisposeInstance()
+        {
+            lock (singletonMutex)
+            {
+                if (manager != null)
+                {
+                    manager = null;
+                }
+            }
         }
 
         /// <summary>
@@ -180,6 +192,20 @@ namespace RevitServices.Persistence
 
         }
 
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("ElementIdLifeCycleManager:");
+            foreach (var kvp in wrappers)
+            {
+                sb.AppendLine(string.Format("\tElement ID {0}:", kvp.Key));
+                foreach (var item in kvp.Value)
+                {
+                    sb.AppendLine(string.Format("\t\t{0}:", item));
+                }
+            }
 
+            return sb.ToString();
+        }
     }
 }


### PR DESCRIPTION
This pull request fixes [MAGN-5850](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5850#comment=61-17451), by adding an element reconciliation step after the first evaluation.

## Why
Open a Revit model that, for example, has 5 structural framing members that were created by Dynamo. Then open the corresponding dyn file, and adjust some parameters that affect the layout of the structural framing such that you will get 2 structural framing members, and hit Run. What you get in Revit is 2 elements that are in the right place and 3 that haven't been touched. Those 3 elements should be deleted. But Dynamo doesn't know that it's supposed to delete them, because it doesn't know anything about the historical state of the model.

## How The Fix Works
After a `HomeWorkspaceModel` is added to `DynamoModel`, we check to see whether the workspace has `PreloadedTraceData`. This will be the raw trace data as it is serialized into the .dyn file. If trace data is available, we deserialize the data and build a map for the workspace of previously executed nodes and the elements ids that were associated with them. This is stored in the `historicalElementData` field. This map is built in such a way as to support multiple home workspaces in the future. 

After evaluation is completed, we check whether there is historical element data available for the workspace. If there is we proceed with element reconciliation. During element reconciliation we build another element id map, this time using the trace data from the current run. We compare the current map with the historical map and we identify any elements that were created historically, but were not created during this run. Those "orphan" elements are then deleted. At the conclusion of element reconciliation we delete the current workspace's historical id map so that this reconciliation never takes place again.

This PR requires [this core PR](https://github.com/DynamoDS/Dynamo/pull/4093).

PTAL:
- [x] @Randy-Ma (Because I think you'll get a kick out of this...and because of some small fixes to `ElementIdLifeCycleManager`)


Requires Merge:
- [ ] Revit2015
- [ ] Revit2016

DO NOT APPLY THIS CHANGE TO THE 0.8.0 RC BRANCHES!!