### PR TITLE
Fix MAGN-6762 Revit crashes after reopen of project after family creation

### DIFF
--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -44,6 +44,12 @@ namespace DSRevitNodesUI
                 SelectedIndex = 0;
             }
         }
+
+        public override void Dispose()
+        {
+            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -= Controller_RevitDocumentChanged;
+            base.Dispose();
+        }
     }
 
     [NodeName("Family Types")]

--- a/src/Libraries/RevitNodesUI/SiteLocation.cs
+++ b/src/Libraries/RevitNodesUI/SiteLocation.cs
@@ -61,9 +61,9 @@ namespace DSRevitNodesUI
 
         public override void Dispose()
         {
+            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -= model_RevitDocumentChanged;
+            RevitServicesUpdater.Instance.ElementsModified -= RevitServicesUpdater_ElementsModified;
             base.Dispose();
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened += model_RevitDocumentChanged;
-            RevitServicesUpdater.Instance.ElementsModified += RevitServicesUpdater_ElementsModified;
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)


### PR DESCRIPTION
<h4>Summary</h4>

Because now we have moved the event handlers related to opening/closing documents to the model, when the model is shutdown, the event handlers will be unregistered. As a result, before a new model is created and the event handlers are registered, the events will not be handled. Even a document opening event will not be handled and the document hold by the document manager instance is invalid.

This submission makes the change to unregister the events for some nodes so there will be no chance to access the document to avoid a crash.

This will also help avoid memory leaks.

@Benglin 
PTAL