### PR TITLE
Fix MAGN-7647 cannot use "Select Divided Surface Families" node to select divided surface in Revit

### DIFF
--- a/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
@@ -178,6 +178,15 @@ namespace DSRevitNodesUI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No family instances found in the divided surface..
+        /// </summary>
+        internal static string NoFamilyInstancesInDividedSurfaceWarning {
+            get {
+                return ResourceManager.GetString("NoFamilyInstancesInDividedSurfaceWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No floor types available..
         /// </summary>
         internal static string NoFloorTypesAvailable {

--- a/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
@@ -276,4 +276,7 @@
   <data name="NoFloorTypesAvailable" xml:space="preserve">
     <value>No floor types available.</value>
   </data>
+  <data name="NoFamilyInstancesInDividedSurfaceWarning" xml:space="preserve">
+    <value>No family instances found in the divided surface.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodesUI/Properties/Resources.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.resx
@@ -276,4 +276,7 @@
   <data name="NoFloorTypesAvailable" xml:space="preserve">
     <value>No floor types available.</value>
   </data>
+  <data name="NoFamilyInstancesInDividedSurfaceWarning" xml:space="preserve">
+    <value>No family instances found in the divided surface.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -29,6 +29,7 @@ using UV = Autodesk.DesignScript.Geometry.UV;
 using RevitServices.EventHandler;
 using Autodesk.Revit.DB.Events;
 using Dynamo.Applications;
+using DSRevitNodesUI.Properties;
 
 namespace Dynamo.Nodes
 {
@@ -705,6 +706,16 @@ namespace Dynamo.Nodes
             return
                 RevitElementSelectionHelper<DividedSurface>.GetFamilyInstancesFromDividedSurface(
                     selection);
+        }
+
+        public override string ToString()
+        {
+            if (Selection.Any() && !SelectionResults.Any())
+            {
+                return Resources.NoFamilyInstancesInDividedSurfaceWarning;
+            }
+
+            return base.ToString();
         }
     }
 


### PR DESCRIPTION
### Purpose

A discussion with @monikaprabhu and @riteshchandawar concludes that we change the text in the node so that users will know that if there are no family instances in the divided surface.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@aparajit-pratap PTAL

### FYIs

@monikaprabhu 
@riteshchandawar 