### PR TITLE
Fix MAGN-7741 Element.OverrideColorInView fails on 2d elements(curves) in Revit

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -372,8 +372,10 @@ namespace Revit.Elements
             patternCollector.OfClass(typeof(FillPatternElement));
             FillPatternElement solidFill = patternCollector.ToElements().Cast<FillPatternElement>().First(x => x.GetFillPattern().IsSolidFill);
 
-            ogs.SetProjectionFillColor(new Autodesk.Revit.DB.Color(color.Red, color.Green, color.Blue));
+            var overrideColor = new Autodesk.Revit.DB.Color(color.Red, color.Green, color.Blue);
+            ogs.SetProjectionFillColor(overrideColor);
             ogs.SetProjectionFillPatternId(solidFill.Id);
+            ogs.SetProjectionLineColor(overrideColor);
             view.SetElementOverrides(InternalElementId, ogs);
 
             TransactionManager.Instance.TransactionTaskDone();

--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -936,6 +936,33 @@ namespace RevitSystemTests
             Assert.IsNotNull(surface);
         }
 
+        [Test]
+        [Category("RegressionTests")]
+        [TestModel(@".\empty.rvt")]
+        public void OverrideColorInView_MAGN_7741()
+        {
+            var model = ViewModel.Model;
+
+            string filePath = Path.Combine(workingDirectory, @".\Bugs\MAGN_7741.dyn");
+            string testPath = Path.GetFullPath(filePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+            AssertNoDummyNodes();
+
+            // check all the nodes and connectors are loaded
+            Assert.AreEqual(5, model.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(7, model.CurrentWorkspace.Connectors.Count());
+
+            RunCurrentModel();
+
+            string nodeID = "fd42a0e6-e256-48b6-b65b-7b2fac46af1f";
+            var curve = GetPreviewValue(nodeID) as ModelCurve;
+            Assert.IsNotNull(curve);
+
+            var settings = DocumentManager.Instance.CurrentUIDocument.ActiveView.
+                GetElementOverrides(curve.InternalElement.Id);
+            Assert.AreEqual(255, settings.ProjectionLineColor.Red);
+        }
 
         protected static IList<Autodesk.Revit.DB.CurveElement> GetAllCurveElements()
         {

--- a/test/System/Bugs/MAGN_7741.dyn
+++ b/test/System/Bugs/MAGN_7741.dyn
@@ -1,0 +1,37 @@
+<Workspace Version="0.8.3.2433" X="-24.5744178938259" Y="24.1895421708766" zoom="0.803321593462598" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Point" resolvedName="Autodesk.DesignScript.Geometry.Point" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Line" resolvedName="Autodesk.DesignScript.Geometry.Line" assemblyName="ProtoGeometry.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="a36a5bdc-8c94-41e0-9247-e5cc9a9a3de7" type="Dynamo.Nodes.DSFunction" nickname="ModelCurve.ByCurve" x="641" y="200" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="RevitNodes.dll" function="Revit.Elements.ModelCurve.ByCurve@Autodesk.DesignScript.Geometry.Curve" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="cc58400e-aea6-445c-b0a6-53cf64f7dfb1" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="184" y="196" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="pt1 = Point.ByCoordinates(0,0,0);&#xA;pt2 = Point.ByCoordinates(10,0,0);&#xA;l = Line.ByStartPointEndPoint(pt1, pt2);" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="fd42a0e6-e256-48b6-b65b-7b2fac46af1f" type="Dynamo.Nodes.DSFunction" nickname="Element.OverrideColorInView" x="906.685572227114" y="285.440099775674" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="RevitNodes.dll" function="Revit.Elements.Element.OverrideColorInView@DSCore.Color" />
+    <Dynamo.Nodes.DSFunction guid="5ccfc8e3-a0f4-45aa-ab19-0014adca314d" type="Dynamo.Nodes.DSFunction" nickname="Color.ByARGB" x="679.323714752316" y="393.2264618378" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="DSCoreNodes.dll" function="DSCore.Color.ByARGB@int,int,int,int">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+      <PortInfo index="2" default="True" />
+      <PortInfo index="3" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="d3ba9a85-83e5-4d3d-93d2-c501e1f2384b" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="449.732952577659" y="456.473295257766" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="1;&#xA;255;&#xA;0;" ShouldFocus="false" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="a36a5bdc-8c94-41e0-9247-e5cc9a9a3de7" start_index="0" end="fd42a0e6-e256-48b6-b65b-7b2fac46af1f" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="cc58400e-aea6-445c-b0a6-53cf64f7dfb1" start_index="2" end="a36a5bdc-8c94-41e0-9247-e5cc9a9a3de7" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="5ccfc8e3-a0f4-45aa-ab19-0014adca314d" start_index="0" end="fd42a0e6-e256-48b6-b65b-7b2fac46af1f" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d3ba9a85-83e5-4d3d-93d2-c501e1f2384b" start_index="0" end="5ccfc8e3-a0f4-45aa-ab19-0014adca314d" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d3ba9a85-83e5-4d3d-93d2-c501e1f2384b" start_index="1" end="5ccfc8e3-a0f4-45aa-ab19-0014adca314d" end_index="1" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d3ba9a85-83e5-4d3d-93d2-c501e1f2384b" start_index="2" end="5ccfc8e3-a0f4-45aa-ab19-0014adca314d" end_index="2" portType="0" />
+    <Dynamo.Models.ConnectorModel start="d3ba9a85-83e5-4d3d-93d2-c501e1f2384b" start_index="2" end="5ccfc8e3-a0f4-45aa-ab19-0014adca314d" end_index="3" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="18.980443855626" eyeY="16.6068296282101" eyeZ="15.2685751383585" lookX="-15.2852828740649" lookY="-15.2852828740649" lookZ="-15.2852828740649" upX="0" upY="1" upZ="0" />
+  </Cameras>
+  <SessionTraceData>
+    <NodeTraceData NodeId="a36a5bdc-8c94-41e0-9247-e5cc9a9a3de7">
+    </NodeTraceData>
+  </SessionTraceData>
+</Workspace>


### PR DESCRIPTION
### Purpose

When overriding colors, right now only face colors will be overridden. In this fix, I am making the projection lines' colors overridden as well.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] The level of testing this PR includes is appropriate

### Reviewers

@aparajit-pratap PTAL
