### PR TITLE
Use xcopy to copy a file instead of copy

### DIFF
--- a/src/DynamoRevit/DynamoRevit.csproj
+++ b/src/DynamoRevit/DynamoRevit.csproj
@@ -182,15 +182,15 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(DynamoExternPath)\DynamoRaaS\RevitRaaS.dll.config" "$(OutputPath)"
-copy /Y "$(DynamoExternPath)\DynamoRaaS\DynamoRaaS.dll" "$(OutputPath)\nodes\DynamoRaaS.dll"
-copy /Y "$(DynamoExternPath)\DynamoRaaS\SimpleRaaS.dll" "$(OutputPath)"
-copy /Y "$(DynamoExternPath)\DynamoRaaS\JobMonitor.dll" "$(OutputPath)"
-copy /Y "$(DynamoExternPath)\DynamoRaaS\RevitRaaS.dll" "$(OutputPath)"
-copy /Y "$(DynamoExternPath)\DynamoRaaS\SDF.dll" "$(OutputPath)"
-copy /Y "$(DynamoExternPath)\DynamoRaaS\*_DynamoCustomization.xml" "$(OutputPath)"
-copy /Y "$(DynamoExternPath)\DynamoRaaS\SimpleRaas.xml" "$(OutputPath)\en-US"
-copy /Y "$(DynamoExternPath)\DynamoRaaS\en-US\*resources.dll" "$(OutputPath)\en-US"</PostBuildEvent>
+    <PostBuildEvent>xcopy /Y "$(DynamoExternPath)\DynamoRaaS\RevitRaaS.dll.config" "$(OutputPath)"
+xcopy /Y "$(DynamoExternPath)\DynamoRaaS\DynamoRaaS.dll" "$(OutputPath)nodes\"
+xcopy /Y "$(DynamoExternPath)\DynamoRaaS\SimpleRaaS.dll" "$(OutputPath)"
+xcopy /Y "$(DynamoExternPath)\DynamoRaaS\JobMonitor.dll" "$(OutputPath)"
+xcopy /Y "$(DynamoExternPath)\DynamoRaaS\RevitRaaS.dll" "$(OutputPath)"
+xcopy /Y "$(DynamoExternPath)\DynamoRaaS\SDF.dll" "$(OutputPath)"
+xcopy /Y "$(DynamoExternPath)\DynamoRaaS\*_DynamoCustomization.xml" "$(OutputPath)"
+xcopy /Y "$(DynamoExternPath)\DynamoRaaS\SimpleRaas.xml" "$(OutputPath)en-US\"
+xcopy /Y "$(DynamoExternPath)\DynamoRaaS\en-US\*resources.dll" "$(OutputPath)en-US\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
### Purpose

This is to fix an issue in the script for the PostBuildEvent. The issue is that the copy will fail if the target directory does not exist. This fix uses xcopy instead of copy.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@riteshchandawar PTAL

