### PR TITLE
Direct shape.byMesh does not support non-planar quads

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
@@ -143,13 +143,13 @@ namespace Revit.GeometryConversion
                 if (f.Count > 3)
                 {
                     //test if the face is a planar...
-                    var BACNormal = Vector.ByTwoPoints(currentVerts[1], currentVerts[0]).Cross(Vector.ByTwoPoints(currentVerts[1], currentVerts[2])).Normalized();
+                    var CABnormal = Vector.ByTwoPoints(currentVerts[2], currentVerts[0]).Cross(Vector.ByTwoPoints(currentVerts[2], currentVerts[1])).Normalized();
                     var DACNormal = Vector.ByTwoPoints(currentVerts[3], currentVerts[0]).Cross(Vector.ByTwoPoints(currentVerts[3], currentVerts[2])).Normalized();
 
                     //if the two triangle normals are not parallel then we have a non planar quad
                     //and we'll skip adding this face and instead add two new faces to list to process
                     //these new faces are two triangles representing the quad
-                    if (Math.Abs(BACNormal.Dot(DACNormal) - 1) > 0.000001 ||
+                    if (Math.Abs(CABnormal.Dot(DACNormal) - 1) > 0.000001 ||
                         //or if there are any self intersections between non 
                         //contigous polygon edges we also triangulate, this finds a twisted quad
                         QuadSelfIntersects(currentVerts)

--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
@@ -93,8 +93,8 @@ namespace Revit.GeometryConversion
             var result = tsb.Build(target, fallback, ElementId.InvalidElementId);
             return result.GetGeometricalObjects();
         }
-       
-        //this method checks intersections between non contigous edges of a quad for self intersection
+
+        //this method checks intersections between non contiguous edges of a quad for self intersection
         private static bool QuadSelfIntersects(List<Autodesk.DesignScript.Geometry.Point> quadVerts)
         {
             var AB = Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint(quadVerts[0], quadVerts[1]);
@@ -142,7 +142,7 @@ namespace Revit.GeometryConversion
                 }
                 if (f.Count > 3)
                 {
-                    //test if the face is a planar...
+                    //test if the face is a planar by comparing the cross products (normals) of two tri edges
                     var CABnormal = Vector.ByTwoPoints(currentVerts[2], currentVerts[0]).Cross(Vector.ByTwoPoints(currentVerts[2], currentVerts[1])).Normalized();
                     var DACNormal = Vector.ByTwoPoints(currentVerts[3], currentVerts[0]).Cross(Vector.ByTwoPoints(currentVerts[3], currentVerts[2])).Normalized();
 
@@ -151,7 +151,7 @@ namespace Revit.GeometryConversion
                     //these new faces are two triangles representing the quad
                     if (Math.Abs(CABnormal.Dot(DACNormal) - 1) > 0.000001 ||
                         //or if there are any self intersections between non 
-                        //contigous polygon edges we also triangulate, this finds a twisted quad
+                        //contiguous polygon edges we also triangulate, this finds a twisted quad which is planar
                         QuadSelfIntersects(currentVerts)
                         )
                     {

--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
@@ -108,7 +108,7 @@ namespace Revit.GeometryConversion
             var tsb = new TessellatedShapeBuilder();
             tsb.OpenConnectedFaceSet(false);
 
-            for (int faceindex = 0; faceindex < indices.Count(); faceindex++)
+            for (int faceindex = 0, count = indices.Count(); faceindex < count; faceindex++)
             {
                 var f = indices[faceindex];
                 //if this is a quad face triangulate it
@@ -118,12 +118,12 @@ namespace Revit.GeometryConversion
                     var tri1 = IndexGroup.ByIndices(f.B, f.C, f.A);
                     var tri2 = IndexGroup.ByIndices(f.A, f.C, f.D);
 
-                    AddProtoFaceToTSB(tsb, tri1, verts, performHostUnitConversion, MaterialId);
-                    AddProtoFaceToTSB(tsb, tri2, verts, performHostUnitConversion, MaterialId);
+                    AddFace(tsb, tri1, verts, performHostUnitConversion, MaterialId);
+                    AddFace(tsb, tri2, verts, performHostUnitConversion, MaterialId);
                 }
                 else
                 {
-                    AddProtoFaceToTSB(tsb, f, verts, performHostUnitConversion, MaterialId);
+                    AddFace(tsb, f, verts, performHostUnitConversion, MaterialId);
                 }
             }
 
@@ -139,10 +139,17 @@ namespace Revit.GeometryConversion
             return result.GetGeometricalObjects();
         }
 
-        //this method converts a proto indexGroup and verts to a tessellated face, and adds it
-        //to the tessellated shape builder that is passed in.
-        //the verts array should be the entire vert array extracted from a proto mesh.
-        private static void AddProtoFaceToTSB(TessellatedShapeBuilder tsb,
+        /// <summary>
+        /// this method converts a ProtoGeometry IndexGroup and Points to a Revit tessellated face, and adds it
+        //  to the TessellatedShape Builder that is passed in.
+        /// </summary>
+        /// <param name="tsb">a Revit TessellatedShapeBuilder which we wish to add a face to </param>
+        /// <param name="f"> a ProtoGeometry indexGroup defining a Mesh face</param>
+        /// <param name="meshVerts">a vertex array of Points which should be the 
+        /// entire vertex array extracted from a ProtoGeometry Mesh.</param>
+        /// <param name="performHostUnitConversion">a Bool which enables host unit conversion scaling</param>
+        /// <param name="materialId">an ElementId represnting the Material we want to apply to this face</param>
+        private static void AddFace(TessellatedShapeBuilder tsb,
             IndexGroup f,
             Autodesk.DesignScript.Geometry.Point[] meshVerts,
             bool performHostUnitConversion,

--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
@@ -5,10 +5,9 @@ using Autodesk.DesignScript.Interfaces;
 using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 using Dynamo;
-using Dynamo.Engine;
 
 using RevitServices.Materials;
-using RevitServices.Persistence;
+using Autodesk.DesignScript.Geometry;
 
 namespace Revit.GeometryConversion
 {
@@ -94,6 +93,26 @@ namespace Revit.GeometryConversion
             var result = tsb.Build(target, fallback, ElementId.InvalidElementId);
             return result.GetGeometricalObjects();
         }
+       
+        //this method checks intersections between non contigous edges of a quad for self intersection
+        private static bool QuadSelfIntersects(List<Autodesk.DesignScript.Geometry.Point> quadVerts)
+        {
+            var AB = Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint(quadVerts[0], quadVerts[1]);
+            var BC = Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint(quadVerts[1], quadVerts[2]);
+            var CD = Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint(quadVerts[2], quadVerts[3]);
+            var DA = Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint(quadVerts[3], quadVerts[0]);
+
+            if (AB.DoesIntersect(CD))
+            {
+                return true;
+            }
+
+            if (BC.DoesIntersect(DA))
+            {
+                return true;
+            }
+            return false;
+        }
 
         public static IList<GeometryObject> ToRevitType(
             this Autodesk.DesignScript.Geometry.Mesh mesh,
@@ -104,15 +123,15 @@ namespace Revit.GeometryConversion
         {
          
             var verts = mesh.VertexPositions;
-            var indicies = mesh.FaceIndices;
+            var indicies = mesh.FaceIndices.ToList();
 
             var currentVerts = new List<Autodesk.DesignScript.Geometry.Point>();
             var tsb = new TessellatedShapeBuilder();
             tsb.OpenConnectedFaceSet(false);
 
-            foreach (var f in indicies)
+            for(int faceindex = 0; faceindex<indicies.Count();faceindex++)
             {
-
+                var f = indicies[faceindex];
                 currentVerts.Clear();
                 var currentIndicies = new List<uint>() { f.A, f.B, f.C, f.D };
                 for (int i = 0; i < f.Count; i++)
@@ -121,7 +140,27 @@ namespace Revit.GeometryConversion
 
                     currentVerts.Add(verts[currentindex]);
                 }
+                if (f.Count > 3)
+                {
+                    //test if the face is a planar...
+                    var BACNormal = Vector.ByTwoPoints(currentVerts[1], currentVerts[0]).Cross(Vector.ByTwoPoints(currentVerts[1], currentVerts[2])).Normalized();
+                    var DACNormal = Vector.ByTwoPoints(currentVerts[3], currentVerts[0]).Cross(Vector.ByTwoPoints(currentVerts[3], currentVerts[2])).Normalized();
 
+                    //if the two triangle normals are not parallel then we have a non planar quad
+                    //and we'll skip adding this face and instead add two new faces to list to process
+                    //these new faces are two triangles representing the quad
+                    if (Math.Abs(BACNormal.Dot(DACNormal) - 1) > 0.000001 ||
+                        //or if there are any self intersections between non 
+                        //contigous polygon edges we also triangulate, this finds a twisted quad
+                        QuadSelfIntersects(currentVerts)
+                        )
+                    {
+                        indicies.Add(IndexGroup.ByIndices(f.B, f.C, f.A));
+                        indicies.Add(IndexGroup.ByIndices(f.A, f.C, f.D));
+                        continue;
+                    }
+                }
+              
                 //convert all the points to Revit XYZ vectors and perform unit conversion here
                 var xyzs = currentVerts.Select(x => x.ToXyz(performHostUnitConversion)).ToList();
 

--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
@@ -45,7 +45,7 @@ namespace Revit.GeometryConversion
                 var b = new XYZ(v[i + 3], v[i + 4], v[i + 5]);
                 var c = new XYZ(v[i + 6], v[i + 7], v[i + 8]);
 
-                var face = new TessellatedFace(new List<XYZ>() { a, b, c },  MaterialId != null ? MaterialId : MaterialsManager.Instance.DynamoMaterialId);
+                var face = new TessellatedFace(new List<XYZ>() { a, b, c }, MaterialId != null ? MaterialId : MaterialsManager.Instance.DynamoMaterialId);
                 tsb.AddFace(face);
             }
 
@@ -94,26 +94,6 @@ namespace Revit.GeometryConversion
             return result.GetGeometricalObjects();
         }
 
-        //this method checks intersections between non contiguous edges of a quad for self intersection
-        private static bool QuadSelfIntersects(List<Autodesk.DesignScript.Geometry.Point> quadVerts)
-        {
-            var AB = Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint(quadVerts[0], quadVerts[1]);
-            var BC = Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint(quadVerts[1], quadVerts[2]);
-            var CD = Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint(quadVerts[2], quadVerts[3]);
-            var DA = Autodesk.DesignScript.Geometry.Line.ByStartPointEndPoint(quadVerts[3], quadVerts[0]);
-
-            if (AB.DoesIntersect(CD))
-            {
-                return true;
-            }
-
-            if (BC.DoesIntersect(DA))
-            {
-                return true;
-            }
-            return false;
-        }
-
         public static IList<GeometryObject> ToRevitType(
             this Autodesk.DesignScript.Geometry.Mesh mesh,
              TessellatedShapeBuilderTarget target = TessellatedShapeBuilderTarget.Mesh,
@@ -121,55 +101,42 @@ namespace Revit.GeometryConversion
              ElementId MaterialId = null,
             bool performHostUnitConversion = true)
         {
-         
+
             var verts = mesh.VertexPositions;
-            var indicies = mesh.FaceIndices.ToList();
+            var indices = mesh.FaceIndices.ToList();
 
             var currentVerts = new List<Autodesk.DesignScript.Geometry.Point>();
             var tsb = new TessellatedShapeBuilder();
             tsb.OpenConnectedFaceSet(false);
 
-            for(int faceindex = 0; faceindex<indicies.Count();faceindex++)
+            for (int faceindex = 0; faceindex < indices.Count(); faceindex++)
             {
-                var f = indicies[faceindex];
+                var f = indices[faceindex];
                 currentVerts.Clear();
-                var currentIndicies = new List<uint>() { f.A, f.B, f.C, f.D };
-                for (int i = 0; i < f.Count; i++)
-                {
-                    var currentindex = Convert.ToInt32(currentIndicies[i]);
+                var currentIndices = new List<uint>() { f.A, f.B, f.C, f.D };
 
-                    currentVerts.Add(verts[currentindex]);
-                }
+                //if this is a quad face triangulate it and skip the rest of this loop
                 if (f.Count > 3)
                 {
-                    //test if the face is a planar by comparing the cross products (normals) of two tri edges
-                    var CABnormal = Vector.ByTwoPoints(currentVerts[2], currentVerts[0]).Cross(Vector.ByTwoPoints(currentVerts[2], currentVerts[1])).Normalized();
-                    var DACNormal = Vector.ByTwoPoints(currentVerts[3], currentVerts[0]).Cross(Vector.ByTwoPoints(currentVerts[3], currentVerts[2])).Normalized();
-
-                    //if the two triangle normals are not parallel then we have a non planar quad
-                    //and we'll skip adding this face and instead add two new faces to list to process
-                    //these new faces are two triangles representing the quad
-                    if (Math.Abs(CABnormal.Dot(DACNormal) - 1) > 0.000001 ||
-                        //or if there are any self intersections between non 
-                        //contiguous polygon edges we also triangulate, this finds a twisted quad which is planar
-                        QuadSelfIntersects(currentVerts)
-                        )
-                    {
-                        indicies.Add(IndexGroup.ByIndices(f.B, f.C, f.A));
-                        indicies.Add(IndexGroup.ByIndices(f.A, f.C, f.D));
-                        continue;
-                    }
+                    indices.Add(IndexGroup.ByIndices(f.B, f.C, f.A));
+                    indices.Add(IndexGroup.ByIndices(f.A, f.C, f.D));
+                    continue;
                 }
-              
+
+                for (int i = 0; i < f.Count; i++)
+                {
+                    var currentindex = Convert.ToInt32(currentIndices[i]);
+                    currentVerts.Add(verts[currentindex]);
+                }
                 //convert all the points to Revit XYZ vectors and perform unit conversion here
                 var xyzs = currentVerts.Select(x => x.ToXyz(performHostUnitConversion)).ToList();
 
-                var face = new TessellatedFace(xyzs, MaterialId != null ? MaterialId :MaterialsManager.Instance.DynamoMaterialId );
+                var face = new TessellatedFace(xyzs, MaterialId != null ? MaterialId : MaterialsManager.Instance.DynamoMaterialId);
                 tsb.AddFace(face);
             }
 
             tsb.CloseConnectedFaceSet();
-          
+
             var result = tsb.Build(target, fallback, ElementId.InvalidElementId);
 
             foreach (IDisposable vert in verts)

--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
@@ -103,7 +103,8 @@ namespace Revit.GeometryConversion
         {
 
             var verts = mesh.VertexPositions;
-            var indices = mesh.FaceIndices.ToList();
+            var indices = mesh.FaceIndices;
+            var finalIndices = new List<IndexGroup>();
 
             var currentVerts = new List<Autodesk.DesignScript.Geometry.Point>();
             var tsb = new TessellatedShapeBuilder();
@@ -112,16 +113,23 @@ namespace Revit.GeometryConversion
             for (int faceindex = 0; faceindex < indices.Count(); faceindex++)
             {
                 var f = indices[faceindex];
-                currentVerts.Clear();
-                var currentIndices = new List<uint>() { f.A, f.B, f.C, f.D };
-
-                //if this is a quad face triangulate it and skip the rest of this loop
+                //if this is a quad face triangulate it
                 if (f.Count > 3)
                 {
-                    indices.Add(IndexGroup.ByIndices(f.B, f.C, f.A));
-                    indices.Add(IndexGroup.ByIndices(f.A, f.C, f.D));
-                    continue;
+                    finalIndices.Add(IndexGroup.ByIndices(f.B, f.C, f.A));
+                    finalIndices.Add(IndexGroup.ByIndices(f.A, f.C, f.D));
                 }
+                else
+                {
+                    finalIndices.Add(f);
+                }
+            }
+
+            for (int faceindex = 0; faceindex < finalIndices.Count(); faceindex++)
+            {
+                var f = finalIndices[faceindex];
+                currentVerts.Clear();
+                var currentIndices = new List<uint>() { f.A, f.B, f.C, f.D };
 
                 for (int i = 0; i < f.Count; i++)
                 {

--- a/test/Libraries/RevitNodesTests/Elements/DirectShapeTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DirectShapeTests.cs
@@ -188,6 +188,33 @@ namespace RevitNodesTests.Elements
 
         [Test]
         [TestModel(@".\empty.rfa")]
+        public void ByMeshNameCategoryMaterial_TriWith4PointsPlanarForms()
+        {
+
+            var p1 = Point.ByCoordinates(0.0, 0.0, 0.0);
+            var p2 = Point.ByCoordinates(2.5, 0.0, 0.0);
+            var p3 = Point.ByCoordinates(5.0, 0.0, 0.0);
+            var p4 = Point.ByCoordinates(0.0, 5.0, 0.0);
+
+            var index1 = IndexGroup.ByIndices(0, 1, 2, 3);
+
+            var mesh = Mesh.ByPointsFaceIndices(new List<Point>() { p1, p2, p3, p4 }, new List<IndexGroup>() { index1 });
+            var mat = DocumentManager.Instance.ElementsOfType<Autodesk.Revit.DB.Material>().First();
+
+            var ds = DirectShape.ByMesh(mesh, Category.ByName("OST_GenericModel"), Material.ByName(mat.Name), "a mesh");
+
+            Assert.NotNull(ds);
+            Assert.AreEqual("a mesh", ds.Name);
+            Assert.AreEqual((mesh.Tags.LookupTag(ds.InternalElement.Id.ToString()) as DirectShapeState).materialId, mat.Id.IntegerValue);
+            //make sure a mesh comes back into Dynamo - for some reason we cannot query the mesh api for quad face even though Revit does not
+            //draw it as two triangles, the mesh reports it has two tris.
+            Assert.AreEqual(1, ds.Geometry().Count());
+
+            mesh.Dispose();
+        }
+
+        [Test]
+        [TestModel(@".\empty.rfa")]
         public void ByMeshNameCategoryMaterial_QuadNonPlanar()
         {
 


### PR DESCRIPTION
### Purpose
It was found that the method for converting from Dynamo Meshes to Revit Meshes using the TessellatedShapeBuilder failed when the Dynamo mesh was built with quads and those quads were non planar. The TessellatedShapeBuilder does not support non planar quads, but it does support quads.

~~To fix the issue we look for quad faces in the Dynamo mesh that are non planar by comparing the normals of two triangles defined by quad vertices. If the normals are not parallel than we skip adding the quad and instead add two triangles to the tessellated shape builder that represent this quad.~~

~~We also check for one case where the quad is planar but twisted by checking the quad for self intersections.~~

Instead we just triangulate all quads when converting from a  Proto Mesh to Revit Mesh

http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8322

<img width="986" alt="screen shot 2015-09-10 at 2 28 00 pm" src="https://cloud.githubusercontent.com/assets/508936/9797248/29241f64-57c8-11e5-91f1-106f4448a3a0.png">

![screen shot 2015-09-09 at 4 16 49 pm](https://cloud.githubusercontent.com/assets/508936/9797229/10dea258-57c8-11e5-912e-5f379a7ce5db.png)

<img width="720" alt="screen shot 2015-09-10 at 2 33 11 pm" src="https://cloud.githubusercontent.com/assets/508936/9797400/e91051d0-57c8-11e5-97a2-ddb03b3bdbd4.png">


### Testing
I've added tests for the above pictured cases and a simple non planar quad with one point out of plane.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate

### Reviewers

@pboyer 

### FYIs
@jnealb 
@Randy-Ma 