### PR TITLE
MAGN-9023 Remove Dynamo.Wpf namespace from CoreNodeModelsWpf (2017)

### DIFF
--- a/src/Libraries/RevitNodesUI/FamilyInstanceParametersNodeViewCustomization.cs
+++ b/src/Libraries/RevitNodesUI/FamilyInstanceParametersNodeViewCustomization.cs
@@ -1,4 +1,5 @@
-﻿using DSRevitNodesUI;
+﻿using CoreNodeModelsWpf.Nodes;
+using DSRevitNodesUI;
 
 namespace Dynamo.Wpf.Nodes.Revit
 {

--- a/src/Libraries/RevitNodesUI/SelectionNodeViewCustomizations.cs
+++ b/src/Libraries/RevitNodesUI/SelectionNodeViewCustomizations.cs
@@ -8,6 +8,7 @@ using Dynamo.Nodes;
 using Dynamo.Wpf;
 using Dynamo.Wpf.Nodes;
 using Dynamo.Applications.Models;
+using CoreNodeModelsWpf.Nodes;
 
 namespace Dynamo.Wpf.Nodes.Revit
 {


### PR DESCRIPTION
### Purpose

https://github.com/DynamoDS/Dynamo/pull/5876

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.

### Reviewers
@ramramps 