### PR TITLE
Update Manager configuration with specific lookup

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -2,12 +2,12 @@ using Dynamo.Applications.ViewModel;
 
 using Dynamo.Applications;
 using Greg.AuthProviders;
-using RevitServices.Elements;
 
 #region
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Windows.Interop;
@@ -26,14 +26,15 @@ using Dynamo.Models;
 using Dynamo.Services;
 using Dynamo.ViewModels;
 
-using DynamoUtilities;
-
 using RevitServices.Persistence;
 using RevitServices.Transactions;
 using RevitServices.Threading;
 
 using MessageBox = System.Windows.Forms.MessageBox;
-using Autodesk.Revit.DB.Events;
+using DynUpdateManager = Dynamo.UpdateManager.UpdateManager;
+using System.Collections.Generic;
+using Microsoft.Win32;
+using Dynamo.UpdateManager;
 
 #endregion
 
@@ -194,6 +195,9 @@ namespace Dynamo.Applications
             var parentDirectory = Directory.GetParent(assemblyDirectory);
             var corePath = parentDirectory.FullName;
 
+            var umConfig = UpdateManagerConfiguration.GetSettings(new DynamoRevitLookUp());
+            Debug.Assert(umConfig.DynamoLookUp != null);
+
             return RevitDynamoModel.Start(
                 new RevitDynamoModel.RevitStartConfiguration()
                 {
@@ -202,7 +206,8 @@ namespace Dynamo.Applications
                     Context = GetRevitContext(commandData),
                     SchedulerThread = new RevitSchedulerThread(commandData.Application),
                     AuthProvider = new RevitOxygenProvider(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher)),
-                    ExternalCommandData = commandData
+                    ExternalCommandData = commandData,
+                    UpdateManager = new DynUpdateManager(umConfig),
                 });
         }
 
@@ -402,5 +407,21 @@ namespace Dynamo.Applications
         }
 
         #endregion
+    }
+
+    internal class DynamoRevitLookUp : DynamoLookUp
+    {
+        public override IEnumerable<string> GetDynamoInstallLocations()
+        {
+            const string regKey64 = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\";
+            //Open HKLM for 64bit registry
+            var regKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+            //Open Windows/CurrentVersion/Uninstall registry key
+            regKey = regKey.OpenSubKey(regKey64);
+
+            //Get "InstallLocation" value as string for all the subkey that starts with "Dynamo"
+            return regKey.GetSubKeyNames().Where(s => s.StartsWith("Dynamo")).Select(
+                (s) => regKey.OpenSubKey(s).GetValue("InstallLocation") as string);
+        }
     }
 }


### PR DESCRIPTION
### Purpose
Initializes UpdateManager with default configuration and DynamoRevitLookUp to start DynamoRevitModel.

- DynamoRevitLookUp implements abstract class DynamoLookUp to get Dynamo installations on the system.
- UpdateManagerConfiguration is updated with DynamoRevitLookUp instance.
- It's a follow-up of https://github.com/DynamoDS/Dynamo/pull/4556

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers
- [x] @aparajit-pratap