### PR TITLE
mark selectionButtonShouldBeDisableAfterOpeningDoc as failure

### DIFF
--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -721,7 +721,7 @@ namespace RevitSystemTests
             //There should be no infinite loop, otherwise, there will be an error with this test case.
         }
 
-        [Test]
+        [Test, Category("Failure")]// Failure being tracked as MAGN-7656
         [Category("RegressionTests")]
         [TestModel(@".\empty.rfa")]
         public void SelectionButtonShouldBeDisabledAfterOpeningNewDocument()


### PR DESCRIPTION
### Purpose

mark selectionButtonShouldBeDisableAfterOpeningDoc as failure since it is being worked on as MAGN-7656
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

Mr . @Benglin 

### FYIs

@ikeough