### PR TITLE
Fix the failing test case - DynamoAllSelectionNodeTests_WithPreSelectedEntities

### DIFF
--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -169,7 +169,7 @@ namespace Revit.Elements
                 case ViewType.CeilingPlan:
                     return CeilingPlanView.FromExisting(view, isRevitOwned);
                 case ViewType.FloorPlan:
-                    return CeilingPlanView.FromExisting(view, isRevitOwned);
+                    return FloorPlanView.FromExisting(view, isRevitOwned);
                 case ViewType.EngineeringPlan:
                     return StructuralPlanView.FromExisting(view, isRevitOwned);
                 default:


### PR DESCRIPTION
This is to fix one failing test case. When the view type is FloorPlan, a FloorPlanView need to be wrapped instead of a CeilingPlanView.