### PR TITLE
MAGN 9099  One element remains if an error happens for the AdaptiveComponent.ByPoints node

### DIFF
--- a/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
+++ b/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
@@ -419,6 +419,7 @@ namespace Revit.Elements
                 {
                     var fi = oldInstances.ElementAt(i);
                     var comp = new AdaptiveComponent(fi);
+                    components.Add(comp);
 
                     //Update the family symbol
                     if (familyType.InternalFamilySymbol.Id != fi.Symbol.Id)
@@ -427,7 +428,6 @@ namespace Revit.Elements
                     }
 
                     UpdatePlacementPoints(fi, points[i].ToXyzs());
-                    components.Add(comp);
                     instances.Add(fi);
                 }
 


### PR DESCRIPTION
### Purpose

This PR is to fix [MAGN 9099  One element remains if an error happens for the AdaptiveComponent.ByPoints node](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9099).

That is because the newly created adaptive component is not unregistered from the element life cycle manager if there is an exception thrown out in the following code. 

Previous code is
```
try
{
    var comp = new AdaptiveComonent(...);
    ...
    // exception thrown out
    ...
    components.Add(comp);
}
catch (Exception e)
{
    unregister adaptive components in components
    ...
}
```

As the exception is thrown out before adding the component to `components` array, it won't be unregistered. 

The fix is to add the component to `components` array immediately after it is created.

Test case `CreateAdaptiveComponentsByInvalidPoints` added:

![untitled](https://cloud.githubusercontent.com/assets/2600379/11415780/3b732a64-9442-11e5-91f8-72e0e5de8226.png)


### Reviewer

@Randy-Ma 