### PR TITLE
Fix MAGN-9229 Crash after running a sample

### DIFF
--- a/src/Libraries/RevitServices/Materials/Materials.cs
+++ b/src/Libraries/RevitServices/Materials/Materials.cs
@@ -66,8 +66,19 @@ namespace RevitServices.Materials
             TransactionManager.Instance.EnsureInTransaction(
                 DocumentManager.Instance.CurrentDBDocument);
 
-            var glass = materials["Glass"];
-            var dynamoMaterial = glass.Duplicate("Dynamo");
+            Material glass;
+            Material dynamoMaterial;
+            if (materials.TryGetValue("Glass", out glass))
+            {
+                dynamoMaterial = glass.Duplicate("Dynamo");
+            }
+            else
+            {
+                var dynamoMaterialId = Material.Create(DocumentManager.Instance.CurrentDBDocument, "Dynamo");
+                dynamoMaterial = DocumentManager.Instance.CurrentDBDocument.GetElement(dynamoMaterialId) as Material;
+                dynamoMaterial.Transparency = 90;
+                dynamoMaterial.UseRenderAppearanceForShading = true;
+            }
             dynamoMaterial.Color = new Color(255, 128, 0);
             DynamoMaterialId = dynamoMaterial.Id;
 


### PR DESCRIPTION
### Purpose

This submission is to fix MAGN-9229 that a crash happens when a sample is run.

Actually this is a more general issue that when the material is not created successfully, later a tessellated face can not created successfully with a material id of null and an exception is thrown.

The reason the material is not created successfully is that in some cases, there are no materials named "Glass". This may happen if the string has been localized or if the material has been deleted. 

The fix here is to try to find the material named "Glass". If it is found, a new materail will be created based on it. This is the same as the old implementation. But if the material is not found, a new material will be created.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@mjkkirschner 
