### PR TITLE
Fix Display_ModelCurveDrawnInBackground_HasCorrectColor. 2015

### DIFF
--- a/src/Libraries/RevitNodes/Elements/CurveElement.cs
+++ b/src/Libraries/RevitNodes/Elements/CurveElement.cs
@@ -11,9 +11,9 @@ namespace Revit.Elements
 {
     public abstract class CurveElement : Element, IGraphicItem
     {
-        private const byte DefR = 101;
-        private const byte DefG = 86;
-        private const byte DefB = 130;
+        private const byte DefR = 0;
+        private const byte DefG = 0;
+        private const byte DefB = 0;
         private const byte DefA = 255;
 
         public override Autodesk.Revit.DB.Element InternalElement


### PR DESCRIPTION
This PR fixes one broken test, `Display_ModelCurveDrawnInBackground_HasCorrectColor`. The edge color had not yet been updated to match core.

### Cherry Picks:
- [x] Revit2016
- [x] Revit2017