### PR TITLE
Fix MAGN-3419 Element.Parameter not returning value for Mark

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Parameter.cs
+++ b/src/Libraries/RevitNodes/Elements/Parameter.cs
@@ -27,7 +27,18 @@ namespace Revit.Elements
 
         public override string ToString()
         {
-            return string.Format("{0} : {1}", Name, InternalParameter.AsValueString(new FormatOptions(){}));
+            string value = string.Empty;
+            switch(InternalParameter.StorageType)
+            {
+                case StorageType.String:
+                    value = InternalParameter.AsString();
+                    break;
+                default:
+                    var ops = new FormatOptions() { };
+                    value = InternalParameter.AsValueString(ops);
+                    break;
+            }
+            return string.Format("{0} : {1}", Name, value);
         }
     }
 }


### PR DESCRIPTION
<h4>Summary</h4>

AsValueString is not working when the parameter's storage type is string. It is found another function AsString will work if the storage type is string. This submission makes the fix by making the corresponding call based on the storage type.

@ikeough 
PTAL