### PR TITLE
Fix the failing test cases caused by invalid runtime binding

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/GeometryObjectConverter.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/GeometryObjectConverter.cs
@@ -28,7 +28,7 @@ namespace Revit.GeometryConversion
             if (geom == null) return null;
 
             dynamic dynGeom = geom;
-            Autodesk.DesignScript.Geometry.Geometry protoGeom = null;
+            dynamic protoGeom = null;
             try
             {
                 protoGeom = InternalConvert(dynGeom);
@@ -36,14 +36,28 @@ namespace Revit.GeometryConversion
             }
             catch (Exception)
             {
-                return null; 
+                return null;
             }
             finally
             {
                 // Dispose the temporary geometry that has been transformed.
                 if (protoGeom != null && transform != null)
                 {
-                    protoGeom.Dispose();
+                    if (protoGeom is Autodesk.DesignScript.Geometry.Geometry)
+                    {
+                        protoGeom.Dispose();
+                    }
+                    else if (protoGeom is IEnumerable<Autodesk.DesignScript.Geometry.Geometry>)
+                    {
+                        var geoms = protoGeom as IEnumerable<Autodesk.DesignScript.Geometry.Geometry>;
+                        foreach (var g in geoms)
+                        {
+                            if (g != null)
+                            {
+                                g.Dispose();
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Purpose

This is to fix the failing test cases introduced in:
https://github.com/DynamoDS/DynamoRevit/pull/556

The test cases are failing because which version of the function InternalConvert is called is determined at runtime. But unfortunately we are always assuming the result is a single geometry which is not correct. For those cases which are returning a collection of geometries, the assignment will fail.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@aparajit-pratap PTAL
