### PR TITLE
MAGN-8187 Level.ByElevationName hangs Revit 

### DIFF
--- a/src/Libraries/RevitNodes/Elements/DirectShape.cs
+++ b/src/Libraries/RevitNodes/Elements/DirectShape.cs
@@ -133,7 +133,7 @@ namespace Revit.Elements
         {
             //Phase 1 - Check to see if a DirectShape exists in trace and should be rebound
             var oldShape =
-                ElementBinder.GetElementAndTraceData<Autodesk.Revit.DB.DirectShape,DirectShapeState>();
+                ElementBinder.GetElementAndTraceData<Autodesk.Revit.DB.DirectShape,DirectShapeState>(Document);
 
             //There was a oldDirectShape, rebind to that
             if (oldShape != null)

--- a/src/Libraries/RevitNodes/Elements/DirectShape.cs
+++ b/src/Libraries/RevitNodes/Elements/DirectShape.cs
@@ -133,7 +133,7 @@ namespace Revit.Elements
         {
             //Phase 1 - Check to see if a DirectShape exists in trace and should be rebound
             var oldShape =
-                GetElementAndTraceData();
+                ElementBinder.GetElementAndTraceData<Autodesk.Revit.DB.DirectShape,DirectShapeState>();
 
             //There was a oldDirectShape, rebind to that
             if (oldShape != null)
@@ -153,7 +153,7 @@ namespace Revit.Elements
                     //we also check the material, if it's different than the currently assigned material
                     //then we need to rebuild the geo so that a new material is applied
                     //
-                    this.IntenralSetShape(shapeReference,new ElementId(material.Id),oldShape.Item2);
+                    this.IntenralSetShape(shapeReference,new ElementId(material.Id),oldShape.Item2.syncId);
                     this.InternalSetName(shapeReference,shapeName,material,category);
                     return;
                 }
@@ -442,34 +442,5 @@ namespace Revit.Elements
         { 
             return InternalDirectShape.Name;
         }
-
-        /// <summary>
-        /// Get the DirectShape Element, syncId, and materialId from Thread Local Storage
-        /// </summary>
-        /// <returns></returns>
-        protected Tuple<Autodesk.Revit.DB.DirectShape, string,int> GetElementAndTraceData()
-        {
-            var id = ElementBinder.GetRawDataFromTrace();
-            if (id == null)
-                return null;
-
-            var traceData = id as DirectShapeState;
-            if (traceData == null)
-                return null;
-
-            var elementId = traceData.IntID;
-            var uuid = traceData.StringID;
-            var materialId = traceData.materialId;
-            var syncLock = traceData.syncId;
-
-            Autodesk.Revit.DB.DirectShape ds = null;
-
-            // if we can't get the ds, return null
-            if (!Document.TryGetElement(uuid, out ds))
-                return null;
-
-            return new Tuple<Autodesk.Revit.DB.DirectShape, string,int>(ds, syncLock,materialId);
-        }
-
     }
 }

--- a/src/Libraries/RevitNodes/Elements/DirectShape.cs
+++ b/src/Libraries/RevitNodes/Elements/DirectShape.cs
@@ -153,7 +153,7 @@ namespace Revit.Elements
                     //we also check the material, if it's different than the currently assigned material
                     //then we need to rebuild the geo so that a new material is applied
                     //
-                    this.IntenralSetShape(shapeReference,new ElementId(material.Id),oldShape.Item2.syncId);
+                    this.InternalSetShape(shapeReference,new ElementId(material.Id),oldShape.Item2.syncId);
                     this.InternalSetName(shapeReference,shapeName,material,category);
                     return;
                 }
@@ -258,7 +258,7 @@ namespace Revit.Elements
         /// this method also generates tessellated geometry from the protogeometry object
         /// and sets the material of the generated Revit faces
         /// </summary>
