### PR TITLE
Build Fix for PR #4157

### DIFF
--- a/test/Libraries/RevitIntegrationTests/CoreTests.cs
+++ b/test/Libraries/RevitIntegrationTests/CoreTests.cs
@@ -58,7 +58,8 @@ namespace RevitSystemTests
             Assert.IsNotNull(xyzNode);
             
             //test the shortest lacing
-            xyzNode.ArgumentLacing = LacingStrategy.Shortest;
+            //xyzNode.ArgumentLacing = LacingStrategy.Shortest;
+            xyzNode.UpdateValue(new UpdateValueParams("ArgumentLacing", "Shortest"));
 
             RunCurrentModel();
 
@@ -67,7 +68,8 @@ namespace RevitSystemTests
             Assert.AreEqual(4, fec.ToElements().Count());
 
             //test the longest lacing
-            xyzNode.ArgumentLacing = LacingStrategy.Longest;
+            //xyzNode.ArgumentLacing = LacingStrategy.Longest;
+            xyzNode.UpdateValue(new UpdateValueParams("ArgumentLacing", "Longest"));
             RunCurrentModel();
 
             fec = null;
@@ -78,7 +80,8 @@ namespace RevitSystemTests
             Assert.AreEqual(5, fec.ToElements().Count());
 
             //test the cross product lacing
-            xyzNode.ArgumentLacing = LacingStrategy.CrossProduct;
+            //xyzNode.ArgumentLacing = LacingStrategy.CrossProduct;
+            xyzNode.UpdateValue(new UpdateValueParams("ArgumentLacing", "CrossProduct"));
 
             RunCurrentModel();
 


### PR DESCRIPTION
- ArgumentLacing property has been made readonly, so it can't be set externally. 
- Use UpdateValue method to change ArgumentLacing property.