### PR TITLE
Add event handlers through a proxy for view or document events

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -35,7 +35,6 @@ using RevitServices.Threading;
 
 using MessageBox = System.Windows.Forms.MessageBox;
 using DynUpdateManager = Dynamo.UpdateManager.UpdateManager;
-using System.Collections.Generic;
 using Microsoft.Win32;
 
 
@@ -227,8 +226,7 @@ namespace Dynamo.Applications
 
             revitDynamoModel.ShutdownStarted += (drm) =>
             {
-                var uiApplication = DocumentManager.Instance.CurrentUIApplication;
-                uiApplication.Idling += DeleteKeeperElementOnce;
+                DynamoRevitApp.AddIdleAction(DeleteKeeperElement);
             };
 
             return viewModel;

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -2,25 +2,25 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+using System.Linq;
 using System.IO;
 using System.Reflection;
 using System.Resources;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media.Imaging;
-
 using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
-
+using Autodesk.Revit.UI.Events;
 using Dynamo.Applications.Properties;
-
 using RevitServices.Elements;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
-
 using MessageBox = System.Windows.Forms.MessageBox;
+using Dynamo.Models;
+using RevitServices.EventHandler;
 
 namespace Dynamo.Applications
 {
@@ -33,16 +33,21 @@ namespace Dynamo.Applications
         private static readonly string assemblyName = Assembly.GetExecutingAssembly().Location;
         private static ResourceManager res;
         public static ControlledApplication ControlledApplication;
+        public static UIControlledApplication UIControlledApplication;
         public static List<IUpdater> Updaters = new List<IUpdater>();
         internal static PushButton DynamoButton;
+        private static readonly Queue<Action> idleActionQueue = new Queue<Action>(10);
+        private static EventHandlerProxy proxy;
 
         public Result OnStartup(UIControlledApplication application)
         {
             try
             {
-                SubscribeAssemblyResolvingEvent();
-
+                UIControlledApplication = application;
                 ControlledApplication = application.ControlledApplication;
+
+                SubscribeAssemblyResolvingEvent();
+                SubscribeApplicationEvents();
 
                 TransactionManager.SetupManager(new AutomaticTransactionStrategy());
                 ElementBinder.IsEnabled = true;
@@ -89,8 +94,51 @@ namespace Dynamo.Applications
         public Result OnShutdown(UIControlledApplication application)
         {
             UnsubscribeAssemblyResolvingEvent();
+            UnsubscribeApplicationEvents();
 
             return Result.Succeeded;
+        }
+
+        private static void OnApplicationIdle(object sender, IdlingEventArgs e)
+        {
+            if (!idleActionQueue.Any())
+                return;
+
+            Action pendingAction = null;
+            lock (idleActionQueue)
+            {
+                pendingAction = idleActionQueue.Dequeue();
+            }
+
+            if (pendingAction != null)
+                pendingAction();
+        }
+
+
+        /// <summary>
+        /// Add an action to run when the application is in the idle state
+        /// </summary>
+        /// <param name="a"></param>
+        public static void AddIdleAction(Action a)
+        {
+            // If we are running in test mode, invoke 
+            // the action immediately.
+            if (DynamoModel.IsTestMode)
+            {
+                a.Invoke();
+            }
+            else
+            {
+                lock (idleActionQueue)
+                {
+                    idleActionQueue.Enqueue(a);
+                }
+            }
+        }
+
+        public static EventHandlerProxy EventHandlerProxy
+        {
+            get { return proxy; }
         }
 
         // should be handled by the ModelUpdater class. But there are some
@@ -115,6 +163,34 @@ namespace Dynamo.Applications
                 filter,
                 Element.GetChangeTypeAny());
             Updaters.Add(sunUpdater);
+        }
+
+        private void SubscribeApplicationEvents()
+        {
+            UIControlledApplication.Idling += OnApplicationIdle;
+
+            proxy = new EventHandlerProxy();
+
+            UIControlledApplication.ViewActivated += proxy.OnApplicationViewActivated;
+            UIControlledApplication.ViewActivating += proxy.OnApplicationViewActivating;
+
+            ControlledApplication.DocumentClosing += proxy.OnApplicationDocumentClosing;
+            ControlledApplication.DocumentClosed += proxy.OnApplicationDocumentClosed;
+            ControlledApplication.DocumentOpened += proxy.OnApplicationDocumentOpened;
+        }
+
+        private void UnsubscribeApplicationEvents()
+        {
+            UIControlledApplication.Idling -= OnApplicationIdle;
+
+            UIControlledApplication.ViewActivated -= proxy.OnApplicationViewActivated;
+            UIControlledApplication.ViewActivating -= proxy.OnApplicationViewActivating;
+
+            ControlledApplication.DocumentClosing -= proxy.OnApplicationDocumentClosing;
+            ControlledApplication.DocumentClosed -= proxy.OnApplicationDocumentClosed;
+            ControlledApplication.DocumentOpened -= proxy.OnApplicationDocumentOpened;
+
+            proxy = null;
         }
 
         private void SubscribeAssemblyResolvingEvent()

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -7,33 +7,25 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Soap;
 using System.Windows.Forms;
-
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Events;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Events;
-
 using DSIronPython;
-
 using Dynamo.DSEngine;
 using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.UpdateManager;
 using Dynamo.Utilities;
-
 using DynamoServices;
-
 using Greg;
-
 using ProtoCore;
-
 using Revit.Elements;
-
 using RevitServices.Elements;
+using RevitServices.EventHandler;
 using RevitServices.Persistence;
 using RevitServices.Threading;
 using RevitServices.Transactions;
-
 using Category = Revit.Elements.Category;
 using Element = Autodesk.Revit.DB.Element;
 using View = Autodesk.Revit.DB.View;
@@ -355,12 +347,11 @@ namespace Dynamo.Applications.Models
                 return;
             }
 
