### PR TITLE
Use correct property in property change handler.

### DIFF
--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -134,13 +134,15 @@ namespace DSRevitNodesUI
 
         void OnPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName != "IsUpdated")
+            if (e.PropertyName != "CachedValue")
                 return;
 
             if (InPorts.Any(x => x.Connectors.Count == 0))
                 return;
 
             element = GetInputElement();
+
+            PopulateItems();
         }
 
         private static string getStorageTypeString(StorageType st)
@@ -159,26 +161,36 @@ namespace DSRevitNodesUI
             }
         }
 
+        /// <summary>
+        /// Reads the internal element to get all the family 
+        /// or instance parameters, and adds them to the Items collection.
+        /// 
+        /// Items are sorted alphabetically by name. 
+        /// If the SelectedIndex is already set, it is set to zero.
+        /// </summary>
         public override void PopulateItems() //(IEnumerable set, bool readOnly)
         {
             //only update the collection on evaluate
             //if the item coming in is different
             if (element == null || element.Id.Equals(this.storedId))
                 return;
-            else
-            {
-                this.storedId = element.Id;
-                this.Items.Clear();
-            }
 
-            FamilySymbol fs = element as FamilySymbol;
-            FamilyInstance fi = element as FamilyInstance;
+            storedId = element.Id;
+            Items.Clear();
+
+            var fs = element as FamilySymbol;
+            var fi = element as FamilyInstance;
             if(null != fs)
                 AddFamilySymbolParameters(fs);
             if(null != fi)
                 AddFamilyInstanceParameters(fi);
 
             Items = Items.OrderBy(x => x.Name).ToObservableCollection<DynamoDropDownItem>();
+
+            if (SelectedIndex == -1)
+            {
+                SelectedIndex = 0;
+            }
         }
 
         private void AddFamilySymbolParameters(FamilySymbol fs)

--- a/test/Libraries/RevitIntegrationTests/GetFamilyParametersTests.cs
+++ b/test/Libraries/RevitIntegrationTests/GetFamilyParametersTests.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+using System.Linq;
+using DSRevitNodesUI;
+using NUnit.Framework;
+using RevitTestServices;
+using RTF.Framework;
+
+namespace RevitSystemTests
+{
+    [TestFixture]
+    public class GetFamilyParametersTests : RevitSystemTestBase
+    {
+        [Test, TestModel(@".\Selection\DynamoSample.rvt")]
+        public void CachedValueChanges_HasItemsAndSelectedIndex()
+        {
+            var model = ViewModel.Model;
+            var samplePath = Path.Combine(workingDirectory,
+                                                @".\Family\GetFamilyParameter.dyn");
+            var testPath = Path.GetFullPath(samplePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+
+            var parametersNode = model.CurrentWorkspace.Nodes.OfType<FamilyInstanceParameters>().FirstOrDefault();
+            Assert.NotNull(parametersNode);
+
+            Assert.Greater(parametersNode.Items.Count, 0);
+            Assert.AreNotEqual(parametersNode.SelectedIndex, -1);
+        }
+    }
+}

--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="AsynchronousModeTests.cs" />
     <Compile Include="DirectShapeTests.cs" />
     <Compile Include="DisplayTests.cs" />
+    <Compile Include="GetFamilyParametersTests.cs" />
     <Compile Include="RevitLibraryTests.cs" />
     <Compile Include="ImportInstanceTests.cs" />
     <Compile Include="RevitWatch3DViewModelTests.cs" />

--- a/test/System/Family/GetFamilyParameter.dyn
+++ b/test/System/Family/GetFamilyParameter.dyn
@@ -1,0 +1,21 @@
+<Workspace Version="0.9.1.3155" X="-313.668121136307" Y="-80.1286167700013" zoom="1.31537540500821" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <DSRevitNodesUI.FamilyInstanceParameters guid="4bce83e2-53b0-4464-aee3-306d2d771698" type="DSRevitNodesUI.FamilyInstanceParameters" nickname="Get Family Parameter" x="620.577642785946" y="254.237575800462" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" index="0:Assembly Code(Type)(string)">
+      <familyid value="954992" />
+      <index value="0" />
+    </DSRevitNodesUI.FamilyInstanceParameters>
+    <Dynamo.Nodes.DSModelElementSelection guid="7f7f8905-2a0e-4055-90a7-2ce7572c3b13" type="Dynamo.Nodes.DSModelElementSelection" nickname="Select Model Element" x="351.577642785946" y="254.237575800462" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
+      <instance id="5ba82f05-9759-4b6e-8b19-8f869f7ed622-000e9270" />
+    </Dynamo.Nodes.DSModelElementSelection>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="7f7f8905-2a0e-4055-90a7-2ce7572c3b13" start_index="0" end="4bce83e2-53b0-4464-aee3-306d2d771698" end_index="0" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR fixes https://github.com/DynamoDS/Dynamo/issues/5684. The property changed handler was incorrectly referencing `IsUpdated`, which no longer exists on `NodeModel`.

In addition to fixing the item population error, this PR adds a call to `PopulateItems` in the property change handler, and sets the selected item index to 0 if the control did not previously have a selected item. These two additions together ensure that the control does not look blank, even when the `Items` collection has values.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
  - New documentation is added to `PopulateItems` to explain what it does and its side effects.
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files <b>n/a</b>
- [ ] All tests pass using the self-service CI. <b>n/a</b> (Revit only)

### Reviewers

@mjkkirschner 

### Cherry-picks:
- [x] Revit2016
- [x] Revit2017