### PR TITLE
Remove usage of obsolete API for Revit NurbSpline curve creation

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitCurve.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitCurve.cs
@@ -100,7 +100,7 @@ namespace Revit.GeometryConversion
             {
                 using (var converted = NurbsUtils.ElevateBezierDegree(crv, 3))
                 {
-                    return Autodesk.Revit.DB.NurbSpline.Create(converted.ControlPoints().ToXyzs(false),
+                    return CreateNurbSpline(converted.ControlPoints().ToXyzs(false),
                             converted.Weights(),
                             converted.Knots(),
                             converted.Degree,
@@ -123,7 +123,7 @@ namespace Revit.GeometryConversion
                 using (var resampledCrv = NurbsCurve.ByPointsTangents(pts, tstart.Normalized(), tend.Normalized()))
                 {
 
-                    return Autodesk.Revit.DB.NurbSpline.Create(resampledCrv.ControlPoints().ToXyzs(false),
+                    return CreateNurbSpline(resampledCrv.ControlPoints().ToXyzs(false),
                             resampledCrv.Weights(),
                             resampledCrv.Knots(),
                             resampledCrv.Degree,
@@ -133,13 +133,20 @@ namespace Revit.GeometryConversion
             }
 
             // general implementation
-            return Autodesk.Revit.DB.NurbSpline.Create(crv.ControlPoints().ToXyzs(false),
+            return CreateNurbSpline(crv.ControlPoints().ToXyzs(false),
                 crv.Weights(),
                 crv.Knots(),
                 crv.Degree,
                 crv.IsClosed,
                 crv.IsRational);
 
+        }
+        private static Autodesk.Revit.DB.Curve CreateNurbSpline(IList<XYZ> controlPoints, IList<double> weights, IList<double> knots, int degree, bool closed, bool rational)
+        {
+            if (rational)
+                return NurbSpline.CreateCurve(degree, knots, controlPoints, weights);
+
+            return NurbSpline.CreateCurve(degree, knots, controlPoints);
         }
 
         private static Autodesk.Revit.DB.Arc Convert(Autodesk.DesignScript.Geometry.Arc arc)


### PR DESCRIPTION
### Purpose

Autodesk.Revit.DB.NurbSpline.Create has been marked as obsolete and also call of this API is throwing exception in Revit2017 tests.

The call of NurbSpline.Create method is now replaced with a new utility method CreateNurbSpline which calls correct API based on whether the curve is rational or not.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewer

- [ ] @Randy-Ma 