### PR TITLE
Part 2 of fixing MAGN-7251 [Regression from 0.7.5] Select elements will cause a crash after switching Revit documents #418

### DIFF
--- a/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
@@ -322,6 +322,15 @@ namespace DSRevitNodesUI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Selection is disabled when Dynamo run is disabled..
+        /// </summary>
+        internal static string SelectionIsDisabledDescription {
+            get {
+                return ResourceManager.GetString("SelectionIsDisabledDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select a model element from the document..
         /// </summary>
         internal static string SelectModelElementDescription {

--- a/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
@@ -267,4 +267,7 @@
   <data name="PortDataCategoriesToolTip" xml:space="preserve">
     <value>The selected Category.</value>
   </data>
+  <data name="SelectionIsDisabledDescription" xml:space="preserve">
+    <value>Selection is disabled when Dynamo run is disabled.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodesUI/Properties/Resources.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.resx
@@ -267,4 +267,7 @@
   <data name="PortDataCategoriesToolTip" xml:space="preserve">
     <value>The selected Category.</value>
   </data>
+  <data name="SelectionIsDisabledDescription" xml:space="preserve">
+    <value>Selection is disabled when Dynamo run is disabled.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -35,14 +35,48 @@ namespace Dynamo.Nodes
     public abstract class RevitSelection<TSelection, TResult> : SelectionBase<TSelection, TResult>
     {
         protected Document SelectionOwner { get; private set; }
-        protected RevitDynamoModel RevitDynamoModel { get; private set; }
+        private RevitDynamoModel revitDynamoModel; 
 
         #region public properties
 
-        /* TODO: Now that nodes know nothing about their owners, we can't access RunEnabled.
+        public RevitDynamoModel RevitDynamoModel
+        {
+            get
+            {
+                return revitDynamoModel;
+            }
+            set
+            {
+                if (revitDynamoModel != null)
+                {
+                    var hwm = revitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
+                    hwm.RunSettings.PropertyChanged -= revMod_PropertyChanged;
+                }
+
+                revitDynamoModel = value;
+
+                if (revitDynamoModel != null)
+                {
+                    var hwm = revitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
+                    hwm.RunSettings.PropertyChanged += revMod_PropertyChanged;
+                }
+            }
+        }
+
         public override bool CanSelect
         {
-            get { return base.CanSelect && RevitDynamoModel.RunEnabled; }
+            get
+            {
+                if (revitDynamoModel != null)
+                {
+                    var hwm = RevitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
+                    return base.CanSelect && hwm.RunSettings.RunEnabled;
+                }
+                else
+                {
+                    return base.CanSelect;
+                }
+            }
             set { base.CanSelect = value; }
         }
 
@@ -50,9 +84,17 @@ namespace Dynamo.Nodes
         {
             get
             {
-                return RevitDynamoModel.RunEnabled
-                    ? base.SelectionSuggestion
-                    : "Selection is disabled when Dynamo run is disabled.";
+               if (revitDynamoModel != null)
+                {
+                    var hwm = RevitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
+                    return hwm.RunSettings.RunEnabled
+                        ? base.SelectionSuggestion
+                        : DSRevitNodesUI.Properties.Resources.SelectionIsDisabledDescription;
+                }
+                else
+                {
+                    return base.SelectionSuggestion;
+                }  
             }
         }
 
@@ -73,7 +115,7 @@ namespace Dynamo.Nodes
                 RaisePropertyChanged("SelectionSuggestion");
             }
         }
-        */
+     
 
         #endregion
 
@@ -86,7 +128,7 @@ namespace Dynamo.Nodes
             RevitServicesUpdater.Instance.ElementsDeleted += Updater_ElementsDeleted;
             RevitServicesUpdater.Instance.ElementsModified += Updater_ElementsModified;
             DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened += Controller_RevitDocumentChanged;
-            //revMod.PropertyChanged += revMod_PropertyChanged;
+           
         }
 
         #endregion
@@ -108,7 +150,12 @@ namespace Dynamo.Nodes
             RevitServicesUpdater.Instance.ElementsDeleted -= Updater_ElementsDeleted;
             RevitServicesUpdater.Instance.ElementsModified -= Updater_ElementsModified;
             DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -= Controller_RevitDocumentChanged;
-        }
+         if (revitDynamoModel != null)
+            {
+                var hwm = RevitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
+                hwm.RunSettings.PropertyChanged -= revMod_PropertyChanged;
+            }
+         }
 
         public override void UpdateSelection(IEnumerable<TSelection> rawSelection)
         {

--- a/src/Libraries/RevitNodesUI/SelectionNodeViewCustomizations.cs
+++ b/src/Libraries/RevitNodesUI/SelectionNodeViewCustomizations.cs
@@ -7,6 +7,7 @@ using Dynamo.Controls;
 using Dynamo.Nodes;
 using Dynamo.Wpf;
 using Dynamo.Wpf.Nodes;
+using Dynamo.Applications.Models;
 
 namespace Dynamo.Wpf.Nodes.Revit
 {
@@ -23,6 +24,7 @@ namespace Dynamo.Wpf.Nodes.Revit
         public void CustomizeView(ElementSelection<Element> model, NodeView nodeView)
         {
             base.CustomizeView(model, nodeView);
+            model.RevitDynamoModel = nodeView.ViewModel.DynamoViewModel.Model as RevitDynamoModel;
         }
     }
 
@@ -33,6 +35,7 @@ namespace Dynamo.Wpf.Nodes.Revit
         public void CustomizeView(ElementSelection<DividedSurface> model, NodeView nodeView)
         {
             base.CustomizeView(model, nodeView);
+            model.RevitDynamoModel = nodeView.ViewModel.DynamoViewModel.Model as RevitDynamoModel;
         }
     }
 
@@ -43,6 +46,7 @@ namespace Dynamo.Wpf.Nodes.Revit
         public void CustomizeView(ReferenceSelection model, NodeView nodeView)
         {
             base.CustomizeView(model, nodeView);
+            model.RevitDynamoModel = nodeView.ViewModel.DynamoViewModel.Model as RevitDynamoModel;
         }
     }
 

--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -23,6 +23,7 @@ using Revit.GeometryConversion;
 
 using DoubleSlider = DSCoreNodesUI.Input.DoubleSlider;
 using IntegerSlider = DSCoreNodesUI.Input.IntegerSlider;
+using Dynamo.Applications.Models;
 
 namespace RevitSystemTests
 {
@@ -719,6 +720,28 @@ namespace RevitSystemTests
             RunCurrentModel();
             //There should be no infinite loop, otherwise, there will be an error with this test case.
         }
+
+        [Test]
+        [Category("RegressionTests")]
+        [TestModel(@".\empty.rfa")]
+        public void SelectionButtonShouldBeDisabledAfterOpeningNewDocument()
+        {
+             string filePath = Path.Combine(workingDirectory, @".\Bugs\MAGN_7251.dyn");
+             string testPath = Path.GetFullPath(filePath);
+
+             ViewModel.OpenCommand.Execute(testPath);
+             AssertNoDummyNodes();
+             RunCurrentModel();
+
+             var node = AllNodes.OfType<DSModelElementSelection>().ElementAt(0);
+             node.RevitDynamoModel = Model as RevitDynamoModel;
+             Assert.IsTrue(node.CanSelect);
+
+             string newRfaFilePath = Path.Combine(workingDirectory, "modelLines.rfa");
+             DocumentManager.Instance.CurrentUIApplication.OpenAndActivateDocument(newRfaFilePath);
+             node = AllNodes.OfType<DSModelElementSelection>().ElementAt(0);
+             Assert.IsFalse(node.CanSelect);
+         }
 
         protected static IList<Autodesk.Revit.DB.CurveElement> GetAllCurveElements()
         {

--- a/test/System/Bugs/MAGN_7251.dyn
+++ b/test/System/Bugs/MAGN_7251.dyn
@@ -1,0 +1,9 @@
+<Workspace Version="0.8.2.1473" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSModelElementSelection guid="aff57bd5-4576-4258-a159-a632f216932c" type="Dynamo.Nodes.DSModelElementSelection" nickname="Select Model Element" x="474.5" y="217.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+</Workspace>


### PR DESCRIPTION
Purpose

create pull requests to merge the changes in the following pull request
to other branches and related 0.8.1 branches
https://github.com/DynamoDS/DynamoRevit/pull/418


Declarations

The new test [SelectionButtonShouldBedisabledAfterOpeningNewDocument]passes

Reviewers

@Randy-Ma 

Thank you