### PR TITLE
Encapsulate DynamoButton field

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -186,7 +186,7 @@ namespace Dynamo.Applications
                 TryOpenAndExecuteWorkspace(extCommandData);
 
                 // Disable the Dynamo button to prevent a re-run
-                DynamoRevitApp.DynamoButton.Enabled = false;
+                DynamoRevitApp.DynamoButtonEnabled = false;
             }
             catch (Exception ex)
             {
@@ -196,7 +196,7 @@ namespace Dynamo.Applications
 
                 MessageBox.Show(ex.ToString());
 
-                DynamoRevitApp.DynamoButton.Enabled = true;
+                DynamoRevitApp.DynamoButtonEnabled = true;
 
                 return Result.Failed;
             }
@@ -471,7 +471,7 @@ namespace Dynamo.Applications
             finally
             {
                 args.Handled = true;
-                DynamoRevitApp.DynamoButton.Enabled = true;
+                DynamoRevitApp.DynamoButtonEnabled = true;
             }
         }
 
@@ -494,7 +494,7 @@ namespace Dynamo.Applications
             AppDomain.CurrentDomain.AssemblyResolve -=
                 Analyze.Render.AssemblyHelper.ResolveAssemblies;
 
-            DynamoRevitApp.DynamoButton.Enabled = true;
+            DynamoRevitApp.DynamoButtonEnabled = true;
         }
 
         #endregion

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -36,7 +36,7 @@ namespace Dynamo.Applications
         public static ControlledApplication ControlledApplication;
         public static UIControlledApplication UIControlledApplication;
         public static List<IUpdater> Updaters = new List<IUpdater>();
-        internal static PushButton DynamoButton;
+        private static PushButton DynamoButton;
         private static readonly Queue<Action> idleActionQueue = new Queue<Action>(10);
         private static EventHandlerProxy proxy;
 
@@ -249,6 +249,12 @@ namespace Dynamo.Applications
             {
                 throw new Exception(string.Format("The location of the assembly, {0} could not be resolved for loading.", assemblyPath), ex);
             }
+        }
+
+        public static bool DynamoButtonEnabled
+        {
+            get { return DynamoButton.Enabled; }
+            set { DynamoButton.Enabled = value; }
         }
     }
 }


### PR DESCRIPTION
### Purpose
- Define DynamoButtonEnabled property on DynamoRevitApp class to encapsulate DynamoButton field.
- Align the code refactoring expected for Revit2017 #732 

### Reviewer
@Randy-Ma 