### PR TITLE
MAGN-7268 Dynamo fails to load  within Revit if the system  Environment variable "Path" has string within curly braces e.g.{0}

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -142,10 +142,9 @@ namespace Dynamo.Applications
             // Add the main exec path to the system PATH
             // This is required to pickup certain dlls.
             var path =
-                string.Format(
                     Environment.GetEnvironmentVariable(
                         "Path",
-                        EnvironmentVariableTarget.Process) + ";{0}", corePath);
+                        EnvironmentVariableTarget.Process) + ";" + corePath;
             Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Process);
         }
 


### PR DESCRIPTION
### Purpose
This PR solves an issue raised in https://github.com/DynamoDS/Dynamo/issues/4256#issuecomment-9740693.

### Declarations
- [x] The code base is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
  - Without adjusting the system path for the Revit test process, we cannot test this.

### Reviewers
- [x] @ramramps

### Requires Merge
- [ ] Revit2015
- [ ] Revit2016