-        private void IntenralSetShape(DesignScriptEntity shapeReference, ElementId materialId,string currentSyncId)
+        private void InternalSetShape(DesignScriptEntity shapeReference, ElementId materialId,string currentSyncId)
         {
             //if the elementID for the current directShape revitElement exists on the input Geometry AND
             //the value stored at that key is equal to the materialId we're trying to set AND

--- a/src/Libraries/RevitNodes/Elements/Level.cs
+++ b/src/Libraries/RevitNodes/Elements/Level.cs
@@ -111,7 +111,7 @@ namespace Revit.Elements
         private void InitLevel(double elevation, string name)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
-            var oldEle = ElementBinder.GetElementAndTraceData<Autodesk.Revit.DB.Level, LevelTraceData>();
+            var oldEle = ElementBinder.GetElementAndTraceData<Autodesk.Revit.DB.Level, LevelTraceData>(Document);
 
             //There was an element, bind & mutate
             if (oldEle != null)

--- a/src/Libraries/RevitNodes/Elements/Level.cs
+++ b/src/Libraries/RevitNodes/Elements/Level.cs
@@ -111,15 +111,14 @@ namespace Revit.Elements
         private void InitLevel(double elevation, string name)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
-            var oldEle =
-                GetElementAndTraceData();
+            var oldEle = ElementBinder.GetElementAndTraceData<Autodesk.Revit.DB.Level, LevelTraceData>();
 
             //There was an element, bind & mutate
             if (oldEle != null)
             {
                 InternalSetLevel(oldEle.Item1);
                 InternalSetElevation(elevation);
-                InternalSetName(oldEle.Item2,name);
+                InternalSetName(oldEle.Item2.InputName,name);
                 return;
             }
 
@@ -336,31 +335,5 @@ namespace Revit.Elements
             return string.Format("Level(Name={0}, Elevation={1})", Name, Elevation);
         }
 
-        /// <summary>
-        /// Get the Level Element, and input name from Thread Local Storage
-        /// </summary>
-        /// <returns></returns>
-        protected Tuple<Autodesk.Revit.DB.Level, string> GetElementAndTraceData()
-        {
-            var id = ElementBinder.GetRawDataFromTrace();
-            if (id == null)
-                return null;
-
-            var traceData = id as LevelTraceData;
-            if (traceData == null)
-                return null;
-
-            var elementId = traceData.IntID;
-            var uuid = traceData.StringID;
-            var name = traceData.InputName;
-
-            Autodesk.Revit.DB.Level lev = null;
-
-            // if we can't get the ds, return null
-            if (!Document.TryGetElement(uuid, out lev))
-                return null;
-
-            return new Tuple<Autodesk.Revit.DB.Level, string>(lev,name);
-        }
     }
 }

--- a/src/Libraries/RevitServices/Persistence/ElementBinder.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementBinder.cs
@@ -357,7 +357,7 @@ namespace RevitServices.Persistence
         /// Requires that K inherits from SerializableId so the element can be retrieved from the Revit Document
         /// </summary>
         /// <returns></returns>
