### PR TITLE
MAGN-9022 Rename DSCoreNodesUI to CoreNodeModels (Revit2015)

### DIFF
--- a/src/Libraries/Migrations/RevitNodes/Solid.cs
+++ b/src/Libraries/Migrations/RevitNodes/Solid.cs
@@ -145,7 +145,7 @@ namespace Dynamo.Nodes
             string dsRevitNodeId = MigrationManager.GetGuidFromXmlElement(dsRevitNode);
 
             XmlElement createListNode = MigrationManager.CreateNode(data.Document,
-                oldNode, 0, "DSCoreNodesUI.CreateList", "Create List");
+                oldNode, 0, "CoreNodeModels.CreateList", "Create List");
             migratedData.AppendNode(createListNode);
             createListNode.SetAttribute("inputcount", "2");
             string createListNodeId = MigrationManager.GetGuidFromXmlElement(createListNode);

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -6,7 +6,7 @@ using System.Xml;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Events;
 using DSCore;
-using DSCoreNodesUI;
+using CoreNodeModels;
 using Dynamo.Applications;
 using Dynamo.Engine;
 using Dynamo.Graph;

--- a/src/Libraries/RevitNodesUI/RevitNodesUI.csproj
+++ b/src/Libraries/RevitNodesUI/RevitNodesUI.csproj
@@ -107,8 +107,8 @@
       <HintPath>$(DYNAMOAPI)\nodes\CoreNodeModelsWpf.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DSCoreNodesUI">
-      <HintPath>$(DYNAMOAPI)\nodes\DSCoreNodesUI.dll</HintPath>
+    <Reference Include="CoreNodeModels">
+      <HintPath>$(DYNAMOAPI)\nodes\CoreNodeModels.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoCore">

--- a/src/Libraries/RevitNodesUI/RevitSelectionHelper.cs
+++ b/src/Libraries/RevitNodesUI/RevitSelectionHelper.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI.Selection;
-using DSCoreNodesUI;
+using CoreNodeModels;
 using Dynamo.Interfaces;
 using Dynamo.Logging;
 

--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -28,7 +28,7 @@ using String = System.String;
 using UV = Autodesk.DesignScript.Geometry.UV;
 using RevitServices.EventHandler;
 using Autodesk.Revit.DB.Events;
-using DSCoreNodesUI;
+using CoreNodeModels;
 using Dynamo.Applications;
 using DSRevitNodesUI.Properties;
 using Dynamo.Graph.Nodes;

--- a/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
+++ b/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
@@ -9,7 +9,7 @@ using RevitTestServices;
 
 using RTF.Framework;
 
-using DoubleSlider = DSCoreNodesUI.Input.DoubleSlider;
+using DoubleSlider = CoreNodeModels.Input.DoubleSlider;
 
 using Revit.Elements;
 

--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -21,11 +21,11 @@ using System.Collections.Generic;
 using RevitServices.Transactions;
 using Revit.GeometryConversion;
 
-using DoubleSlider = DSCoreNodesUI.Input.DoubleSlider;
-using IntegerSlider = DSCoreNodesUI.Input.IntegerSlider;
+using DoubleSlider = CoreNodeModels.Input.DoubleSlider;
+using IntegerSlider = CoreNodeModels.Input.IntegerSlider;
 using Dynamo.Applications.Models;
 using System;
-using DSCoreNodesUI;
+using CoreNodeModels;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Revit.Elements.InternalUtilities;

--- a/test/Libraries/RevitIntegrationTests/CoreTests.cs
+++ b/test/Libraries/RevitIntegrationTests/CoreTests.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 
-using DSCoreNodesUI;
-using DSCoreNodesUI.Input;
+using CoreNodeModels;
+using CoreNodeModels.Input;
 using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;

--- a/test/Libraries/RevitIntegrationTests/CurveTests.cs
+++ b/test/Libraries/RevitIntegrationTests/CurveTests.cs
@@ -6,7 +6,7 @@ using Autodesk.Revit.DB;
 
 using Dynamo.Nodes;
 using Autodesk.DesignScript.Geometry;
-using DSCoreNodesUI.Input;
+using CoreNodeModels.Input;
 using NUnit.Framework;
 
 using RevitServices.Persistence;
@@ -71,9 +71,9 @@ namespace RevitSystemTests
             Assert.IsTrue(mc.IsReferenceLine);
 
             //now flip the switch for creating a reference curve
-            var boolNode = ViewModel.Model.CurrentWorkspace.Nodes.Where(x => x is DSCoreNodesUI.Input.BoolSelector).First();
+            var boolNode = ViewModel.Model.CurrentWorkspace.Nodes.Where(x => x is CoreNodeModels.Input.BoolSelector).First();
 
-            ((DSCoreNodesUI.Input.BasicInteractive<bool>)boolNode).Value = false;
+            ((CoreNodeModels.Input.BasicInteractive<bool>)boolNode).Value = false;
 
             RunCurrentModel();
 

--- a/test/Libraries/RevitIntegrationTests/DirectShapeTests.cs
+++ b/test/Libraries/RevitIntegrationTests/DirectShapeTests.cs
@@ -86,7 +86,7 @@ namespace RevitSystemTests
             var input = model.CurrentWorkspace.Nodes.Where(x => x.GUID.ToString() == "06e1461a-2eb4-4069-a581-93914d500115").First();
             input.UpdateValue(new UpdateValueParams("Value", "20.0"));
 
-            Assert.AreEqual((input as DSCoreNodesUI.Input.DoubleInput).Value, "20.0");
+            Assert.AreEqual((input as CoreNodeModels.Input.DoubleInput).Value, "20.0");
 
             var pnt2 = GetPreviewValue("53eb0459-4cd3-4131-b7ce-c4e689c57248") as Autodesk.DesignScript.Geometry.Point;
             Assert.IsNotNull(pnt2);

