### PR TITLE
Fix the failing test case named as Regressions

### DIFF
--- a/test/Libraries/RevitIntegrationTests/RegressionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RegressionTests.cs
@@ -69,9 +69,6 @@ namespace RevitSystemTests
             }
             finally
             {
-                ViewModel.Model.ShutDown(false);
-                ViewModel = null;
-                RevitServicesUpdater.DisposeInstance();
                 TearDown();
             }
 


### PR DESCRIPTION
### Purpose

This is to fix the failing test case named as Regressions. The test case is failing is because the ViewModel is still used after it is assigned null. In this fix, I am removing the redundant lines of code as in the shutdown method, the same code will run.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@aparajit-pratap 

### FYIs

@ikeough 