-            commandData.Application.ViewActivating += OnApplicationViewActivating;
-            commandData.Application.ViewActivated += OnApplicationViewActivated;
-
-            commandData.Application.Application.DocumentClosing += OnApplicationDocumentClosing;
-            commandData.Application.Application.DocumentClosed += OnApplicationDocumentClosed;
-            commandData.Application.Application.DocumentOpened += OnApplicationDocumentOpened;
+            DynamoRevitApp.EventHandlerProxy.ViewActivating += OnApplicationViewActivating;
+            DynamoRevitApp.EventHandlerProxy.ViewActivated += OnApplicationViewActivated;
+            DynamoRevitApp.EventHandlerProxy.DocumentClosing += OnApplicationDocumentClosing;
+            DynamoRevitApp.EventHandlerProxy.DocumentClosed += OnApplicationDocumentClosed;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened += OnApplicationDocumentOpened;
 
             hasRegisteredApplicationEvents = true;
         }
@@ -372,12 +363,11 @@ namespace Dynamo.Applications.Models
                 return;
             }
 
-            commandData.Application.ViewActivating -= OnApplicationViewActivating;
-            commandData.Application.ViewActivated -= OnApplicationViewActivated;
-
-            commandData.Application.Application.DocumentClosing -= OnApplicationDocumentClosing;
-            commandData.Application.Application.DocumentClosed -= OnApplicationDocumentClosed;
-            commandData.Application.Application.DocumentOpened -= OnApplicationDocumentOpened;
+            DynamoRevitApp.EventHandlerProxy.ViewActivating -= OnApplicationViewActivating;
+            DynamoRevitApp.EventHandlerProxy.ViewActivated -= OnApplicationViewActivated;
+            DynamoRevitApp.EventHandlerProxy.DocumentClosing -= OnApplicationDocumentClosing;
+            DynamoRevitApp.EventHandlerProxy.DocumentClosed -= OnApplicationDocumentClosed;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened -= OnApplicationDocumentOpened;
 
             hasRegisteredApplicationEvents = false;
         }

--- a/src/Libraries/RevitNodesUI/Elements.cs
+++ b/src/Libraries/RevitNodesUI/Elements.cs
@@ -2,23 +2,21 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
 using Autodesk.Revit.DB.Electrical;
+using Autodesk.Revit.DB.Events;
 using Autodesk.Revit.DB.Structure;
-
+using Autodesk.Revit.UI.Events;
+using Dynamo.Applications;
 using Dynamo.Applications.Models;
 using Dynamo.Models;
-
 using ProtoCore.AST.AssociativeAST;
-
 using Revit.Elements;
 using Revit.Elements.InternalUtilities;
-
 using RevitServices.Elements;
+using RevitServices.EventHandler;
 using RevitServices.Persistence;
-
 using Category = Revit.Elements.Category;
 using CurveElement = Autodesk.Revit.DB.CurveElement;
 using DividedSurface = Autodesk.Revit.DB.DividedSurface;
