### PR TITLE
Fix one failing test case

### DIFF
--- a/test/Libraries/RevitIntegrationTests/DisplayTests.cs
+++ b/test/Libraries/RevitIntegrationTests/DisplayTests.cs
@@ -49,7 +49,8 @@ namespace RevitSystemTests
         void NodeRenderPackagesUpdated(NodeModel node, IEnumerable<IRenderPackage> packages)
         {
             var curvePackage = packages.FirstOrDefault(p => p.LineVertexCount > 0);
-            Assert.NotNull(curvePackage);
+            if (curvePackage == null)
+                return;
 
             var expectedColor = (Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["EdgeColor"];
             Assert.True(curvePackage.AllLineStripVerticesHaveColor(expectedColor));


### PR DESCRIPTION
### Purpose

This is to fix one failing test case. As there are many nodes in the graph and most of them won't have curve geometries, so there will be no line vertices for them. The fix here is to correct the test case by filtering out such cases.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### FYIs

@ikeough 