### PR TITLE
Cross merge the fix for MAGN 9099 to Revit2017 branch

### DIFF
--- a/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
+++ b/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
@@ -419,6 +419,7 @@ namespace Revit.Elements
                 {
                     var fi = oldInstances.ElementAt(i);
                     var comp = new AdaptiveComponent(fi);
+                    components.Add(comp);
 
                     //Update the family symbol
                     if (familyType.InternalFamilySymbol.Id != fi.Symbol.Id)
@@ -427,7 +428,6 @@ namespace Revit.Elements
                     }
 
                     UpdatePlacementPoints(fi, points[i].ToXyzs());
-                    components.Add(comp);
                     instances.Add(fi);
                 }
 


### PR DESCRIPTION
### Purpose

Cross merge the fix (PR #776) for  [MAGN 9099  One element remains if an error happens for the AdaptiveComponent.ByPoints node](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9099) to Revit2017 branch.