### PR TITLE
disable raw trace writing when the element binder is turned off(in RevitNodeTests)

### DIFF
--- a/src/Libraries/RevitServices/Persistence/ElementBinder.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementBinder.cs
@@ -340,6 +340,7 @@ namespace RevitServices.Persistence
         /// <param name="data"></param>
         public static void SetRawDataForTrace(ISerializable data)
         {
+            if (!IsEnabled) return;
             TraceUtils.SetTraceData(REVIT_TRACE_ID, data);
         }
 

--- a/test/Libraries/RevitNodesTests/Elements/DirectShapeTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DirectShapeTests.cs
@@ -134,7 +134,9 @@ namespace RevitNodesTests.Elements
             var dsSurf = DirectShape.ByGeometry(surf, Category.ByName("OST_GenericModel"), Material.ByName(mat.Name), "a surf");
             BoundingBoxCentroid(ds).DistanceTo(BoundingBoxCentroid(dsSurf)).ShouldBeApproximately(0);
 
-            (ds.Geometry().First() as Surface).Area.ShouldDifferByLessThanPercentage((dsSurf.Geometry().First() as Surface).Area, ApproximateAssertExtensions.Epsilon);
+            Surface.ByPerimeterPoints((ds.Geometry().First() as Mesh).VertexPositions).Area.ShouldDifferByLessThanPercentage(
+                (dsSurf.Geometry().First() as Surface).Area, ApproximateAssertExtensions.Epsilon);
+
 
             mesh.Dispose();
             surf.Dispose();


### PR DESCRIPTION
### Purpose

This PR fixes two failing tests, these tests fail because they use levels that now use ``SetRawTrace`` instead of ``SetElementForTrace``.

``SetRawTrace`` did not check if the element binder was turned off before writing into trace so rebinding was occurring during testing which was causing the issue with these tests as they both try to create multiple levels but the level was being mutated instead.

@lukechurch @Randy-Ma is there a reason that setRawTrace did not have this check for the element Binder being enabled? Is it known if this was intentional?

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate

### Reviewers

@lukechurch -

### FYIs

@Randy-Ma 