### PR TITLE
Fix MAGN-5870 GetParamterValueByName node returns different value each time for Sheet Number

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -310,7 +310,7 @@ namespace Revit.Elements
         {
             object result;
 
-            var param = InternalElement.Parameters.Cast<Autodesk.Revit.DB.Parameter>().FirstOrDefault(x => x.Definition.Name == parameterName);
+            var param = InternalElement.GetOrderedParameters().FirstOrDefault(x => x.Definition.Name == parameterName);
 
             if (param == null || !param.HasValue)
                 return string.Empty;

--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -24,6 +24,7 @@ using Revit.GeometryConversion;
 using DoubleSlider = DSCoreNodesUI.Input.DoubleSlider;
 using IntegerSlider = DSCoreNodesUI.Input.IntegerSlider;
 using Dynamo.Applications.Models;
+using System;
 
 namespace RevitSystemTests
 {
@@ -741,6 +742,36 @@ namespace RevitSystemTests
             DocumentManager.Instance.CurrentUIApplication.OpenAndActivateDocument(newRfaFilePath);
             node = AllNodes.OfType<DSModelElementSelection>().ElementAt(0);
             Assert.IsFalse(node.CanSelect);
+        }
+
+        [Test]
+        [Category("RegressionTests")]
+        [TestModel(@".\Samples\DynamoSample.rvt")]
+        public void GetParameterValueByNameWorksForSheetNumber()
+        {
+            string filePath = Path.Combine(workingDirectory, @".\Bugs\MAGN_5870.dyn");
+            string testPath = Path.GetFullPath(filePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+            AssertNoDummyNodes();
+            RunCurrentModel();
+
+            Action<string> checkFunc = delegate(string guid)
+            {
+                List<object> objects = GetPreviewCollection(guid);
+
+                Assert.AreEqual(objects.Count, 5);
+                Assert.IsTrue(string.CompareOrdinal(objects[0] as string, "A102") == 0);
+                Assert.IsTrue(string.CompareOrdinal(objects[1] as string, "A104") == 0);
+                Assert.IsTrue(string.CompareOrdinal(objects[2] as string, "A103") == 0);
+                Assert.IsTrue(string.CompareOrdinal(objects[3] as string, "A105") == 0);
+                Assert.IsTrue(string.CompareOrdinal(objects[4] as string, "A101") == 0);
+            };
+
+            checkFunc("a45ab78b-b7cb-4317-a763-ac8c9a55753f");
+            checkFunc("8fad0166-bb08-48e0-a62c-dcfb6b11a9fe");
+            checkFunc("d4fd1c38-e3cb-484b-8187-66061476cd6a");
+            checkFunc("6defe7da-caf9-489e-991d-4665eb26e786");
         }
 
         [Test]

--- a/test/System/Bugs/MAGN_5870.dyn
+++ b/test/System/Bugs/MAGN_5870.dyn
@@ -1,0 +1,20 @@
+<Workspace Version="0.7.5.3566" X="-1341.76486367605" Y="-345.16801431987" zoom="1.00277440221293" Description="" Category="" Name="Home">
+  <Elements>
+    <DSRevitNodesUI.Categories type="DSRevitNodesUI.Categories" guid="1e168a3a-da90-445f-b339-b7093e04017a" nickname="Categories" x="1348.80173418367" y="534.533222804465" isVisible="true" isUpstreamVisible="true" lacing="Disabled" index="745:Sheets" />
+    <DSRevitNodesUI.ElementsOfCategory type="DSRevitNodesUI.ElementsOfCategory" guid="2a70bf61-d84d-41cc-a054-ba19608c2fd4" nickname="All Elements of Category" x="1616.84447204461" y="527.704617671281" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="a45ab78b-b7cb-4317-a763-ac8c9a55753f" nickname="Code Block" x="1927.86330120678" y="632.929915041704" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="a.GetParameterValueByName(&quot;Sheet Number&quot;);" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="8fad0166-bb08-48e0-a62c-dcfb6b11a9fe" nickname="Code Block" x="1518.79348748085" y="751.449659071316" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="a.GetParameterValueByName(&quot;Sheet Number&quot;);" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="d4fd1c38-e3cb-484b-8187-66061476cd6a" nickname="Code Block" x="1946.6209219456" y="852.775813145983" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="a.GetParameterValueByName(&quot;Sheet Number&quot;);" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="b7152914-780d-4195-b2e7-69471b7d0a3e" nickname="Code Block" x="1693.407297062" y="413.185648338002" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="&quot;Sheet Number&quot;;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="6defe7da-caf9-489e-991d-4665eb26e786" nickname="Element.GetParameterValueByName" x="1982.47337188319" y="405.960030343967" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="RevitNodes.dll" function="Revit.Elements.Element.GetParameterValueByName@string" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="1e168a3a-da90-445f-b339-b7093e04017a" start_index="0" end="2a70bf61-d84d-41cc-a054-ba19608c2fd4" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="2a70bf61-d84d-41cc-a054-ba19608c2fd4" start_index="0" end="a45ab78b-b7cb-4317-a763-ac8c9a55753f" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="2a70bf61-d84d-41cc-a054-ba19608c2fd4" start_index="0" end="8fad0166-bb08-48e0-a62c-dcfb6b11a9fe" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="2a70bf61-d84d-41cc-a054-ba19608c2fd4" start_index="0" end="d4fd1c38-e3cb-484b-8187-66061476cd6a" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="2a70bf61-d84d-41cc-a054-ba19608c2fd4" start_index="0" end="6defe7da-caf9-489e-991d-4665eb26e786" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="b7152914-780d-4195-b2e7-69471b7d0a3e" start_index="0" end="6defe7da-caf9-489e-991d-4665eb26e786" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+</Workspace>


### PR DESCRIPTION
### Purpose

This submission is to fix MAGN-5870. Right now the GetParamterValueByName node may return different value each time it is run. This is because an element may have multiple parameters of the same name. We are trying to only get the first one. But the first one is not fixed.

The fix here is to use a different API to get the user visible parameters so that we will not get multiple parameters of the same name.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] The level of testing this PR includes is appropriate

### Reviewers

@aparajit-pratap 

### FYIs
@ikeough 