### PR TITLE
Fix MAGN-8852 Label is missing on the toggle option "Revit background preview on"

### DIFF
--- a/src/DynamoRevit/Properties/Resources.en-US.resx
+++ b/src/DynamoRevit/Properties/Resources.en-US.resx
@@ -151,4 +151,7 @@
   <data name="NewDocument" xml:space="preserve">
     <value>a new document.</value>
   </data>
+  <data name="BackgroundPreviewName" xml:space="preserve">
+    <value>Revit Background Preview</value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose

This submission is to fix an issue that the menu item to toggle one background preview has not text.

The reason is that in the en-US resources, the string resource is missing. I am adding it here in this pull request.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@aparajit-pratap 