-        public static Tuple<T, K> GetElementAndTraceData<T, K>() 
+        public static Tuple<T, K> GetElementAndTraceData<T, K>(Document document) 
             where T : Autodesk.Revit.DB.Element
             where K: SerializableId
         {
@@ -375,7 +375,7 @@ namespace RevitServices.Persistence
             var element = default(T);
             
             // if we can't get the element, return null
-            if (!DocumentManager.Instance.CurrentDBDocument.TryGetElement(uuid,out element))
+            if (!document.TryGetElement(uuid,out element))
                 return null;
 
             return new Tuple<T, K>(element,traceData);

--- a/src/Libraries/RevitServices/Persistence/ElementBinder.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementBinder.cs
@@ -357,28 +357,28 @@ namespace RevitServices.Persistence
         /// Requires that K inherits from SerializableId so the element can be retrieved from the Revit Document
         /// </summary>
         /// <returns></returns>
-        public static Tuple<T, K> GetElementAndTraceData<T, K>(Document document) 
-            where T : Autodesk.Revit.DB.Element
-            where K: SerializableId
+        public static Tuple<TElement, TId> GetElementAndTraceData<TElement, TId>(Document document)
+            where TElement : Autodesk.Revit.DB.Element
+            where TId: SerializableId
         {
             var id = ElementBinder.GetRawDataFromTrace();
             if (id == null)
                 return null;
 
-            var traceData = id as K;
+            var traceData = id as TId;
             if (traceData == null)
                 return null;
 
             var elementId = traceData.IntID;
             var uuid = traceData.StringID;
 
-            var element = default(T);
+            var element = default(TElement);
             
             // if we can't get the element, return null
             if (!document.TryGetElement(uuid,out element))
                 return null;
 
-            return new Tuple<T, K>(element,traceData);
+            return new Tuple<TElement, TId>(element, traceData);
         }
         /// <summary>
         /// This function gets the nodes which are binding with the elements which have the

--- a/test/Libraries/RevitIntegrationTests/LevelTests.cs
+++ b/test/Libraries/RevitIntegrationTests/LevelTests.cs
@@ -10,6 +10,7 @@ using RevitServices.Persistence;
 using RevitTestServices;
 
 using RTF.Framework;
+using System;
 
 namespace RevitSystemTests
 {
@@ -45,6 +46,36 @@ namespace RevitSystemTests
             levelColl.OfClass(typeof(Level));
             Assert.AreEqual(levelColl.ToElements().Count(), 11);
        }
+
+        [Test]
+        [TestModel(@".\Level\Level.rvt")]
+        public void SetAllLevelsToSameName()
+        {
+            var samplePath = Path.Combine(workingDirectory, @".\Level\SameNameLevels.dyn");
+            var testPath = Path.GetFullPath(samplePath);
+      
+            ViewModel.OpenCommand.Execute(testPath);
+
+            AssertNoDummyNodes();
+
+            //ensure that the level count is the same
+            var levelColl = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
+            levelColl.OfClass(typeof(Level));
+            Assert.AreEqual(levelColl.ToElements().Count(), 6);
+
+            //change the name and run again
+            var stringNode = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<StringInput>();
+            stringNode.Value = "aNewName";
+
+           //assert that the scheduler is empty:
+            Assert.AreEqual(0, Model.Scheduler.Tasks.Count());
+
+            //ensure that the level count is the same
+            levelColl = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
+            levelColl.OfClass(typeof(Level));
+            Assert.AreEqual(levelColl.ToElements().Count(), 6);
+            
+        }
 
         [Test]
         [Category("IntegrationTests")]

--- a/test/Libraries/RevitIntegrationTests/LevelTests.cs
+++ b/test/Libraries/RevitIntegrationTests/LevelTests.cs
@@ -47,7 +47,8 @@ namespace RevitSystemTests
             Assert.AreEqual(levelColl.ToElements().Count(), 11);
        }
 
-        [Test]
+        //this test runs in automatic to attempt to reproduce the defect in MAGN 8187
+        [Test,Ignore]
         [TestModel(@".\Level\Level.rvt")]
         public void SetAllLevelsToSameName()
         {
@@ -55,25 +56,31 @@ namespace RevitSystemTests
             var testPath = Path.GetFullPath(samplePath);
       
             ViewModel.OpenCommand.Execute(testPath);
-
             AssertNoDummyNodes();
 
             //ensure that the level count is the same
             var levelColl = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
             levelColl.OfClass(typeof(Level));
-            Assert.AreEqual(levelColl.ToElements().Count(), 6);
+            Assert.AreEqual(levelColl.ToElements().Count(),6);
+
+            var firstLevelID = levelColl.ToElementIds().First().IntegerValue;
 
             //change the name and run again
             var stringNode = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<StringInput>();
             stringNode.Value = "aNewName";
-
-           //assert that the scheduler is empty:
-            Assert.AreEqual(0, Model.Scheduler.Tasks.Count());
-
-            //ensure that the level count is the same
+            
+            //ensure that the first level has new name
             levelColl = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
             levelColl.OfClass(typeof(Level));
-            Assert.AreEqual(levelColl.ToElements().Count(), 6);
+            Assert.AreEqual(levelColl.ToElements().First().Name,"aNewName");
+            Assert.AreEqual(levelColl.ToElements().Last().Name, "aNewName(5)");
+
+            var firstLevelIDModified = levelColl.ToElementIds().First().IntegerValue;
+
+            //assert that the elementId of the first level is unchanged... and rebinding has succeeded.
+            //while this is true... currently this test throws exceptions during nodeModified runs
+            //so the infinite loop would not occur even before the fix, so I have marked the test ignore.
+            Assert.AreEqual(firstLevelID, firstLevelIDModified);
             
         }
 

