### PR TITLE
Fix failing test cases

### DIFF
--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -225,9 +225,9 @@ namespace Dynamo.Nodes
                 return;
             }
 
-            // If the deleted list doesn't include any objects in the current selection
-            // then return;
-            if (!SelectionResults.Select(x => x.Id).Any(deleted.Contains))
+            // If the deleting operations does not make any elements in SelectionResults
+            // invalid, then there is no need to update.
+            if (SelectionResults.Select(el => !el.IsValidObject).Count() == 0)
             {
                 return;
             }
@@ -379,7 +379,7 @@ namespace Dynamo.Nodes
             if (!SelectionResults.Any() ||
                 !document.Equals(SelectionOwner) ||
                 !deleted.Any() ||
-                !SelectionResults.Any(x=>deleted.Contains(x.ElementId))) return;
+                !SelectionResults.Any(x => deleted.Contains(x.ElementId))) return;
 
             // The new selections is everything in the current selection
             // that is not in the deleted collection as well


### PR DESCRIPTION
### Purpose

This submission is to fix two regressions caused by changes in the selection nodes. The original logic has issues in that if SelectionResults contain some deleted elements, then trying to get Id from these elements will throw exceptions.

An attempt to fix the issue by filtering SelectionResults to check whether the element is valid. But the filtered result will never have even one element contained by the deleted elements. So in this submission, the issue is fixed by checking whether SelectionResults contains any invalid elements.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@aparajit-pratap 
