### PR TITLE
bad merge - causing test failures, need to create a TSB on 2017 using…

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
@@ -106,7 +106,7 @@ namespace Revit.GeometryConversion
             var verts = mesh.VertexPositions;
             var indices = mesh.FaceIndices;
 
-            var tsb = new TessellatedShapeBuilder();
+            var tsb = new TessellatedShapeBuilder() { Fallback = fallback, Target = target, GraphicsStyleId = ElementId.InvalidElementId };
             tsb.OpenConnectedFaceSet(false);
 
             for (int faceindex = 0, count = indices.Count(); faceindex < count; faceindex++)


### PR DESCRIPTION
… the target and fallback from the start, not passed in when build() is called

@ikeough 

this should fix the three failing directShape test cases, for mesh conversion we created a tessellatedShapeBuilder but did not set the target to mesh so surfaces/solids were being created where the tests expect meshes.