### PR TITLE
Updated test case using Voronoi node inside Revit

### DIFF
--- a/test/Libraries/RevitIntegrationTests/SampleTests.cs
+++ b/test/Libraries/RevitIntegrationTests/SampleTests.cs
@@ -369,13 +369,19 @@ namespace RevitSystemTests
 
             RunCurrentModel();
             var refPointNodeID = "a80c323f-7443-42fd-a38c-4a84623fdeb5";
-            AssertPreviewCount(refPointNodeID, 122);
+            AssertPreviewCount(refPointNodeID, 509);
 
             // get all Reference Points.
+            // There are 121 points and 388 lines
             for (int i = 0; i <= 120; i++)
             {
                 var point = GetPreviewValueAtIndex(refPointNodeID, i) as Point;
                 Assert.IsNotNull(point);
+            }
+            for (int i = 121; i < 509; i++)
+            {
+                var line = GetPreviewValueAtIndex(refPointNodeID, i) as Line;
+                Assert.IsNotNull(line);
             }
         }
 


### PR DESCRIPTION
### Purpose

This PR updates failing test: `RevitSystemTests.SampleTests.Tesselation_2()`. This test case now runs properly after a [recent fix] (https://github.com/DynamoDS/Dynamo/pull/5057) to `Voronoi.ByParametersOnSurface` node. Therefore this test case needed updating.

### Declarations

- [X] The code base is in a better state after this PR
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@Randy-Ma  Reviewer 1 
