### PR TITLE
Changes to ExtractSelectionResults to catch exceptions

### DIFF
--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -703,9 +703,18 @@ namespace Dynamo.Nodes
         // Revit, this will cause the sub-elements to be modified.
         protected override IEnumerable<Element> ExtractSelectionResults(DividedSurface selection)
         {
-            return
-                RevitElementSelectionHelper<DividedSurface>.GetFamilyInstancesFromDividedSurface(
-                    selection);
+            IEnumerable<Element> result;
+            try
+            {
+                result = RevitElementSelectionHelper<DividedSurface>.GetFamilyInstancesFromDividedSurface(
+                            selection).ToList();
+            }
+            catch
+            {
+                result = new List<Element>();
+            }
+
+            return result;
         }
 
         public override string ToString()


### PR DESCRIPTION
### Purpose

It is found that GetFamilyInstancesFromDividedSurface may throw exception. The exception makes the text in the selection node not updated as expected. Here the exception is caught and an empty list is returned

This pull request is related to:
https://github.com/DynamoDS/DynamoRevit/pull/623

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@aparajit-pratap PTAL

