### PR TITLE
MAGN-9069

### DIFF
--- a/test/Libraries/RevitIntegrationTests/SelectionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/SelectionTests.cs
@@ -383,8 +383,11 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             // ElementsAtLevel
+            // See http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9069
+            // The number of elements at level is different here in 2016 and 2017, due
+            // to a fault in the 2017 API.
             var allElementAtLevelNodeID = "da009f85-80e6-4541-b8fd-165ea7f23449";
-            AssertPreviewCount(allElementAtLevelNodeID, 81);
+            AssertPreviewCount(allElementAtLevelNodeID, 73);
 
             var wall = GetPreviewValueAtIndex(allElementAtLevelNodeID, 0) as Revit.Elements.Wall;
             Assert.IsNotNull(wall);


### PR DESCRIPTION
### Purpose

[MAGN-9069](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9069)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI. <b>n/a</b> Revit only.

### Reviewers

@mjkkirschner 

NOTE: This does not require cherry-picking to other Revit branches as it is an error specific to the Revit API in 2017. We should fix ONLY the test until we can get feedback from the Revit team.