### PR TITLE
Tweak the initialization logic for RevitServicesUpdater

### DIFF
--- a/src/Libraries/RevitServices/Elements/ModelUpdater.cs
+++ b/src/Libraries/RevitServices/Elements/ModelUpdater.cs
@@ -74,14 +74,10 @@ namespace RevitServices.Elements
         {
             lock (mutex)
             {
-                if (instance == null)
-                {
-                    instance = new RevitServicesUpdater(app, updaters);
-                }
-                else
-                {
-                    throw new InvalidOperationException("RevitServicesUpdater can only be initialized once.");
-                }
+                if (instance != null)
+                    DisposeInstance();
+
+                instance = new RevitServicesUpdater(app, updaters);
             }
         }
 


### PR DESCRIPTION
<h4>Summary</h4>

It is really unnecessary to throw an exception at the time when we initialize the RevitServicesUpdater instance which has already been initialized. So why not dispose the original instance instead of throwing an exception to crash the application.

There is one case I am getting is that when the addin crashes and the old instance is not disposed because the code does not have a chance to be run when an exception is thrown. As a result, the addin can not be started the second time simply because the RevitServicesUpdater can not initialized.

I am fixing the issue I mentioned by tweaking the initialization logic.

@ikeough 
PTAL