### PR TITLE
Add support for structural plan views. (corrected)

### DIFF
--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -167,6 +167,10 @@ namespace Revit.Elements
             {
                 return FloorPlanView.FromExisting(view, isRevitOwned);
             }
+            else if (view.ViewType == ViewType.EngineeringPlan)
+            {
+                return StructuralPlanView.FromExisting(view, isRevitOwned);
+            }
             else
             {
                 // unknown type of plan view, just wrap as unknown

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -159,13 +159,13 @@ namespace Revit.Elements
 
         public static Element Wrap(Autodesk.Revit.DB.ViewPlan view, bool isRevitOwned)
         {
-            switch (view.ViewType.ToString())
+            switch (view.ViewType)
             {
-                case "CeilingPlan":
+                case ViewType.CeilingPlan:
                     return CeilingPlanView.FromExisting(view, isRevitOwned);
-                case "FloorPlan":
+                case ViewType.FloorPlan:
                     return CeilingPlanView.FromExisting(view, isRevitOwned);
-                case "EngineeringPlan":
+                case ViewType.EngineeringPlan:
                     return StructuralPlanView.FromExisting(view, isRevitOwned);
                 default:
                     return UnknownElement.FromExisting(view, true);

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -159,22 +159,16 @@ namespace Revit.Elements
 
         public static Element Wrap(Autodesk.Revit.DB.ViewPlan view, bool isRevitOwned)
         {
-            if (view.ViewType == ViewType.CeilingPlan)
+            switch (view.ViewType.ToString())
             {
-                return CeilingPlanView.FromExisting(view, isRevitOwned);
-            }
-            else if (view.ViewType == ViewType.FloorPlan)
-            {
-                return FloorPlanView.FromExisting(view, isRevitOwned);
-            }
-            else if (view.ViewType == ViewType.EngineeringPlan)
-            {
-                return StructuralPlanView.FromExisting(view, isRevitOwned);
-            }
-            else
-            {
-                // unknown type of plan view, just wrap as unknown
-                return UnknownElement.FromExisting(view, true);
+                case "CeilingPlan":
+                    return CeilingPlanView.FromExisting(view, isRevitOwned);
+                case "FloorPlan":
+                    return CeilingPlanView.FromExisting(view, isRevitOwned);
+                case "EngineeringPlan":
+                    return StructuralPlanView.FromExisting(view, isRevitOwned);
+                default:
+                    return UnknownElement.FromExisting(view, true);
             }
         }
 

--- a/src/Libraries/RevitNodes/Elements/Views/StructuralPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/StructuralPlanView.cs
@@ -1,84 +1,107 @@
 using System;
+
 using Autodesk.Revit.DB;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
+
 namespace Revit.Elements.Views
 {
-/// <summary>
-/// A Revit ViewPlan
-/// </summary>
-[DynamoServices.RegisterForTrace]
-public class StructuralPlanView : PlanView
-{
-#region Private constructors
-/// <summary>
-/// Private constructor
-/// </summary>
-private StructuralPlanView(Autodesk.Revit.DB.ViewPlan view)
-{
-SafeInit(() => InitStructuralPlanView(view));
-}
-/// <summary>
-/// Private constructor
-/// </summary>
-private StructuralPlanView(Autodesk.Revit.DB.Level level)
-{
-SafeInit(() => InitStructuralPlanView(level));
-}
-#endregion
-#region Helpers for private constructors
-/// <summary>
-/// Initialize a StructuralPlanView element
-/// </summary>
-private void InitStructuralPlanView(Autodesk.Revit.DB.ViewPlan view)
-{
-InternalSetPlanView(view);
-}
-/// <summary>
-/// Initialize a StructuralPlanView element
-/// </summary>
-private void InitStructuralPlanView(Autodesk.Revit.DB.Level level)
-{
-TransactionManager.Instance.EnsureInTransaction(Document);
-var vd = CreatePlanView(level, ViewFamily.CeilingPlan);
-InternalSetPlanView(vd);
-TransactionManager.Instance.TransactionTaskDone();
-ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
-}
-#endregion
-#region Public static constructors
-/// <summary>
-/// Create a Revit Structural Plan at a given Level
-/// </summary>
-/// <param name="level"></param>
-/// <returns></returns>
-public static StructuralPlanView ByLevel(Level level)
-{
-if (level == null)
-{
-throw new ArgumentNullException("level");
-}
-return new StructuralPlanView(level.InternalLevel);
-}
-#endregion
-#region Internal methods
-/// <summary>
-/// Create from existing Element
-/// </summary>
-/// <param name="plan"></param>
-/// <param name="isRevitOwned"></param>
-/// <returns></returns>
-internal static StructuralPlanView FromExisting(Autodesk.Revit.DB.ViewPlan plan, bool isRevitOwned)
-{
-if (plan == null)
-{
-throw new ArgumentNullException("plan");
-}
-return new StructuralPlanView(plan)
-{
-IsRevitOwned = isRevitOwned
-};
-}
-#endregion
-}
+    /// <summary>
+    /// A Revit ViewPlan
+    /// </summary>
+    [DynamoServices.RegisterForTrace]
+    public class StructuralPlanView : PlanView
+    {
+
+        #region Private constructors
+
+        /// <summary>
+        /// Private constructor
+        /// </summary>
+        private StructuralPlanView(Autodesk.Revit.DB.ViewPlan view)
+        {
+            SafeInit(() => InitStructuralPlanView(view));
+        }
+
+        /// <summary>
+        /// Private constructor
+        /// </summary>
+        private StructuralPlanView(Autodesk.Revit.DB.Level level)
+        {
+            SafeInit(() => InitStructuralPlanView(level));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a StructuralPlanView element
+        /// </summary>
+        private void InitStructuralPlanView(Autodesk.Revit.DB.ViewPlan view)
+        {
+            InternalSetPlanView(view);
+        }
+
+        /// <summary>
+        /// Initialize a StructuralPlanView element
+        /// </summary>
+        private void InitStructuralPlanView(Autodesk.Revit.DB.Level level)
+        {
+            TransactionManager.Instance.EnsureInTransaction(Document);
+
+            var vd = CreatePlanView(level, ViewFamily.StructuralPlan);
+
+            InternalSetPlanView(vd);
+
+            TransactionManager.Instance.TransactionTaskDone();
+
+            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+        }
+
+        #endregion
+
+        #region Public static constructors
+
+        /// <summary>
+        /// Create a Revit Structural Plan at a given Level
+        /// </summary>
+        /// <param name="level"></param>
+        /// <returns></returns>
+        public static StructuralPlanView ByLevel(Level level)
+        {
+            if (level == null)
+            {
+                throw new ArgumentNullException("level");
+            }
+
+            return new StructuralPlanView(level.InternalLevel);
+        }
+
+        #endregion
+
+        #region Internal methods
+
+        /// <summary>
+        /// Create from existing Element
+        /// </summary>
+        /// <param name="plan"></param>
+        /// <param name="isRevitOwned"></param>
+        /// <returns></returns>
+        internal static StructuralPlanView FromExisting(Autodesk.Revit.DB.ViewPlan plan, bool isRevitOwned)
+        {
+            if (plan == null)
+            {
+                throw new ArgumentNullException("plan");
+            }
+
+            return new StructuralPlanView(plan)
+            {
+                IsRevitOwned = isRevitOwned
+            };
+        }
+
+        #endregion
+
+    }
 }

--- a/src/Libraries/RevitNodes/Elements/Views/StructuralPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/StructuralPlanView.cs
@@ -1,0 +1,84 @@
+using System;
+using Autodesk.Revit.DB;
+using RevitServices.Persistence;
+using RevitServices.Transactions;
+namespace Revit.Elements.Views
+{
+/// <summary>
+/// A Revit ViewPlan
+/// </summary>
+[DynamoServices.RegisterForTrace]
+public class StructuralPlanView : PlanView
+{
+#region Private constructors
+/// <summary>
+/// Private constructor
+/// </summary>
+private StructuralPlanView(Autodesk.Revit.DB.ViewPlan view)
+{
+SafeInit(() => InitStructuralPlanView(view));
+}
+/// <summary>
+/// Private constructor
+/// </summary>
+private StructuralPlanView(Autodesk.Revit.DB.Level level)
+{
+SafeInit(() => InitStructuralPlanView(level));
+}
+#endregion
+#region Helpers for private constructors
+/// <summary>
+/// Initialize a StructuralPlanView element
+/// </summary>
+private void InitStructuralPlanView(Autodesk.Revit.DB.ViewPlan view)
+{
+InternalSetPlanView(view);
+}
+/// <summary>
+/// Initialize a StructuralPlanView element
+/// </summary>
+private void InitStructuralPlanView(Autodesk.Revit.DB.Level level)
+{
+TransactionManager.Instance.EnsureInTransaction(Document);
+var vd = CreatePlanView(level, ViewFamily.CeilingPlan);
+InternalSetPlanView(vd);
+TransactionManager.Instance.TransactionTaskDone();
+ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+}
+#endregion
+#region Public static constructors
+/// <summary>
+/// Create a Revit Structural Plan at a given Level
+/// </summary>
+/// <param name="level"></param>
+/// <returns></returns>
+public static StructuralPlanView ByLevel(Level level)
+{
+if (level == null)
+{
+throw new ArgumentNullException("level");
+}
+return new StructuralPlanView(level.InternalLevel);
+}
+#endregion
+#region Internal methods
+/// <summary>
+/// Create from existing Element
+/// </summary>
+/// <param name="plan"></param>
+/// <param name="isRevitOwned"></param>
+/// <returns></returns>
+internal static StructuralPlanView FromExisting(Autodesk.Revit.DB.ViewPlan plan, bool isRevitOwned)
+{
+if (plan == null)
+{
+throw new ArgumentNullException("plan");
+}
+return new StructuralPlanView(plan)
+{
+IsRevitOwned = isRevitOwned
+};
+}
+#endregion
+}
+}

--- a/src/Libraries/RevitNodes/Elements/Views/StructuralPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/StructuralPlanView.cs
@@ -64,10 +64,10 @@ namespace Revit.Elements.Views
         #region Public static constructors
 
         /// <summary>
-        /// Create a Revit Structural Plan at a given Level
+        /// Create a Structural Plan View at the given Level.
         /// </summary>
-        /// <param name="level"></param>
-        /// <returns></returns>
+        /// <param name="level">The Level on which the StructuralPlanView is based.</param>
+        /// <returns>A StructuralPlanView if successful.</returns>
         public static StructuralPlanView ByLevel(Level level)
         {
             if (level == null)

--- a/src/Libraries/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/RevitNodes/RevitNodes.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Elements\Views\Packing\CygonRectanglePacker.cs" />
     <Compile Include="Elements\Views\AxonometricView.cs" />
     <Compile Include="Elements\Views\CeilingPlanView.cs" />
+    <Compile Include="Elements\Views\StructuralPlanView.cs" />
     <Compile Include="Elements\Views\PerspectiveView.cs" />
     <Compile Include="Elements\Form.cs" />
     <Compile Include="Elements\SketchPlane.cs" />

--- a/test/Libraries/RevitNodesTests/Elements/Views/StructuralPlanViewTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/Views/StructuralPlanViewTests.cs
@@ -1,0 +1,37 @@
+using System;
+
+using NUnit.Framework;
+
+using Revit.Elements;
+using Revit.Elements.Views;
+
+using RevitTestServices;
+
+using RTF.Framework;
+
+namespace RevitNodesTests.Elements.Views
+{
+    [TestFixture]
+    class CeilingPlanViewTests : RevitNodeTestBase
+    {
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByLevel_ValidArgs()
+        {
+            var elevation = 100;
+            var level = Level.ByElevation(elevation);
+            Assert.NotNull(level);
+
+            var view = StructuralPlanView.ByLevel(level);
+
+            Assert.NotNull(view);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByLevel_BadArgs()
+        {
+            Assert.Throws(typeof(ArgumentNullException), () => StructuralPlanView.ByLevel(null));
+        }
+    }
+}

--- a/test/Libraries/RevitNodesTests/Elements/Views/StructuralPlanViewTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/Views/StructuralPlanViewTests.cs
@@ -12,7 +12,7 @@ using RTF.Framework;
 namespace RevitNodesTests.Elements.Views
 {
     [TestFixture]
-    class CeilingPlanViewTests : RevitNodeTestBase
+    class StructuralPlanViewTests : RevitNodeTestBase
     {
         [Test]
         [TestModel(@".\Empty.rvt")]


### PR DESCRIPTION
### Purpose

The goal of this PR is to add support for structural plan views to the ElementWrapper and improve the functionality of Revit.Element nodes such as "Sheet.Views" and "Sheet.ByNameNumberTitleBlockAndView", which are currently throwing an exception when handling structural plans.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers
@ikeough 

### FYIs

I've implemented Ian's recommendations from the last PR. Thanks a lot for all the help.
