### PR TITLE
Fix MAGN-7931 Dynamo/Revit hangs when operating on shared nested families

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/GeometryObjectConverter.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/GeometryObjectConverter.cs
@@ -28,15 +28,24 @@ namespace Revit.GeometryConversion
             if (geom == null) return null;
 
             dynamic dynGeom = geom;
+            Autodesk.DesignScript.Geometry.Geometry protoGeom = null;
             try
             {
-                return Tag(Transform(InternalConvert(dynGeom), transform), reference);
+                protoGeom = InternalConvert(dynGeom);
+                return Tag(Transform(protoGeom, transform), reference);
             }
             catch (Exception)
             {
                 return null; 
             }
-
+            finally
+            {
+                // Dispose the temporary geometry that has been transformed.
+                if (protoGeom != null && transform != null)
+                {
+                    protoGeom.Dispose();
+                }
+            }
         }
 
         /// <summary>

--- a/src/Libraries/RevitNodes/GeometryConversion/RevitToProtoSolid.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/RevitToProtoSolid.cs
@@ -28,9 +28,24 @@ namespace Revit.GeometryConversion
             {
                 srfs.AddRange(face.ToProtoType(false));
             }
-            var converted = Solid.ByJoinedSurfaces(srfs);
-            srfs.ForEach(x => x.Dispose());
-            srfs.Clear();
+
+            Solid converted = null;
+            try
+            {
+                converted = Solid.ByJoinedSurfaces(srfs);
+            }
+            catch(Exception)
+            {
+                return null;
+            }
+            finally
+            {
+                srfs.ForEach(x => x.Dispose());
+                srfs.Clear();
+            }
+
+            if (converted == null)
+                return null;
 
             if (performHostUnitConversion)
                 UnitConverter.ConvertToDynamoUnits(ref converted);


### PR DESCRIPTION
### Purpose

This is one part of the fix to MAGN-7931. The fix here is to catch the possible exceptions when joining surfaces and if there are exceptions, null will be returned so that the dot operations to return solids will not be broken.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@aparajit-pratap PTAL

