### PR TITLE
Part 2 of fixing MAGN-7251 [Regression from 0.7.5] Select elements will cause a crash after switching Revit documents

### DIFF
--- a/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
@@ -322,6 +322,15 @@ namespace DSRevitNodesUI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Selection is disabled when Dynamo run is disabled..
+        /// </summary>
+        internal static string SelectionIsDisabledDescription {
+            get {
+                return ResourceManager.GetString("SelectionIsDisabledDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select a model element from the document..
         /// </summary>
         internal static string SelectModelElementDescription {

--- a/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
@@ -267,4 +267,7 @@
   <data name="PortDataCategoriesToolTip" xml:space="preserve">
     <value>The selected Category.</value>
   </data>
+  <data name="SelectionIsDisabledDescription" xml:space="preserve">
+    <value>Selection is disabled when Dynamo run is disabled.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodesUI/Properties/Resources.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.resx
@@ -267,4 +267,7 @@
   <data name="PortDataCategoriesToolTip" xml:space="preserve">
     <value>The selected Category.</value>
   </data>
+  <data name="SelectionIsDisabledDescription" xml:space="preserve">
+    <value>Selection is disabled when Dynamo run is disabled.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodesUI/SelectionNodeViewCustomizations.cs
+++ b/src/Libraries/RevitNodesUI/SelectionNodeViewCustomizations.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Autodesk.Revit.DB;
+using Dynamo.Applications.Models;
 using Dynamo.Controls;
 using Dynamo.Nodes;
 using Dynamo.Wpf;
@@ -23,6 +24,7 @@ namespace Dynamo.Wpf.Nodes.Revit
         public void CustomizeView(ElementSelection<Element> model, NodeView nodeView)
         {
             base.CustomizeView(model, nodeView);
+            model.RevitDynamoModel = nodeView.ViewModel.DynamoViewModel.Model as RevitDynamoModel;
         }
     }
 
@@ -33,6 +35,7 @@ namespace Dynamo.Wpf.Nodes.Revit
         public void CustomizeView(ElementSelection<DividedSurface> model, NodeView nodeView)
         {
             base.CustomizeView(model, nodeView);
+            model.RevitDynamoModel = nodeView.ViewModel.DynamoViewModel.Model as RevitDynamoModel;
         }
     }
 
@@ -43,6 +46,7 @@ namespace Dynamo.Wpf.Nodes.Revit
         public void CustomizeView(ReferenceSelection model, NodeView nodeView)
         {
             base.CustomizeView(model, nodeView);
+            model.RevitDynamoModel = nodeView.ViewModel.DynamoViewModel.Model as RevitDynamoModel;
         }
     }
 

--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -23,6 +23,7 @@ using Revit.GeometryConversion;
 
 using DoubleSlider = DSCoreNodesUI.Input.DoubleSlider;
 using IntegerSlider = DSCoreNodesUI.Input.IntegerSlider;
+using Dynamo.Applications.Models;
 
 namespace RevitSystemTests
 {
@@ -718,6 +719,28 @@ namespace RevitSystemTests
 
             RunCurrentModel();
             //There should be no infinite loop, otherwise, there will be an error with this test case.
+        }
+
+        [Test]
+        [Category("RegressionTests")]
+        [TestModel(@".\empty.rfa")]
+        public void SelectionButtonShouldBeDisabledAfterOpeningNewDocument()
+        {
+            string filePath = Path.Combine(workingDirectory, @".\Bugs\MAGN_7251.dyn");
+            string testPath = Path.GetFullPath(filePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+            AssertNoDummyNodes();
+            RunCurrentModel();
+
+            var node = AllNodes.OfType<DSModelElementSelection>().ElementAt(0);
+            node.RevitDynamoModel = Model as RevitDynamoModel;
+            Assert.IsTrue(node.CanSelect);
+
+            string newRfaFilePath = Path.Combine(workingDirectory, "modelLines.rfa");
+            DocumentManager.Instance.CurrentUIApplication.OpenAndActivateDocument(newRfaFilePath);
+            node = AllNodes.OfType<DSModelElementSelection>().ElementAt(0);
+            Assert.IsFalse(node.CanSelect);
         }
 
         protected static IList<Autodesk.Revit.DB.CurveElement> GetAllCurveElements()

--- a/test/System/Bugs/MAGN_7251.dyn
+++ b/test/System/Bugs/MAGN_7251.dyn
@@ -1,0 +1,9 @@
+<Workspace Version="0.8.2.1473" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSModelElementSelection guid="aff57bd5-4576-4258-a159-a632f216932c" type="Dynamo.Nodes.DSModelElementSelection" nickname="Select Model Element" x="474.5" y="217.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
### Purpose

This is the second part to fix MAGN-7251. The fix here is to add a property called RevitDynamoModel in RevitSelection. The property is set when the related view customization is constructed. As this property will only be set when the view is created, there may be possibility that the property is null. So for places where this property is used, a null check will be conducted.

Refer the first part of the fix:
https://github.com/DynamoDS/Dynamo/pull/4594

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] The level of testing this PR includes is appropriate

### Reviewers

@Benglin 

### FYIs