### PR TITLE
Adjust to return a list to fix a failing test case

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/GeometryObjectConverter.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/GeometryObjectConverter.cs
@@ -91,7 +91,7 @@ namespace Revit.GeometryConversion
         private static IEnumerable<Autodesk.DesignScript.Geometry.Geometry> Transform(IEnumerable<Autodesk.DesignScript.Geometry.Geometry> geom, CoordinateSystem coordinateSystem)
         {
             if (coordinateSystem == null) return geom;
-            return geom.Select(x => Transform(x, coordinateSystem));
+            return geom.Select(x => Transform(x, coordinateSystem)).ToList();
         }
 
         private static Autodesk.DesignScript.Geometry.Geometry Transform(Autodesk.DesignScript.Geometry.Geometry geom, CoordinateSystem coordinateSystem)


### PR DESCRIPTION
### Purpose

This is to fix one failing test case: DynamoAllSelectionNodeTests_WithPreSelectedEntities. The test case fails because elements used by dot LINQ expressions are disposed before used. The fix here will try to convert the result to list .

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@aparajit-pratap PTAL

### FYIs

@ikeough 