--- a/test/Libraries/RevitIntegrationTests/DividedSurfaceTests.cs
+++ b/test/Libraries/RevitIntegrationTests/DividedSurfaceTests.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 
 using Autodesk.Revit.DB;
-using DSCoreNodesUI.Input;
+using CoreNodeModels.Input;
 using Dynamo.Nodes;
 
 using NUnit.Framework;

--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -8,7 +8,7 @@ using RevitTestServices;
 
 using RTF.Framework;
 using Autodesk.Revit.DB;
-using DSCoreNodesUI.Input;
+using CoreNodeModels.Input;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Models;
 using Dynamo.Nodes;
@@ -17,8 +17,8 @@ using Dynamo.Tests;
 using RevitServices.Persistence;
 
 using Transaction = Autodesk.Revit.DB.Transaction;
-using DoubleSlider = DSCoreNodesUI.Input.DoubleSlider;
-using IntegerSlider = DSCoreNodesUI.Input.IntegerSlider;
+using DoubleSlider = CoreNodeModels.Input.DoubleSlider;
+using IntegerSlider = CoreNodeModels.Input.IntegerSlider;
 using Utils = RevitServices.Elements.ElementUtils;
 
 namespace RevitSystemTests

--- a/test/Libraries/RevitIntegrationTests/LevelTests.cs
+++ b/test/Libraries/RevitIntegrationTests/LevelTests.cs
@@ -11,7 +11,7 @@ using RevitTestServices;
 
 using RTF.Framework;
 using System;
-using DSCoreNodesUI.Input;
+using CoreNodeModels.Input;
 
 namespace RevitSystemTests
 {

--- a/test/Libraries/RevitIntegrationTests/ModelCurveTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ModelCurveTests.cs
@@ -5,7 +5,7 @@ using Dynamo.Nodes;
 
 using NUnit.Framework;
 using Autodesk.Revit.DB;
-using DSCoreNodesUI.Input;
+using CoreNodeModels.Input;
 using RevitServices.Persistence;
 
 using RevitTestServices;

--- a/test/Libraries/RevitIntegrationTests/ReferenceCurveTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ReferenceCurveTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 
 using Autodesk.Revit.DB;
-using DSCoreNodesUI.Input;
+using CoreNodeModels.Input;
 using Dynamo.Nodes;
 
 using NUnit.Framework;

--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -151,8 +151,8 @@
       <HintPath>$(DYNAMOTESTAPI)\ProtoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="DSCoreNodesUI">
-      <HintPath>$(DYNAMOTESTAPI)\nodes\DSCoreNodesUI.dll</HintPath>
+    <Reference Include="CoreNodeModels">
+      <HintPath>$(DYNAMOTESTAPI)\nodes\CoreNodeModels.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUnits">

--- a/test/Libraries/RevitIntegrationTests/SampleTests.cs
+++ b/test/Libraries/RevitIntegrationTests/SampleTests.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 using Autodesk.DesignScript.Geometry;
 
-using DSCoreNodesUI.Input;
+using CoreNodeModels.Input;
 using Dynamo.Selection;
 using Dynamo.Tests;
 
@@ -16,8 +16,8 @@ using RevitTestServices;
 
 using RTF.Framework;
 
-using DoubleSlider = DSCoreNodesUI.Input.DoubleSlider;
-using IntegerSlider = DSCoreNodesUI.Input.IntegerSlider;
+using DoubleSlider = CoreNodeModels.Input.DoubleSlider;
+using IntegerSlider = CoreNodeModels.Input.IntegerSlider;
 
 namespace RevitSystemTests
 {

--- a/test/Libraries/RevitIntegrationTests/SelectionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/SelectionTests.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using Autodesk.DesignScript.Geometry;
 using Autodesk.Revit.DB;
-using DSCoreNodesUI;
+using CoreNodeModels;
 using DSRevitNodesUI;
 using Dynamo.Graph.Nodes;
 using Dynamo.Interfaces;

--- a/test/Libraries/RevitIntegrationTests/StructuralFramingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/StructuralFramingTests.cs
@@ -14,7 +14,7 @@ using RevitTestServices;
 using RTF.Framework;
 
 using FamilyType = Revit.Elements.FamilyType;
-using IntegerSlider = DSCoreNodesUI.Input.IntegerSlider;
+using IntegerSlider = CoreNodeModels.Input.IntegerSlider;
 
 namespace RevitSystemTests
 {

--- a/test/Libraries/RevitIntegrationTests/ViewTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ViewTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
-using DSCoreNodesUI.Input;
+using CoreNodeModels.Input;
 using Dynamo.Nodes;
 
 using NUnit.Framework;

--- a/test/Libraries/RevitTestServices/RevitTestServices.csproj
+++ b/test/Libraries/RevitTestServices/RevitTestServices.csproj
@@ -112,9 +112,13 @@
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /Y /R $(ProjectDir)TestServices.dll.config $(TestOutputPath)</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <DllConfig Include="$(ProjectDir)TestServices.dll.config"/>
+    </ItemGroup>
+    <Copy SourceFiles="@(DllConfig)" DestinationFolder="$(TestOutputPath)" />
+  </Target>
+
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
### Purpose

Rename `DSCoreNodesUI` to `CoreNodeModels`

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Task link

[MAGN-9022 Rename DSCoreNodesUI to CoreNodeModels](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9022)

### Dependencies

To work correctly, [corresponding changes](https://github.com/DynamoDS/Dynamo/pull/5885) should be made in Dynamo

### Reviewers

@mjkkirschner 