--- a/test/System/Level/SameNameLevels.dyn
+++ b/test/System/Level/SameNameLevels.dyn
@@ -1,0 +1,21 @@
+<Workspace Version="0.8.3.2466" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Nodes.DSFunction guid="786257d8-230f-4bfb-9d3f-606e6958e6f4" type="Dynamo.Nodes.DSFunction" nickname="Level.ByElevationAndName" x="535" y="222" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="RevitNodes.dll" function="Revit.Elements.Level.ByElevationAndName@double,string" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="964b7d41-442a-44ad-8c84-0e7a244ed101" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="170" y="168" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="1..6;" ShouldFocus="false" />
+    <Dynamo.Nodes.StringInput guid="e45c9f6b-1502-4cdd-98b6-2b441225256d" type="Dynamo.Nodes.StringInput" nickname="String" x="189" y="282.5" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
+      <System.String>steve</System.String>
+      <System.String value="steve" />
+    </Dynamo.Nodes.StringInput>
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="964b7d41-442a-44ad-8c84-0e7a244ed101" start_index="0" end="786257d8-230f-4bfb-9d3f-606e6958e6f4" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="e45c9f6b-1502-4cdd-98b6-2b441225256d" start_index="0" end="786257d8-230f-4bfb-9d3f-606e6958e6f4" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

The issue in this task http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8187 was found to be occurring because element rebinding would cause an infinite loop in run automatic when updating the name of the revit levels.

We currently update Revit level names so they do not have the same name, i.e.. an input of level produces level, level(1) level(2) etc... when this modified name is compared to the original input name, they are different so another modification occurs... causing the loop.

instead of finding all string comparison edge cases that can occur with various user input of names which could contain "()" or other inputs which make it difficult or impossible to tell if the name is a modified name or not, I think the more robust fix is to use the raw trace mechanism.

We store the desired input name (the string that was the input argument to the node) inside trace when the name is updated. Later when rebinding occurs we compare our input name for the new run, to the original name in trace and do not update the level name, if these are the same.

Since the method for getting the raw trace data and revit element out of raw trace was almost identical to the method for DirectShape I replaced both of these with a generic method inside ElementBinder.


#### Testing... 
I have been unable to find a mechanism to test this rebinding issue with Levels or DirectShapes, and it appears that the same exception is being thrown here that prevented testing of directShape rebinding. 

As far as I can tell when `onNodeModifed` events occur on Revit Constructor nodes, and attempt to start transactions in Revit System Tests, an exception is thrown from the revit API that the document cannot be modified when attempting to start a transaction, and instead the elements are not further modified... this stops the test from running in an infinite loop so it's unclear if our tests can currently catch this defect on any revit wrapper type.

I've included one test that passes, but marked it ignore because it passes before the fix as well, due to the issue mentioned above.

@ikeough explained that the Revit Test Framework runs in a different manner than during normal application use and this may be related to this issue. I think we should create a task around hardening / investigating this issue if possible, preferably someone familiar with the difference between RTF runs and regular DynamoRevit runs.

**At this time I'm unsure how to test this form of defect.**

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ikeough 

### FYIs
@Randy-Ma 
@mccrone 