### PR TITLE
MAGN-9218 Freezeing a node deletes revit elements on re-exectution

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -8,6 +8,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Events;
 using DSIronPython;
+using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
 using Dynamo.Logging;
@@ -147,6 +148,32 @@ namespace Dynamo.Applications.Models
 
             if (workspace is HomeWorkspaceModel)
                 DisposeLogic.IsClosingHomeworkspace = false;
+
+            //Unsubscribe the event
+            foreach (var node in workspace.Nodes.ToList())
+            {
+                node.PropertyChanged -= node_PropertyChanged;
+            }
+        }
+
+        protected override void OnWorkspaceAdded(WorkspaceModel workspace)
+        {
+            base.OnWorkspaceAdded(workspace);
+
+            foreach (var node in workspace.Nodes.ToList())
+            {
+                node.PropertyChanged += node_PropertyChanged;
+            }
+        }
+
+        private void node_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case "IsFrozen":
+                    ElementBinder.SetElementFreezeState(CurrentWorkspace, sender as NodeModel, EngineController);
+                    break;
+            }
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -187,18 +187,23 @@ namespace Revit.Elements
         protected string InternalUniqueId;
 
         /// <summary>
+        /// Set the element's freeze state. If the node is set to freeze
+        /// all the elements for that node will be set to freeze.
+        /// </summary>
+        public bool IsFrozen = false;
+
+        /// <summary>
         /// Default implementation of dispose that removes the element from the
         /// document
         /// </summary>
         [IsVisibleInDynamoLibrary(false)]
         public virtual void Dispose()
         {
-
             // Do not cleanup Revit elements if we are shutting down Dynamo or
-            // closing homeworkspace.
-            if (DisposeLogic.IsShuttingDown || DisposeLogic.IsClosingHomeworkspace)
+            // closing homeworkspace or the element itself is frozen.
+            if (DisposeLogic.IsShuttingDown || DisposeLogic.IsClosingHomeworkspace || IsFrozen)
                 return;
-
+            
             bool didRevitDelete = ElementIDLifecycleManager<int>.GetInstance().IsRevitDeleted(Id);
 
             var elementManager = ElementIDLifecycleManager<int>.GetInstance();

--- a/src/Libraries/RevitServices/Persistence/ElementBinder.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementBinder.cs
@@ -460,6 +460,68 @@ namespace RevitServices.Persistence
 
             return nodes.AsEnumerable();
         }
+
+        /// <summary>
+        /// Sets the freeze state of the elements associated with that node.
+        /// </summary>
+        /// <param name="workspace">The workspace.</param>
+        /// <param name="node">The node.</param>
+        /// <param name="engine">The engine.</param>
+        public static void SetElementFreezeState(WorkspaceModel workspace, NodeModel node, EngineController engine)
+        {
+            RuntimeCore runtimeCore = null;
+            if (engine != null && (engine.LiveRunnerCore != null))
+                runtimeCore = engine.LiveRunnerRuntimeCore;
+
+            if (runtimeCore == null || node == null)
+                return;
+
+            // Selecting all nodes that are either a DSFunction,
+            // a DSVarArgFunction or a CodeBlockNodeModel into a list.
+            var nodeGuids = workspace.Nodes.Where((n) =>
+            {
+                return (n is DSFunction
+                        || (n is DSVarArgFunction)
+                        || (n is CodeBlockNodeModel));
+            }).Where((n) => n.GUID == node.GUID).Select((x) => x.GUID);
+
+            var nodeTraceDataList = runtimeCore.RuntimeData.GetCallsitesForNodes(nodeGuids, runtimeCore.DSExecutable);
+            foreach (Guid guid in nodeTraceDataList.Keys)
+            {
+                foreach (CallSite cs in nodeTraceDataList[guid])
+                {
+                    foreach (CallSite.SingleRunTraceData srtd in cs.TraceData)
+                    {
+                        List<ISerializable> traceData = srtd.RecursiveGetNestedData();
+
+                        foreach (ISerializable thingy in traceData)
+                        {
+                            SerializableId sid = thingy as SerializableId;
+
+                            if (sid != null)
+                            {
+                                //Get the Autodesk.Revit.Element.
+                                Element el;
+                                DocumentManager.Instance.CurrentDBDocument.TryGetElement(new ElementId(sid.IntID),
+                                    out el);
+
+                                //Get the Revit Element wrapper.
+                                if (el != null)
+                                {
+                                    dynamic elem =
+                                        ElementIDLifecycleManager<int>.GetInstance().GetFirstWrapper(el.Id.IntegerValue);
+                                    if (elem != null)
+                                    {
+                                        elem.IsFrozen = node.IsFrozen;
+                                    }
+                                }
+
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## Purpose
This PR fixes the issue with Revit elements getting deleted when the graph re-executes. 

This PR refers to the below tasks 
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9218

 ## Declaration
Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [] The level of testing this PR includes is appropriate
- [] User facing strings, if any, are extracted into `*.resx` files

## Reviewers
 @mjkkirschner 