### PR TITLE
Updated Revit related components to preload libraries

### DIFF
--- a/src/DynamoRevit/RevitPathResolver.cs
+++ b/src/DynamoRevit/RevitPathResolver.cs
@@ -31,7 +31,23 @@ namespace Dynamo.Applications
                 throw new FileNotFoundException(simpleRaaSDll);
 
             // Add Revit-specific library paths for preloading.
-            preloadLibraryPaths = new List<string> { revitNodesDll, simpleRaaSDll };
+            preloadLibraryPaths = new List<string>
+            {
+                "VMDataBridge.dll",
+                "ProtoGeometry.dll",
+                "DSCoreNodes.dll",
+                "DSOffice.dll",
+                "DSIronPython.dll",
+                "FunctionObject.ds",
+                "Optimize.ds",
+                "DynamoConversions.dll",
+                "DynamoUnits.dll",
+                "Tessellation.dll",
+                "Analysis.dll",
+
+                revitNodesDll,
+                simpleRaaSDll
+            };
 
             // Add an additional node processing folder
             additionalNodeDirectories = new List<string> { nodesDirectory };

--- a/test/Libraries/RevitIntegrationTests/RegressionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RegressionTests.cs
@@ -45,6 +45,7 @@ namespace RevitSystemTests
 
                 //Ensure SystemTestBase picks up the right directory.
                 pathResolver = new RevitTestPathResolver();
+                (pathResolver as RevitTestPathResolver).InitializePreloadedLibraries();
 
                 //Setup should be called after swapping document, so that RevitDynamoModel 
                 //is now associated with swapped model.

--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -86,6 +86,9 @@
       <HintPath>$(DYNAMOTESTAPI)\SystemTestServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="TestServices">
+      <HintPath>..\..\..\..\Dynamo\bin\AnyCPU\Debug\TestServices.dll</HintPath>
+    </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -211,6 +211,7 @@ namespace RevitTestServices
                 // of the base class, here a local instance of pathResolver is used.
                 // 
                 var revitTestPathResolver = new RevitTestPathResolver();
+                revitTestPathResolver.InitializePreloadedLibraries();
 
                 DynamoRevit.RevitDynamoModel = RevitDynamoModel.Start(
                     new RevitDynamoModel.RevitStartConfiguration()

--- a/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
+++ b/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
@@ -1,18 +1,26 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using Dynamo.Interfaces;
+using TestServices;
 
 namespace RevitTestServices
 {
-    public class RevitTestPathResolver : IPathResolver
+    public class RevitTestPathResolver : TestPathResolver
     {
-        private readonly HashSet<string> additionalResolutionPaths;
-        private readonly HashSet<string> additionalNodeDirectories;
-        private readonly HashSet<string> preloadedLibraryPaths;
-
-        public RevitTestPathResolver()
+        public void InitializePreloadedLibraries()
         {
+            AddPreloadLibraryPath("VMDataBridge.dll");
+            AddPreloadLibraryPath("ProtoGeometry.dll");
+            AddPreloadLibraryPath("DSCoreNodes.dll");
+            AddPreloadLibraryPath("DSOffice.dll");
+            AddPreloadLibraryPath("DSIronPython.dll");
+            AddPreloadLibraryPath("FunctionObject.ds");
+            AddPreloadLibraryPath("Optimize.ds");
+            AddPreloadLibraryPath("DynamoConversions.dll");
+            AddPreloadLibraryPath("DynamoUnits.dll");
+            AddPreloadLibraryPath("Tessellation.dll");
+            AddPreloadLibraryPath("Analysis.dll");
+
             var assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var nodesDirectory = Path.Combine(assemblyDirectory, "nodes");
             var revitNodesDll = Path.Combine(assemblyDirectory, "RevitNodes.dll");
@@ -25,52 +33,8 @@ namespace RevitTestServices
             if (!File.Exists(simpleRaaSDll))
                 throw new FileNotFoundException(simpleRaaSDll);
 
-            additionalResolutionPaths = new HashSet<string> { assemblyDirectory };
-            additionalNodeDirectories = new HashSet<string> { nodesDirectory };
-            preloadedLibraryPaths = new HashSet<string> { revitNodesDll, simpleRaaSDll };
-        }
-
-        public IEnumerable<string> AdditionalResolutionPaths
-        {
-            get { return additionalResolutionPaths; }
-        }
-
-        public IEnumerable<string> AdditionalNodeDirectories
-        {
-            get { return additionalNodeDirectories; }
-        }
-
-        public IEnumerable<string> PreloadedLibraryPaths
-        {
-            get { return preloadedLibraryPaths; }
-        }
-
-        public void AddNodeDirectory(string nodeDirectory)
-        {
-            if (!additionalNodeDirectories.Contains(nodeDirectory))
-                additionalNodeDirectories.Add(nodeDirectory);
-        }
-
-        public void AddResolutionPath(string resolutionPath)
-        {
-            if (!additionalResolutionPaths.Contains(resolutionPath))
-                additionalResolutionPaths.Add(resolutionPath);
-        }
-
-        public void AddPreloadLibraryPath(string preloadLibraryPath)
-        {
-            if (!preloadedLibraryPaths.Contains(preloadLibraryPath))
-                preloadedLibraryPaths.Add(preloadLibraryPath);
-        }
-
-        public string UserDataRootFolder
-        {
-            get { return string.Empty; }
-        }
-
-        public string CommonDataRootFolder
-        {
-            get { return string.Empty; }
+            AddPreloadLibraryPath(revitNodesDll);
+            AddPreloadLibraryPath(simpleRaaSDll);
         }
     }
 }


### PR DESCRIPTION
This is done for the built-in libraries are now removed from `DynamoModel.Preloader` (see [another pull request](https://github.com/DynamoDS/Dynamo/pull/4050) for details). Now Revit components (include unit test cases) assume the responsibility of specifying which built-in libraries to preload for the session.

Hi @ikeough, please have a look, nothing too surprising I hope (if you need any background, @pboyer can fill you in). Thanks in advance! :)