### PR TITLE
Localize wall type in resource file

### DIFF
--- a/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
@@ -187,6 +187,15 @@ namespace DSRevitNodesUI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No wall types available..
+        /// </summary>
+        internal static string NoWallTypesAvailable {
+            get {
+                return ResourceManager.GetString("NoWallTypesAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A Level.
         /// </summary>
         internal static string PortDataALevelToolTip {

--- a/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
@@ -276,4 +276,7 @@
   <data name="NoFloorTypesAvailable" xml:space="preserve">
     <value>No floor types available.</value>
   </data>
+  <data name="NoWallTypesAvailable" xml:space="preserve">
+    <value>No wall types available.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodesUI/Properties/Resources.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.resx
@@ -276,4 +276,7 @@
   <data name="NoFloorTypesAvailable" xml:space="preserve">
     <value>No floor types available.</value>
   </data>
+  <data name="NoWallTypesAvailable" xml:space="preserve">
+    <value>No wall types available.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -356,7 +356,7 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class WallTypes : RevitDropDownBase
     {
-        private const string noWallTypes = "No wall types available.";
+ 
 
         public WallTypes() : base("Wall Type") { }
 
@@ -369,7 +369,7 @@ namespace DSRevitNodesUI
             fec.OfClass(typeof(Autodesk.Revit.DB.WallType));
             if (fec.ToElements().Count == 0)
             {
-                Items.Add(new DynamoDropDownItem(noWallTypes, null));
+                Items.Add(new DynamoDropDownItem(Properties.Resources.NoWallTypesAvailable, null));
                 SelectedIndex = 0;
                 return;
             }
@@ -385,7 +385,7 @@ namespace DSRevitNodesUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             if (Items.Count == 0 ||
-                Items[0].Name == noWallTypes ||
+                Items[0].Name == Properties.Resources.NoWallTypesAvailable ||
                 SelectedIndex == -1)
             {
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };


### PR DESCRIPTION
### Purpose
* Localize Term " No wall type available".

* Situations:when user use the node [WallType], walltype node will show "no wall type available" if Revit document does not contain any wall type. so we need to localize it


### Declarations
- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate

### Reviewer
@ke-yu  PTAL

Thx