### PR TITLE
MAGN-8222 Sort Element.Parameters when getting a parameter by name

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -316,8 +316,15 @@ namespace Revit.Elements
         {
             object result;
 
-            var param = InternalElement.GetOrderedParameters().FirstOrDefault(x => x.Definition.Name == parameterName);
-
+            var param =
+                // We don't use Element.GetOrderedParameters(), it only returns ordered parameters
+                // as show in the UI
+                InternalElement.Parameters.Cast<Autodesk.Revit.DB.Parameter>()
+                    // Element.Parameters returns a differently ordered list on every invocation.
+                    // We must sort it to get sensible results.
+                    .OrderBy(x => x.Id.IntegerValue) 
+                    .FirstOrDefault(x => x.Definition.Name == parameterName);         
+            
             if (param == null || !param.HasValue)
                 return string.Empty;
 


### PR DESCRIPTION
### Purpose

In order to fix [MAGN-5870](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-5870), @Randy-Ma made a change to use `Element.GetOrderedParameters`. This was a sensible approach, but it turns out `GetOrderedParameters` does not return all of the `Parameter`s for an `Element`. This is from the API docs:

> The collection consists of only visible parameters associated to the element; it returns a different list than Element.Parameters.

So, we need to manually sort them, which is done in this PR. Here is the result:

![sortd](https://cloud.githubusercontent.com/assets/916345/9472116/4f92cde8-4b21-11e5-9b5b-f6c594069627.PNG)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
 - I ran the test from created to validated MAGN-5870 as well
![image](https://cloud.githubusercontent.com/assets/916345/9473707/47538c72-4b2a-11e5-9e4e-facfbda99011.png)

- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough 

### FYIs

@jnealb @RodRecker 