### PR TITLE
update GetIdentifierFromModelObject method in Selection.cs

### DIFF
--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -258,7 +258,21 @@ namespace Dynamo.Nodes
 
         protected override string GetIdentifierFromModelObject(TSelection modelObject)
         {
-            return modelObject == null ? null : modelObject.UniqueId;
+            try
+            {
+                return modelObject == null ? null : modelObject.UniqueId;
+            }
+            catch (Autodesk.Revit.Exceptions.InvalidObjectException)
+            {
+                // This call is being made from SelectionBase.SerializeCore in 
+                // scenarios like dragging of a node (undo recorder needs the 
+                // node to be serialized prior to dragging). If the current 
+                // document is not the same as that of the selected modelObject,
+                // an exception will be thrown. Dynamo shouldn't be crashed in 
+                // cases like this, so handle this exception gracefully.
+                // 
+                return null;
+            }
         }
 
         protected override void Updater_ElementsDeleted(


### PR DESCRIPTION
### Purpose

Updated `GetIdentifierFromModelObject` method to be more robust in handling *missing element* scenario (e.g. when the host document is closed). This is meant to address [an internally tracked defect](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7658).

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

Mr . @Benglin 

### FYIs

@ikeough