### PR TITLE
MAGN-8492 Small curve causes Dynamo to crash when showing background 3D preview in Revit. 2016

### DIFF
--- a/src/DynamoRevit/ViewModel/DynamoRevitViewModel.cs
+++ b/src/DynamoRevit/ViewModel/DynamoRevitViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-
 using Autodesk.Revit.DB;
 
 using Dynamo.Applications.Models;
@@ -28,8 +27,10 @@ namespace Dynamo.Applications.ViewModel
 
             if (RevitWatch3DViewModel.GetTransientDisplayMethod() != null)
             {
-                var watch3DParams = new Watch3DViewModelStartupParams(model, this, "Revit Background Preview");
-                watch3DParams.RenderPackageFactory = new DefaultRenderPackageFactory();
+                var watch3DParams = new Watch3DViewModelStartupParams(model, this, "Revit Background Preview")
+                {
+                    RenderPackageFactory = new DefaultRenderPackageFactory()
+                };
                 Watch3DViewModels.Add(RevitWatch3DViewModel.Start(watch3DParams));
             }
         }

--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -104,6 +104,8 @@ namespace Dynamo.Applications.ViewModel
 
         private void Draw()
         {
+            if (!Active) return;
+
             var graphicItems = model.CurrentWorkspace.Nodes
                 .Where(n => n.IsVisible)
                 .SelectMany(n => n.GeneratedGraphicItems(engineManager.EngineController));
@@ -210,20 +212,18 @@ namespace Dynamo.Applications.ViewModel
             curve.Tessellate(pkg, renderPackageFactory.TessellationParameters);
 
             // get necessary info to enumerate and convert the lines
-            var lineCount = pkg.LineVertexCount * 3 - 3;
+            //var lineCount = pkg.LineVertexCount * 3 - 3;
             var verts = pkg.LineStripVertices.ToList();
 
             // we scale the tesselation rather than the curve
             var conv = UnitConverter.DynamoToHostFactor(UnitType.UT_Length);
 
-            // add the revit Lines to geometry collection
-            for (var i = 0; i < lineCount; i += 3)
+            var scaledXYZs = new List<XYZ>();
+            for (var i = 0; i < verts.Count; i+= 3)
             {
-                var xyz0 = new XYZ(verts[i] * conv, verts[i + 1] * conv, verts[i + 2] * conv);
-                var xyz1 = new XYZ(verts[i + 3] * conv, verts[i + 4] * conv, verts[i + 5] * conv);
-
-                result.Add(Line.CreateBound(xyz0, xyz1));
+                scaledXYZs.Add(new XYZ(verts[i] * conv, verts[i + 1] * conv, verts[i + 2] * conv));
             }
+            result.Add(PolyLine.Create(scaledXYZs));
 
             return result;
         }

--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="DisplayTests.cs" />
     <Compile Include="RevitLibraryTests.cs" />
     <Compile Include="ImportInstanceTests.cs" />
+    <Compile Include="RevitWatch3DViewModelTests.cs" />
     <Compile Include="SiteLocationTests.cs" />
     <Compile Include="RenderingAsAServiceTests.cs" />
     <Compile Include="DividedCurveTests.cs" />

--- a/test/Libraries/RevitIntegrationTests/RevitWatch3DViewModelTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RevitWatch3DViewModelTests.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using System.Linq;
+using Dynamo.Applications.ViewModel;
+using NUnit.Framework;
+using RevitTestServices;
+using RTF.Framework;
+
+namespace RevitSystemTests
+{
+    [TestFixture]
+    public class RevitWatch3DViewModelTests : RevitSystemTestBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            var vm3D = ViewModel.Watch3DViewModels.FirstOrDefault(vm => vm is RevitWatch3DViewModel);
+            vm3D.Active = true;
+        }
+
+        [Test, TestModel(@".\empty.rfa")]
+        public void SmallCurve_Draw_DoesNotThrowException()
+        {
+            var vm3D = ViewModel.Watch3DViewModels.FirstOrDefault(vm => vm is RevitWatch3DViewModel);
+            Assert.NotNull(vm3D);
+
+            var samplePath = Path.Combine(workingDirectory, @".\RevitWatch3DViewModel\ShortLine.dyn");
+            var testPath = Path.GetFullPath(samplePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+            RunCurrentModel();
+
+            Assert.Pass();
+        }
+    }
+}

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -11,6 +11,7 @@ using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Events;
 using Dynamo.Applications;
 using Dynamo.Applications.Models;
