### PR TITLE
Add property ProcessMode to RevitStartConfiguration

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -241,6 +241,7 @@ namespace Dynamo.Applications
                     AuthProvider = new RevitOxygenProvider(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher)),
                     ExternalCommandData = commandData,
                     UpdateManager = new DynUpdateManager(umConfig),
+                    ProcessMode = isAutomationMode ? TaskProcessMode.Synchronous : TaskProcessMode.Asynchronous
                 });
         }
 

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -17,6 +17,7 @@ using Dynamo.Interfaces;
 using Dynamo.Models;
 using Dynamo.UpdateManager;
 using Dynamo.Utilities;
+using Dynamo.Core.Threading;
 using DynamoServices;
 using Greg;
 using ProtoCore;
@@ -54,6 +55,7 @@ namespace Dynamo.Applications.Models
             public string PackageManagerAddress { get; set; }
             public ExternalCommandData ExternalCommandData { get; set; }
             public IEnumerable<Dynamo.Extensions.IExtension> Extensions { get; set; }
+            public TaskProcessMode ProcessMode { get; set; }
         }
 
         /// <summary>
@@ -191,7 +193,7 @@ namespace Dynamo.Applications.Models
 
         public new static RevitDynamoModel Start()
         {
-            return Start(new RevitStartConfiguration());
+            return Start(new RevitStartConfiguration() { ProcessMode = TaskProcessMode.Asynchronous } );
         }
 
         public new static RevitDynamoModel Start(IRevitStartConfiguration configuration)

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -215,7 +215,8 @@ namespace RevitTestServices
                         Context = "Revit 2014",
                         SchedulerThread = new TestSchedulerThread(),
                         PackageManagerAddress = "https://www.dynamopackages.com",
-                        ExternalCommandData = RevitTestExecutive.CommandData
+                        ExternalCommandData = RevitTestExecutive.CommandData,
+                        ProcessMode = TaskProcessMode.Synchronous
                     });
 
                 Model = DynamoRevit.RevitDynamoModel;


### PR DESCRIPTION
### Purpose

This PR updates `RevitStartConfiguration` because of a new property `ProcessMode` added to its interface in Dynamo. This property was added in this [PR](https://github.com/DynamoDS/Dynamo/pull/5373) to specify whether `DynamoScheduler` will process scheduled tasks synchronously or asynchronously. 

### Reviewer
@Randy-Ma 