### PR TITLE
Fix MAGN-7656: select button incorrectly enabled

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -131,7 +131,7 @@ namespace Dynamo.Applications.Models
             }
         }
 
-        public bool IsInRightDocumentContext
+        public bool IsInMatchingDocumentContext
         {
             get
             {

--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -72,7 +72,7 @@ namespace Dynamo.Nodes
                 if (revitDynamoModel != null)
                 {
                     // Different document, disable selection button.
-                    if (!revitDynamoModel.IsInRightDocumentContext)
+                    if (!revitDynamoModel.IsInMatchingDocumentContext)
                         return false;
 
                     var hwm = RevitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);

--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -71,6 +71,10 @@ namespace Dynamo.Nodes
             {
                 if (revitDynamoModel != null)
                 {
+                    // Different document, disable selection button.
+                    if (!revitDynamoModel.IsInRightDocumentContext)
+                        return false;
+
                     var hwm = RevitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
                     return base.CanSelect && hwm.RunSettings.RunEnabled;
                 }

--- a/src/Libraries/RevitServices/Persistence/DocumentManager.cs
+++ b/src/Libraries/RevitServices/Persistence/DocumentManager.cs
@@ -94,6 +94,23 @@ namespace RevitServices.Persistence
         }
 
         /// <summary>
+        /// Handle document activation, closure. See ActiveDocumentHashCode 
+        /// for more details.
+        /// </summary>
+        /// <param name="revitView">The Revit.DB.View object that is being 
+        /// activated. This parameter will be null if the currently active 
+        /// document is closed. If there is another document when the current 
+        /// document is closed, the next document will be activated again 
+        /// after active document is invalidated here.</param>
+        /// 
+        public void HandleDocumentActivation(View revitView)
+        {
+            ActiveDocumentHashCode = 0;
+            if (revitView != null && (revitView.Document != null))
+                ActiveDocumentHashCode = revitView.Document.GetHashCode();
+        }
+
+        /// <summary>
         /// Provides the currently active DB document.
         /// This is based on the CurrentUIDocument
         /// </summary>
@@ -104,6 +121,21 @@ namespace RevitServices.Persistence
                 return c == null ? null : c.Document;
             }
         }
+
+        /// <summary>
+        /// This property represents the hash code for the current active Revit
+        /// Document object. If there is no active document, this value will be 
+        /// set to zero. This property is made an 'int' because it is primarily
+        /// meant to indicate the active document for comparison purposes, no 
+        /// Document specific operations should be allowed on it. This property 
+        /// is updated when a document switch or a document closure happens. The
+        /// reason this property is needed because the following property cannot
+        /// reliably indicate the current active document:
+        /// 
+        ///     DocumentManager.CurrentUIApplication.ActiveUIDocument.Document
+        /// 
+        /// </summary>
+        public int ActiveDocumentHashCode { get; private set; }
 
         /// <summary>
         /// Provides the currently active UI document.


### PR DESCRIPTION
### Purpose

This pull request is meant to fix the issue where selection buttons incorrectly enabled on a different Revit document. Fundamentally, the problem is cause by the fact that the state of selection button is dependent solely on the value of `RunSettings.RunEnabled`, which may be unstable in various stages of the execution.

The fix introduces a new property `bool RevitDynamoModel.IsInRightDocumentContext` which indicates if the active document is the same document that was bound to the Home workspace. In addition to `RunSettings.RunEnabled`, `RevitSelection.CanSelect` is now made dependent on `RevitDynamoModel.IsInRightDocumentContext`, which means the selection button will never incorrectly be enabled in the wrong document context.

There's also the addition of `DocumentManager.ActiveDocumentHashCode` property, which is always updated to reflect the current active document in Revit. This is necessary because Revit API `UIApplication.ActiveUIDocument` is not able to correctly identify the current active document (most of the time it does not change no matter how user switches the document).

This defect is internally tracked as:

[MAGN-7656](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7656) Selection button is activated in different Revit document

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewers

Hi @ikeough, please have a look at this one and let me know if you spot any issue. In the long run (or even in the near term), we need to make constructs around *session document* more robust and only have very few entry-points for setting them. Thanks!

### FYIs

Hi @Randy-Ma, you might be interested in this if you're online.