+using Dynamo.Applications.ViewModel;
 using Dynamo.Core.Threading;
 using Dynamo.Interfaces;
 using Dynamo.Models;
@@ -221,11 +222,17 @@ namespace RevitTestServices
 
                 Model = DynamoRevit.RevitDynamoModel;
 
-                this.ViewModel = DynamoViewModel.Start(
+                this.ViewModel = DynamoRevitViewModel.Start(
                     new DynamoViewModel.StartConfiguration()
                     {
                         DynamoModel = DynamoRevit.RevitDynamoModel,
                     });
+
+                var vm3D = ViewModel.Watch3DViewModels.FirstOrDefault(vm => vm is RevitWatch3DViewModel);
+                if (vm3D != null)
+                {
+                    vm3D.Active = false;
+                }
 
                 // Because the test framework does not work in the idle thread. 
                 // We need to trick Dynamo into believing that it's in the idle

--- a/test/System/RevitWatch3DViewModel/ShortLine.dyn
+++ b/test/System/RevitWatch3DViewModel/ShortLine.dyn
@@ -1,0 +1,28 @@
+<Workspace Version="0.9.0.2815" X="-476.506171271727" Y="42.2743145927621" zoom="0.915987660325295" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="Point" resolvedName="Autodesk.DesignScript.Geometry.Point" assemblyName="ProtoGeometry.dll" />
+    <ClassMap partialName="Line" resolvedName="Autodesk.DesignScript.Geometry.Line" assemblyName="ProtoGeometry.dll" />
+  </NamespaceResolutionMap>
+  <Elements>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="9a42b0b5-e39e-49d7-9b5b-6ee9cb930eb9" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="765.646589211361" y="104.440375642053" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="a=Point.Origin();&#xA;b=Point.ByCoordinates(0.00065104,0,0);&#xA;Line.ByStartPointEndPoint(a,b);" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="81b98a9f-0f9f-4bb0-b2b4-a12aab7ad875" type="Dynamo.Nodes.DSFunction" nickname="Circle.ByCenterPointRadius" x="1266.45947497588" y="243.129393815657" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Circle.ByCenterPointRadius@Autodesk.DesignScript.Geometry.Point,double">
+      <PortInfo index="0" default="True" />
+      <PortInfo index="1" default="True" />
+    </Dynamo.Nodes.DSFunction>
+    <Dynamo.Nodes.CodeBlockNodeModel guid="af813ee4-a997-4046-8cf4-8148c459d8bc" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="1021" y="302" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="0.0001;" ShouldFocus="false" />
+    <Dynamo.Nodes.DSFunction guid="e0aaaf1f-cb41-4ce9-9fac-ce4bf94ff1bf" type="Dynamo.Nodes.DSFunction" nickname="Curve.Length" x="1538.17530591001" y="241.666143706437" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Curve.Length" />
+  </Elements>
+  <Connectors>
+    <Dynamo.Models.ConnectorModel start="9a42b0b5-e39e-49d7-9b5b-6ee9cb930eb9" start_index="0" end="81b98a9f-0f9f-4bb0-b2b4-a12aab7ad875" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="81b98a9f-0f9f-4bb0-b2b4-a12aab7ad875" start_index="0" end="e0aaaf1f-cb41-4ce9-9fac-ce4bf94ff1bf" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="af813ee4-a997-4046-8cf4-8148c459d8bc" start_index="0" end="81b98a9f-0f9f-4bb0-b2b4-a12aab7ad875" end_index="1" portType="0" />
+  </Connectors>
+  <Notes>
+    <Dynamo.Models.NoteModel guid="ab7c868d-4600-43f9-91b4-9a69d2b3fac4" text="1/128&quot; -&gt; decimal feet = 0.00065104" x="1255.28155740884" y="116.963055071274" />
+  </Notes>
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-0.909339333423456" eyeY="3.4923017094419" eyeZ="3.55283335674459" lookX="6.04304616294816" lookY="-8.94001844272133" lookZ="-6.21650781473631" upX="0.384717778962334" upY="0.833885828075745" upZ="-0.395760859914489" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR addresses [MAGN-8492](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8492). Revit cannot draw curves smaller than 1/64". We add a check whether the curve to be drawn is shorter than `Application.ShortCurveTolerance`. If so, we skip it.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@mjkkirschner 

### Cherry Picks:
- [ ] Revit2015
- [ ] Revit2017