### PR TITLE
Fix MAGN-7679 Loading a second Revit sample hangs Revit/Dynamo after loading and running the first sample

### DIFF
--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -49,16 +49,22 @@ namespace Dynamo.Nodes
             {
                 if (revitDynamoModel != null)
                 {
-                    var hwm = revitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
-                    hwm.RunSettings.PropertyChanged -= revMod_PropertyChanged;
+                    var hwm = revitDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
+                    if (hwm != null)
+                    {
+                        hwm.RunSettings.PropertyChanged -= revMod_PropertyChanged;
+                    }
                 }
 
                 revitDynamoModel = value;
 
                 if (revitDynamoModel != null)
                 {
-                    var hwm = revitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
-                    hwm.RunSettings.PropertyChanged += revMod_PropertyChanged;
+                    var hwm = revitDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
+                    if (hwm != null)
+                    {
+                        hwm.RunSettings.PropertyChanged += revMod_PropertyChanged;
+                    }
                 }
             }
         }
@@ -72,9 +78,16 @@ namespace Dynamo.Nodes
                     // Different document, disable selection button.
                     if (!revitDynamoModel.IsInMatchingDocumentContext)
                         return false;
-
-                    var hwm = RevitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
-                    return base.CanSelect && hwm.RunSettings.RunEnabled;
+                    
+                    var hwm = revitDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
+                    if (hwm != null)
+                    {
+                        return base.CanSelect && hwm.RunSettings.RunEnabled;
+                    }
+                    else
+                    {
+                        return false;
+                    }
                 }
                 else
                 {
@@ -90,10 +103,17 @@ namespace Dynamo.Nodes
             {
                 if (revitDynamoModel != null)
                 {
-                    var hwm = RevitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
-                    return hwm.RunSettings.RunEnabled
-                        ? base.SelectionSuggestion
-                        : DSRevitNodesUI.Properties.Resources.SelectionIsDisabledDescription;
+                    var hwm = revitDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
+                    if (hwm != null)
+                    {
+                        return hwm.RunSettings.RunEnabled
+                            ? base.SelectionSuggestion
+                            : DSRevitNodesUI.Properties.Resources.SelectionIsDisabledDescription;
+                    }
+                    else
+                    {
+                        return DSRevitNodesUI.Properties.Resources.SelectionIsDisabledDescription;
+                    }
                 }
                 else
                 {
@@ -155,8 +175,11 @@ namespace Dynamo.Nodes
 
             if (revitDynamoModel != null)
             {
-                var hwm = RevitDynamoModel.Workspaces.OfType<HomeWorkspaceModel>().ElementAt(0);
-                hwm.RunSettings.PropertyChanged -= revMod_PropertyChanged;
+                var hwm = revitDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
+                if (hwm != null)
+                {
+                    hwm.RunSettings.PropertyChanged -= revMod_PropertyChanged;
+                }
             }
         }
 

--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -743,6 +743,26 @@ namespace RevitSystemTests
             Assert.IsFalse(node.CanSelect);
         }
 
+        [Test]
+        [Category("RegressionTests")]
+        [TestModel(@".\empty.rfa")]
+        public void CanOpenAndRunOtherFilesAfterOpeningFileWithSelectNode()
+        {
+            string filePath = Path.Combine(workingDirectory, @".\Bugs\MAGN_7679.dyn");
+            string testPath = Path.GetFullPath(filePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+            AssertNoDummyNodes();
+            RunCurrentModel();
+
+            filePath = Path.Combine(workingDirectory, @".\Samples\MAGN_7679.dyn");
+            testPath = Path.GetFullPath(filePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+            AssertNoDummyNodes();
+            RunCurrentModel();
+        }
+
         protected static IList<Autodesk.Revit.DB.CurveElement> GetAllCurveElements()
         {
             var fec = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);

--- a/test/System/Bugs/MAGN_7679.dyn
+++ b/test/System/Bugs/MAGN_7679.dyn
@@ -1,0 +1,10 @@
+<Workspace Version="0.8.2.1730" X="0" Y="0" zoom="1" Name="Home" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSModelElementSelection guid="3867edfd-bb0f-472a-bf5a-8bef0e6329c9" type="Dynamo.Nodes.DSModelElementSelection" nickname="Select Model Element" x="424.5" y="158" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+</Workspace>


### PR DESCRIPTION
### Purpose

This submission is trying to fix MAGN-7679. The issue is with the selection node. Every time a new file is opened, the old workspace will be removed from the model's workspace list and disposed and so is the selection node. The problem is that the selection node is trying to get the workspace from the model's list of workspaces when it is disposed. But unluckily the list does not contain the workspace because it has been removed.

The fix here is trying to use the CurrentWorkspace property instead of getting the first workspace from the workspace list.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@Benglin 

