### PR TITLE
Fix MAGN-6710 Run CurveByPoints.byReferencePoints will crash Revit and Dynamo

### DIFF
--- a/src/Libraries/RevitNodes/Elements/CurveByPoints.cs
+++ b/src/Libraries/RevitNodes/Elements/CurveByPoints.cs
@@ -8,6 +8,8 @@ using DynamoServices;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
 
+using Revit.GeometryConversion;
+
 namespace Revit.Elements
 {
     /// <summary>
@@ -20,16 +22,25 @@ namespace Revit.Elements
 
         private void InternalSetReferencePoints(ReferencePointArray pts)
         {
-            TransactionManager.Instance.EnsureInTransaction(Document);
-            ((Autodesk.Revit.DB.CurveByPoints) InternalCurveElement).SetPoints(pts);
-            TransactionManager.Instance.TransactionTaskDone();
+            var cbp = ((Autodesk.Revit.DB.CurveByPoints)InternalCurveElement) as Autodesk.Revit.DB.CurveByPoints;
+            var crvPnts = cbp.GetPoints();
+            if (!CurveUtils.PointArraysAreSame(crvPnts, pts))
+            {
+                TransactionManager.Instance.EnsureInTransaction(Document);
+                ((Autodesk.Revit.DB.CurveByPoints)InternalCurveElement).SetPoints(pts);
+                TransactionManager.Instance.TransactionTaskDone();
+            }
         }
 
         private void InternalSetIsReferenceLine(bool isReferenceLine)
         {
-            TransactionManager.Instance.EnsureInTransaction(Document);
-            ((Autodesk.Revit.DB.CurveByPoints) InternalCurveElement).IsReferenceLine = isReferenceLine;
-            TransactionManager.Instance.TransactionTaskDone();
+            var cbp = ((Autodesk.Revit.DB.CurveByPoints)InternalCurveElement) as Autodesk.Revit.DB.CurveByPoints;
+            if (cbp.IsReferenceLine != isReferenceLine)
+            {
+                TransactionManager.Instance.EnsureInTransaction(Document);
+                cbp.IsReferenceLine = isReferenceLine;
+                TransactionManager.Instance.TransactionTaskDone();
+            }
         }
 
         #endregion
@@ -79,7 +90,7 @@ namespace Revit.Elements
             {
                 InternalSetCurveElement(cbp);
                 InternalSetReferencePoints(refPtArr);
-                cbp.IsReferenceLine = isReferenceLine;
+                InternalSetIsReferenceLine(isReferenceLine);
                 return;
             }
 

--- a/src/Libraries/RevitNodes/GeometryConversion/CurveUtils.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/CurveUtils.cs
@@ -14,6 +14,32 @@ namespace Revit.GeometryConversion
     {
         public static readonly double Tolerance = 1e-6;
 
+        public static bool ReferencePointsAreSame(ReferencePoint pnt1, ReferencePoint pnt2)
+        {
+            if (pnt1.Position.IsAlmostEqualTo(pnt2.Position, Tolerance))
+                return true;
+
+            return false;
+        }
+
+        public static bool PointArraysAreSame(ReferencePointArray pnts1, ReferencePointArray pnts2)
+        {
+            int size1 = pnts1.Size;
+            int size2 = pnts2.Size;
+            if (size1 != size2)
+                return false;
+
+            for (int i = 0; i < size1; i++)
+            {
+                var pnt1 = pnts1.get_Item(i);
+                var pnt2 = pnts2.get_Item(i);
+                if (!ReferencePointsAreSame(pnt1, pnt2))
+                    return false;
+            }
+
+            return true;
+        }
+
         public static Plane GetPlaneFromCurve(Curve c, bool planarOnly)
         {
             //find the plane of the curve and generate a sketch plane

--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -622,6 +622,24 @@ namespace RevitSystemTests
            Assert.IsInstanceOf<Autodesk.DesignScript.Geometry.Point>(watchNode.CachedValue);
         }
 
+        [Test]
+        [Category("RegressionTests")]
+        [TestModel(@".\empty.rfa")]
+        public void MAGN_6710()
+        {
+            string filePath = Path.Combine(workingDirectory, @".\Bugs\MAGN_6710.dyn");
+            string testPath = Path.GetFullPath(filePath);
+
+            //open the test file
+            ViewModel.OpenCommand.Execute(testPath);
+            AssertNoDummyNodes();
+
+            RunCurrentModel();
+
+            var curves = GetAllCurveElements();
+            Assert.AreEqual(1, curves.Count);
+        }
+
         protected static IList<Autodesk.Revit.DB.CurveElement> GetAllCurveElements()
         {
             var fec = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);

--- a/test/System/Bugs/MAGN_6710.dyn
+++ b/test/System/Bugs/MAGN_6710.dyn
@@ -1,0 +1,35 @@
+<Workspace Version="0.8.1.962" X="-73.4778624177692" Y="50.5183932825772" zoom="0.818051011248908" Name="Home" RunType="Automatic" RunPeriod="100" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="24c71c0f-11cf-42be-919d-b22ae65c8ffa" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-48" y="119" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="1..10..1;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="befe6265-860a-4569-bd8e-728a72e0c11f" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="137.926133559213" y="30.6841252052829" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="448f8d07-d7d1-4b09-ae8d-fec78a209787" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="151.586102770416" y="240.136986443716" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.DSFunction guid="e2385a8b-18fd-482e-b0f9-ae295dcb1d70" type="Dynamo.Nodes.DSFunction" nickname="Line.ByStartPointEndPoint" x="373.560602452451" y="52.3124097896863" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point" />
+    <Dynamo.Nodes.DSFunction guid="aa8ec979-8909-4e27-b596-fa3310029b23" type="Dynamo.Nodes.DSFunction" nickname="ReferencePoint.ByPoint" x="379.252256290452" y="237.860324908516" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="RevitNodes.dll" function="Revit.Elements.ReferencePoint.ByPoint@Autodesk.DesignScript.Geometry.Point" />
+    <Dynamo.Nodes.DSFunction guid="36204e41-5306-4a69-b2db-1f07c619f7dc" type="Dynamo.Nodes.DSFunction" nickname="CurveByPoints.ByReferencePoints" x="671.803263563698" y="225.338686464914" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="RevitNodes.dll" function="Revit.Elements.CurveByPoints.ByReferencePoints@Revit.Elements.ReferencePoint[],bool">
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="24c71c0f-11cf-42be-919d-b22ae65c8ffa" start_index="0" end="befe6265-860a-4569-bd8e-728a72e0c11f" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="24c71c0f-11cf-42be-919d-b22ae65c8ffa" start_index="0" end="befe6265-860a-4569-bd8e-728a72e0c11f" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="24c71c0f-11cf-42be-919d-b22ae65c8ffa" start_index="0" end="448f8d07-d7d1-4b09-ae8d-fec78a209787" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="24c71c0f-11cf-42be-919d-b22ae65c8ffa" start_index="0" end="448f8d07-d7d1-4b09-ae8d-fec78a209787" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="24c71c0f-11cf-42be-919d-b22ae65c8ffa" start_index="0" end="448f8d07-d7d1-4b09-ae8d-fec78a209787" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="befe6265-860a-4569-bd8e-728a72e0c11f" start_index="0" end="e2385a8b-18fd-482e-b0f9-ae295dcb1d70" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="befe6265-860a-4569-bd8e-728a72e0c11f" start_index="0" end="aa8ec979-8909-4e27-b596-fa3310029b23" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="448f8d07-d7d1-4b09-ae8d-fec78a209787" start_index="0" end="e2385a8b-18fd-482e-b0f9-ae295dcb1d70" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="aa8ec979-8909-4e27-b596-fa3310029b23" start_index="0" end="36204e41-5306-4a69-b2db-1f07c619f7dc" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <SessionTraceData>
+  </SessionTraceData>
+</Workspace>


### PR DESCRIPTION
<h4>Summary</h4>

There is an infinite loop when creating an instance of CurveByPoints. The reason is because when creating the instance, the document is modified. Our document watcher will search the nodes which are causing the modification and re-run the nodes, and then the document is modified again, .... Thus there is an infinite loop.

The fix here is to avoid modifying the curve when it is found the input to set the curve does not change.

I have also added a test case for this.

@ikeough 
PTAL