### PR TITLE
Fix MAGN-6862 Revit_ImportSolid sample goes in infinite loop when this sample opened after few other samples

### DIFF
--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -225,6 +225,13 @@ namespace Dynamo.Nodes
                 return;
             }
 
+            // If the deleted list doesn't include any objects in the current selection
+            // then return;
+            if (!SelectionResults.Select(x => x.Id).Any(deleted.Contains))
+            {
+                return;
+            }
+
             // We are given a set of ElementIds, but because the elements
             // have already been deleted from Revit, we can't get the 
             // corresponding GUID. Instead, we just go through the collection of


### PR DESCRIPTION
<h4>Summary</h4>

There are some selection nodes in the graph. Once an import instance is created and if the node is run for the second time, the element binding happening for ImportInstance will delete the old instance and create a new one. The deleting operation will trigger some document event handlers. The event handler in the selection nodes will cause the graph run again. Then the ImportInstance node will re-run and delete and create and trigger the document event handler.... Thus there is an infinite loop.

In this submission, I am cutting the infinite loop by checking whether the deleted objects contains any one in the selected objects for the selection node, and if not, the graph will not be run. 

@ikeough 
PTAL
