### PR TITLE
MAGN-9085 Revit Background Preview ON interferes with ui interaction in graph

### DIFF
--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -70,7 +70,7 @@ namespace Dynamo.Applications.ViewModel
 
         protected override void OnEvaluationCompleted(object sender, EvaluationCompletedEventArgs e)
         {
-            Draw();
+            if (e.EvaluationTookPlace) Draw();
         }
 
         protected override void OnNodePropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -84,20 +84,28 @@ namespace Dynamo.Applications.ViewModel
             switch (e.PropertyName)
             {
                 case "IsVisible":
-                    Draw();
+                    Draw(node);
                     break;
             }
         }
         
         #region private methods
 
-        private void Draw()
+        private void Draw(NodeModel node = null)
         {
             if (!Active) return;
+            IEnumerable<IGraphicItem> graphicItems;
 
-            var graphicItems = model.CurrentWorkspace.Nodes
+            if (node != null)
+            {
+                graphicItems = node.GeneratedGraphicItems(engineManager.EngineController);
+            }
+            else
+            {
+                graphicItems = model.CurrentWorkspace.Nodes
                 .Where(n => n.IsVisible)
                 .SelectMany(n => n.GeneratedGraphicItems(engineManager.EngineController));
+            }
 
             var geoms = new List<GeometryObject>();
             foreach (var item in graphicItems)

--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -70,7 +70,7 @@ namespace Dynamo.Applications.ViewModel
 
         protected override void OnEvaluationCompleted(object sender, EvaluationCompletedEventArgs e)
         {
-            if (e.EvaluationTookPlace) Draw();
+            Draw();
         }
 
         protected override void OnNodePropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -98,7 +98,10 @@ namespace Dynamo.Applications.ViewModel
 
             if (node != null)
             {
-                graphicItems = node.GeneratedGraphicItems(engineManager.EngineController);
+                if (node.IsVisible)
+                {
+                    graphicItems = node.GeneratedGraphicItems(engineManager.EngineController);
+                }
             }
             else
             {


### PR DESCRIPTION
### Purpose

When we ungroup n nodes `RaisePropertyChanged("IsVisible")` triggers to each node in group. It caused costly and unnecessary tessellation for each node for n times. So the complexity was `O(n^2)` and it took lot of time for complex graphs. I've managed to reduce time of execution to `O(n)`. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers
@pboyer 