@@ -215,11 +213,8 @@ namespace DSRevitNodesUI
             OutPortData.Add(new PortData("elements", Properties.Resources.PortDataAllVisibleElementsToolTip));
             RegisterAllPorts();
 
-            DocumentManager.Instance.CurrentUIApplication.ViewActivated +=
-                RevitDynamoModel_RevitDocumentChanged;
-
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened +=
-                RevitDynamoModel_RevitDocumentChanged;
+            DynamoRevitApp.EventHandlerProxy.ViewActivated += RevitDynamoModel_RevitDocumentChanged;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened += RevitDynamoModel_RevitDocumentChanged;
 
             RevitServicesUpdater.Instance.ElementsDeleted +=
                 RevitServicesUpdaterOnElementsDeleted;
@@ -234,11 +229,8 @@ namespace DSRevitNodesUI
         public override void Dispose()
         {
             base.Dispose();
-            DocumentManager.Instance.CurrentUIApplication.ViewActivated -=
-                RevitDynamoModel_RevitDocumentChanged;
-
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -=
-                RevitDynamoModel_RevitDocumentChanged;
+            DynamoRevitApp.EventHandlerProxy.ViewActivated -= RevitDynamoModel_RevitDocumentChanged;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened -= RevitDynamoModel_RevitDocumentChanged;
 
             RevitServicesUpdater.Instance.ElementsDeleted -=
                 RevitServicesUpdaterOnElementsDeleted;

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -4,18 +4,17 @@ using System.Globalization;
 using System.Linq;
 using System.Xml;
 using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Events;
 using DSCore;
 using DSCoreNodesUI;
-
+using Dynamo.Applications;
 using Dynamo.Applications.Models;
 using Dynamo.DSEngine;
 using Dynamo.Models;
 using Dynamo.Utilities;
-
 using ProtoCore.AST.AssociativeAST;
-
 using Revit.Elements;
-
+using RevitServices.EventHandler;
 using RevitServices.Persistence;
 using Category = Revit.Elements.Category;
 using Element = Autodesk.Revit.DB.Element;
@@ -29,9 +28,10 @@ namespace DSRevitNodesUI
 {
     public abstract class RevitDropDownBase : DSDropDownBase
     {
+
         protected RevitDropDownBase(string value) : base(value)
         {
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened += Controller_RevitDocumentChanged;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened += Controller_RevitDocumentChanged;
         }
 
         void Controller_RevitDocumentChanged(object sender, EventArgs e)
@@ -46,7 +46,7 @@ namespace DSRevitNodesUI
 
         public override void Dispose()
         {
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -= Controller_RevitDocumentChanged;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened -= Controller_RevitDocumentChanged;
             base.Dispose();
         }
     }

--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -26,6 +26,9 @@ using RevitDynamoModel = Dynamo.Applications.Models.RevitDynamoModel;
 using Point = Autodesk.DesignScript.Geometry.Point;
 using String = System.String;
 using UV = Autodesk.DesignScript.Geometry.UV;
+using RevitServices.EventHandler;
+using Autodesk.Revit.DB.Events;
+using Dynamo.Applications;
 
 namespace Dynamo.Nodes
 {
@@ -150,7 +153,7 @@ namespace Dynamo.Nodes
         {
             RevitServicesUpdater.Instance.ElementsDeleted += Updater_ElementsDeleted;
             RevitServicesUpdater.Instance.ElementsModified += Updater_ElementsModified;
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened += Controller_RevitDocumentChanged;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened += Controller_RevitDocumentChanged;
           
         }
 
@@ -172,8 +175,9 @@ namespace Dynamo.Nodes
             base.Dispose();
             RevitServicesUpdater.Instance.ElementsDeleted -= Updater_ElementsDeleted;
             RevitServicesUpdater.Instance.ElementsModified -= Updater_ElementsModified;
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -= Controller_RevitDocumentChanged;
-        if (revitDynamoModel != null)
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened -= Controller_RevitDocumentChanged;
+
+            if (revitDynamoModel != null)
             {
                 var hwm = revitDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
                 if (hwm != null)

--- a/src/Libraries/RevitNodesUI/SiteLocation.cs
+++ b/src/Libraries/RevitNodesUI/SiteLocation.cs
@@ -17,6 +17,9 @@ using Revit.GeometryConversion;
 using Revit.Elements;
 using RevitServices.Elements;
 using RevitServices.Persistence;
+using RevitServices.EventHandler;
+using Autodesk.Revit.DB.Events;
+using Dynamo.Applications;
 
 namespace DSRevitNodesUI
 {
@@ -51,7 +54,7 @@ namespace DSRevitNodesUI
 
             ArgumentLacing = LacingStrategy.Disabled;
 
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened += model_RevitDocumentChanged;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened += model_RevitDocumentChanged;
             RevitServicesUpdater.Instance.ElementsModified += RevitServicesUpdater_ElementsModified;
 
             Update();
@@ -61,7 +64,7 @@ namespace DSRevitNodesUI
 
         public override void Dispose()
         {
-            DocumentManager.Instance.CurrentUIApplication.Application.DocumentOpened -= model_RevitDocumentChanged;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened -= model_RevitDocumentChanged;
             RevitServicesUpdater.Instance.ElementsModified -= RevitServicesUpdater_ElementsModified;
             base.Dispose();
         }

--- a/src/Libraries/RevitServices/Events/EventHandlerProxy.cs
+++ b/src/Libraries/RevitServices/Events/EventHandlerProxy.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using Autodesk.Revit.DB.Events;
+using Autodesk.Revit.UI.Events;
+using Dynamo.Models;
+
+namespace RevitServices.EventHandler
+{
+    /// <summary>
+    /// This is a event handler proxy class to serve as a proxy between the event publisher and
+    /// the event subscriber
+    /// </summary>
+    public class EventHandlerProxy
+    {
+        public event EventHandler<DocumentOpenedEventArgs> DocumentOpened;
+        public event EventHandler<DocumentClosingEventArgs> DocumentClosing;
+        public event EventHandler<DocumentClosedEventArgs> DocumentClosed;
+        public event EventHandler<ViewActivatingEventArgs> ViewActivating;
+        public event EventHandler<ViewActivatedEventArgs> ViewActivated;
+
+        public void OnApplicationDocumentOpened(object sender, DocumentOpenedEventArgs args)
+        {
+            InvokeEventHandler(DocumentOpened, sender, args);
+        }
+
+        public void OnApplicationDocumentClosing(object sender, DocumentClosingEventArgs args)
+        {
+            InvokeEventHandler(DocumentClosing, sender, args);
+        }
+
+        public void OnApplicationDocumentClosed(object sender, DocumentClosedEventArgs args)
+        {
+            InvokeEventHandler(DocumentClosed, sender, args);
+        }
+
+        public void OnApplicationViewActivating(object sender, ViewActivatingEventArgs args)
+        {
+            InvokeEventHandler(ViewActivating, sender, args);
+        }
+
+        public void OnApplicationViewActivated(object sender, ViewActivatedEventArgs args)
+        {
+            InvokeEventHandler(ViewActivated, sender, args);
+        }
+
+        private void InvokeEventHandler<T>(EventHandler<T> eventHandler, object sender, T args) where T: EventArgs
+        {
+            var tempHandler = eventHandler;
+            if (tempHandler != null)
+            {
+                tempHandler(sender, args);
+            }
+        }
+    }
+}

--- a/src/Libraries/RevitServices/RevitServices.csproj
+++ b/src/Libraries/RevitServices/RevitServices.csproj
@@ -79,6 +79,7 @@ limitations under the License.
     <Compile Include="Elements\ElementUtils.cs" />
     <Compile Include="Elements\ModelUpdater.cs" />
     <Compile Include="Elements\Updaters.cs" />
+    <Compile Include="Events\EventHandlerProxy.cs" />
     <Compile Include="Persistence\DocumentManager.cs" />
     <Compile Include="Persistence\ElementBinder.cs" />
     <Compile Include="Persistence\ElementIDLifecycleManager.cs" />


### PR DESCRIPTION
### Purpose

The main purpose of this pull request is to avoid direct reference to the subscriber of several events: DocumentOpened, DocumentClosing, DocumentClosed, ViewActivating and ViewActivated.

To achieve this, a proxy class has been implemented which will contain six events and six member functions. The methods of the proxy object will be subscribed to the application events. The original subscriber will subscribe to the events of the proxy. The implementation of the six methods in the proxy will invoke the corresponding events.

Additionally OnApplicationIdle has been implemented which will be registered to the Idling event of the application. An public function: AddIdleAction is created so that it is possible to add some tasks which need to be run when the application is in an idle state.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers
@ke-yu PTAL

### FYIs
@ikeough 
