### PR TITLE
Fixes Version Selector UI defect MAGN-7250

### DIFF
--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -53,8 +53,10 @@ namespace Dynamo.Applications
                 ElementBinder.IsEnabled = true;
 
                 // Create new ribbon panel
-                RibbonPanel ribbonPanel =
-                    application.CreateRibbonPanel(Resources.App_Description);
+                var panels = application.GetRibbonPanels();
+                var ribbonPanel = panels.FirstOrDefault(p => p.Name.Contains(Resources.App_Description));
+                if(null == ribbonPanel)
+                    ribbonPanel = application.CreateRibbonPanel(Resources.App_Description);
 
                 var fvi = FileVersionInfo.GetVersionInfo(assemblyName);
                 var dynVersion = String.Format(Resources.App_Name, fvi.FileMajorPart, fvi.FileMinorPart);

--- a/src/Legacy/DynamoRevitVersionSelector/Properties/Resources.Designer.cs
+++ b/src/Legacy/DynamoRevitVersionSelector/Properties/Resources.Designer.cs
@@ -105,5 +105,14 @@ namespace DynamoRevitVersionSelector.Properties {
                 return ResourceManager.GetString("RestartMessage", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Visual Programming.
+        /// </summary>
+        internal static string VisualProgramming {
+            get {
+                return ResourceManager.GetString("VisualProgramming", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Legacy/DynamoRevitVersionSelector/Properties/Resources.en-US.resx
+++ b/src/Legacy/DynamoRevitVersionSelector/Properties/Resources.en-US.resx
@@ -133,4 +133,7 @@
   <data name="DynamoVersionTooltip" xml:space="preserve">
     <value>Launches Dynamo {0}, to launch a different version of Dynamo you may need to restart Revit</value>
   </data>
+  <data name="VisualProgramming" xml:space="preserve">
+    <value>Visual Programming</value>
+  </data>
 </root>

--- a/src/Legacy/DynamoRevitVersionSelector/Properties/Resources.resx
+++ b/src/Legacy/DynamoRevitVersionSelector/Properties/Resources.resx
@@ -133,4 +133,7 @@
   <data name="DynamoVersionTooltip" xml:space="preserve">
     <value>Launches Dynamo {0}, to launch a different version of Dynamo you may need to restart Revit</value>
   </data>
+  <data name="VisualProgramming" xml:space="preserve">
+    <value>Visual Programming</value>
+  </data>
 </root>

--- a/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
+++ b/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
@@ -20,18 +20,14 @@ namespace Dynamo.Applications
     internal struct DynamoProduct
     {
         public string InstallLocation;
-        public Tuple<int, int, int, int> VersionInfo;
+        public Version VersionInfo;
 
         public string VersionString
         {
             get
             {
                 return string.Format(
-                    "Dynamo {0}.{1}.{2}.{3}",
-                    VersionInfo.Item1,
-                    VersionInfo.Item2,
-                    VersionInfo.Item3,
-                    VersionInfo.Item4);
+                    @"Dynamo {0}", VersionInfo.ToString(4));
             }
         }
     }
@@ -42,11 +38,12 @@ namespace Dynamo.Applications
     {
         private static UIControlledApplication uiApplication;
         private static SplitButton splitButton;
+        private static RibbonPanel ribbonPanel;
         internal static List<DynamoProduct> Products { get; private set; }
 
         internal static string GetDynamoRevitPath(DynamoProduct product, string revitVersion)
         {
-            if (product.VersionInfo.Item1 == 0 && product.VersionInfo.Item2 < 7)
+            if (product.VersionInfo < new Version(0, 7))
                 return Path.Combine(product.InstallLocation, "DynamoRevit.dll"); //0.6.3 and older version
 
             return Path.Combine(product.InstallLocation, string.Format("Revit_{0}", revitVersion), "DynamoRevitDS.dll");
@@ -94,7 +91,7 @@ namespace Dynamo.Applications
             // If only one version is installed, no multi-selection is required.
             if (Products.Count > 1)
             {
-                RibbonPanel ribbonPanel = application.CreateRibbonPanel(Resources.DynamoVersions);
+                ribbonPanel = application.CreateRibbonPanel(Resources.DynamoVersions);
 
                 splitButton = AddSplitButtonGroup(ribbonPanel);
                 
@@ -124,24 +121,52 @@ namespace Dynamo.Applications
             if (index >= Products.Count)
                 return false; //Index out of range
 
-            var revitVersion = commandData.Application.Application.VersionNumber;
-            var p = Products[index];
-            var path = GetDynamoRevitPath(p, revitVersion);
-            Utils.WriteToFile(path, revitVersion);
+            try
+            {
+                var revitVersion = commandData.Application.Application.VersionNumber;
+                var p = Products[index];
+                var path = GetDynamoRevitPath(p, revitVersion);
+                Utils.WriteToFile(path, revitVersion);
 
-            //Initialize application
-            var ass = Assembly.LoadFrom(path);
-            var revitApp = ass.CreateInstance("Dynamo.Applications.DynamoRevitApp");
-            revitApp.GetType().GetMethod("OnStartup").Invoke(revitApp, new object[] { uiApplication });
+                splitButton.Enabled = false; //Disable the split button, no more needed.
+                splitButton.Visible = false; //Hide it from the UI
+                //For older than 0.8.2, hide the Dynamo Versions ribbon panel
+                //Otherwise rename it to "Visual Programming", so that DynamoRevit
+                //will add it's button to this panel.
+                if (p.VersionInfo < new Version(0, 8, 2))
+                {
+                    ribbonPanel.Visible = false; //Hide the panel
+                }
+                else
+                {
+                    ribbonPanel.Name = Resources.VisualProgramming;//Same as used in App Description for DynamoRevitApp
+                    ribbonPanel.Title = Resources.VisualProgramming;
+                }
 
-            //Invoke command
-            string message = string.Empty;
-            var revitCmd = ass.CreateInstance("Dynamo.Applications.DynamoRevit");
-            revitCmd.GetType().GetMethod("Execute").Invoke(revitCmd, new object[] {commandData, message, null });
+                //Initialize application
+                var ass = Assembly.LoadFrom(path);
+                var revitApp = ass.CreateInstance("Dynamo.Applications.DynamoRevitApp");
+                revitApp.GetType()
+                    .GetMethod("OnStartup")
+                    .Invoke(revitApp, new object[] { uiApplication });
 
-            splitButton.Enabled = false; //Disable the split button, no more needed.
-            uiApplication = null; //release application, no more needed.
-            return true;
+                //Invoke command
+                string message = string.Empty;
+                var revitCmd = ass.CreateInstance("Dynamo.Applications.DynamoRevit");
+                revitCmd.GetType()
+                    .GetMethod("Execute")
+                    .Invoke(revitCmd, new object[] { commandData, message, null });
+
+                uiApplication = null; //release application, no more needed.
+                return true;
+            }
+            catch (Exception)
+            {
+                splitButton.Enabled = true; //Disable the split button, no more needed.
+                splitButton.Visible = true; //Hide it from the UI
+                ribbonPanel.Visible = true; //Hide the panel
+                throw;
+            }
         }
 
         private SplitButton AddSplitButtonGroup(RibbonPanel panel)
@@ -164,7 +189,7 @@ namespace Dynamo.Applications
             {
                 var name = p.VersionString;
                 var versionInfo = p.VersionInfo;
-                var text = string.Format("{0}.{1}.{2}", versionInfo.Item1, versionInfo.Item2, versionInfo.Item3);
+                var text = versionInfo.ToString(3);
                 
                 var itemData = new PushButtonData(
                                 name,
@@ -210,7 +235,8 @@ namespace Dynamo.Applications
             return
                 installs.Cast<KeyValuePair<string, Tuple<int, int, int, int>>>()
                     .Select(
-                        p => new DynamoProduct() { InstallLocation = p.Key, VersionInfo = p.Value });
+                        p => new DynamoProduct() { InstallLocation = p.Key, 
+                            VersionInfo = new Version(p.Value.Item1, p.Value.Item2, p.Value.Item3, p.Value.Item4) });
         }
 
     }

--- a/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
+++ b/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
@@ -162,9 +162,9 @@ namespace Dynamo.Applications
             }
             catch (Exception)
             {
-                splitButton.Enabled = true; //Disable the split button, no more needed.
-                splitButton.Visible = true; //Hide it from the UI
-                ribbonPanel.Visible = true; //Hide the panel
+                splitButton.Enabled = true; //Ensure that the split button is enabled.
+                splitButton.Visible = true; //Also the split button is visible
+                ribbonPanel.Visible = true; //As well as the panel is visible
                 throw;
             }
         }


### PR DESCRIPTION
### Purpose

This PR fixes https://github.com/DynamoDS/Dynamo/issues/4194, where Dynamo version selector and visual programming panel at far apart.

- When a user selects the specific Dynamo version using version selector, we no longer need the version selector UI in the current session of Revit, and hence it was disabled before. 

- This PR now hides the Ribbon Panel for the version selector so that we don't show two Dynamo icon on Ribbon.

- For Dynamo 0.8.2 onwards, the Dynamo Versions panel is renamed to "Visual Programming" so we show the Dynamo button at the same location. 

- We can't do as above for the older version of Dynamo because the previous version of Dynamo always creates a new panel named with "Visual Programming". And if this panel already exists, it throws an error. 0.8.2 onwards DynamoRevitApp checks for any available panel with this name and tries to add the Dynamo button to existing panel.

#### When Revit is launched:
![image](https://cloud.githubusercontent.com/assets/1754137/8955835/cda80c3e-3622-11e5-88ea-91d590333f37.png)

#### If Dynamo 0.8.2 is launched 
![image](https://cloud.githubusercontent.com/assets/1754137/8955866/013927ae-3623-11e5-81f8-b8bff853b776.png)

#### If pre 0.8.2 Dynamo is launched
![image](https://cloud.githubusercontent.com/assets/1754137/8955946/ef5eff26-3623-11e5-944b-0036aadbb6b4.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Randy-Ma  