### PR TITLE
Fix the defect that AsfamilyInstance misses discription

### DIFF
--- a/src/Libraries/RevitNodes/Elements/CurtainPanel.cs
+++ b/src/Libraries/RevitNodes/Elements/CurtainPanel.cs
@@ -460,7 +460,10 @@ namespace Revit.Elements
          }
          return result.ToArray();
       }
-
+      /// <summary>
+      /// Gets family instance from curtainPanel
+      /// </summary>
+      /// <returns></returns>
       public FamilyInstance AsFamilyInstance()
       {
          return FamilyInstance.FromExisting(InternalElement as Autodesk.Revit.DB.FamilyInstance, true);

--- a/src/Libraries/RevitNodes/Elements/CurtainPanel.cs
+++ b/src/Libraries/RevitNodes/Elements/CurtainPanel.cs
@@ -461,7 +461,7 @@ namespace Revit.Elements
          return result.ToArray();
       }
       /// <summary>
-      /// Gets family instance from curtainPanel
+      /// Gets family instance from curtain Panel
       /// </summary>
       /// <returns></returns>
       public FamilyInstance AsFamilyInstance()


### PR DESCRIPTION
### Purpose

Fix the defect that "AsFamilyInstance" node missed its node description in Revit2016

### Reviewer
@ke-yu 

Thanks
