### PR TITLE
MAGN 9341 followup 

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -233,16 +233,16 @@ namespace Dynamo.Applications.Models
 
         public override void PostTraceReconciliation(Dictionary<Guid, List<ISerializable>> orphanedSerializables)
         {
-            var orphanedIds = new List<int>();
+            var orphanedIds = new List<string>();
             var serializables =
                 orphanedSerializables
                 .SelectMany(kvp => kvp.Value)
                 .Where(x => x is ISerializable);
 
             orphanedIds.AddRange(serializables.Where(x => x is SerializableId).
-                Cast<SerializableId>().Select(sid => sid.IntID));
+                Cast<SerializableId>().Select(sid => sid.StringID));
             orphanedIds.AddRange(serializables.Where(x => x is MultipleSerializableId).
-                Cast<MultipleSerializableId>().SelectMany(sid => sid.IntIDs));
+                Cast<MultipleSerializableId>().SelectMany(sid => sid.StringIDs));
 
             if (!orphanedIds.Any())
                 return;
@@ -262,14 +262,14 @@ namespace Dynamo.Applications.Models
             }
         }
 
-        private static void DeleteOrphanedElements(IEnumerable<int> orphanedIds, ILogger logger)
+        private static void DeleteOrphanedElements(IEnumerable<string> orphanedIds, ILogger logger)
         {
             var toDelete = new List<ElementId>();
             foreach (var id in orphanedIds)
             {
                 // Check whether the element is valid before attempting to delete.
                 Element el;
-                if (DocumentManager.Instance.CurrentDBDocument.TryGetElement(new ElementId(id), out el))
+                if (DocumentManager.Instance.CurrentDBDocument.TryGetElement(id, out el))
                     toDelete.Add(el.Id);
             }
 

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -28,6 +28,8 @@ using RevitServices.Transactions;
 using Category = Revit.Elements.Category;
 using Element = Autodesk.Revit.DB.Element;
 using View = Autodesk.Revit.DB.View;
+using ProtoCore;
+using Dynamo.Graph.Nodes.ZeroTouch;
 
 namespace Dynamo.Applications.Models
 {
@@ -231,8 +233,57 @@ namespace Dynamo.Applications.Models
 
         #region trace reconciliation
 
+        /// <summary>
+        /// This method reconciles the current state of the host with the current trace data, in revit's case
+        /// deleting elements which have been orphaned and exist in trace but were not re-created
+        /// </summary>
+        /// <param name="orphanedSerializables"></param>
         public override void PostTraceReconciliation(Dictionary<Guid, List<ISerializable>> orphanedSerializables)
         {
+            // because of multiSerialzableIDs some extra logic is 
+            // required to detect if one multiSerializableID is a subset of another, if thats the case we should not delete it.
+
+            //get all the currentTraceData again
+            RuntimeCore runtimeCore = null;
+            if (this.EngineController != null && (this.EngineController.LiveRunnerCore != null))
+                runtimeCore = this.EngineController.LiveRunnerRuntimeCore;
+
+            if (runtimeCore == null)
+                return;
+
+            var toRemove = new List<String>();
+
+            foreach (var orphan in orphanedSerializables)
+            {
+                // Selecting all nodes that are either a DSFunction,
+                // a DSVarArgFunction or a CodeBlockNodeModel into a list.
+                var nodeGuids = this.Workspaces.Where(x => x.Guid == orphan.Key).First().Nodes.Where((n) =>
+                {
+                    return (n is DSFunction
+                            || (n is DSVarArgFunction)
+                            || (n is CodeBlockNodeModel));
+                }).Select((n) => n.GUID);
+
+                //this is a list of all trace data for all nodes in the workspace of this orphan
+                var nodeTraceDataList = runtimeCore.RuntimeData.GetCallsitesForNodes(nodeGuids, runtimeCore.DSExecutable);
+               
+                //check each callsite's traceData against the orphans
+                //if the orphaned serializable exists in the currentTraceData as as subset in a MultiSerializableID
+                //then remove it from the orphanList so we do not delete it later
+                foreach (var kvp in nodeTraceDataList)
+                {
+                    foreach (var cs in kvp.Value)
+                    {
+                        var currentSerializables = cs.TraceData.SelectMany(td => td.RecursiveGetNestedData());
+                        var currentStringIds = currentSerializables.OfType<MultipleSerializableId>().SelectMany(x => x.StringIDs).ToList();
+
+                        toRemove.AddRange(orphan.Value.OfType<MultipleSerializableId>().Where(x => currentSerializables.OfType<MultipleSerializableId>().Any(y => x.isSubset(y))).SelectMany(x=>x.StringIDs).ToList());
+                        toRemove.AddRange(currentStringIds.Intersect(orphan.Value.OfType<MultipleSerializableId>().SelectMany(y => y.StringIDs)).ToList());
+                    }
+
+                }
+            }
+           
             var orphanedIds = new List<string>();
             var serializables =
                 orphanedSerializables
@@ -244,9 +295,13 @@ namespace Dynamo.Applications.Models
             orphanedIds.AddRange(serializables.Where(x => x is MultipleSerializableId).
                 Cast<MultipleSerializableId>().SelectMany(sid => sid.StringIDs));
 
+            toRemove.ForEach(x => orphanedIds.Remove(x));
+            //the orphansList is now free of elements that are subsets of newly created element
+
+
             if (!orphanedIds.Any())
                 return;
-
+            
             if (IsTestMode)
             {
                 DeleteOrphanedElements(orphanedIds, Logger);

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -260,6 +260,11 @@ namespace Dynamo.Applications.Models
             //in either of these cases we must remove the IDs from the orphan list so they are not deleted by accident
             foreach (var orphan in orphanedSerializables)
             {
+                //if there are no multiSeriializables in the orphan then we can skip this orphan
+                if (orphan.Value.OfType<MultipleSerializableId>().Count() == 0)
+                {
+                    continue;
+                }
                 // Selecting all nodes that are either a DSFunction,
                 // a DSVarArgFunction or a CodeBlockNodeModel into a list.
                 var nodeGuids = this.Workspaces.Where(x => x.Guid == orphan.Key).First().Nodes.Where((n) =>

--- a/src/Libraries/RevitNodes/Elements/AbstractFamilyInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/AbstractFamilyInstance.cs
@@ -90,7 +90,7 @@ namespace Revit.Elements
 
         public override string ToString()
         {
-            return string.Format("Family={0}, Type={1}", InternalFamilyInstance.Symbol.Name, InternalFamilyInstance.Name);
+            return string.Format("Family={0}, Type={1}", InternalFamilyInstance != null ? InternalFamilyInstance.Symbol.Name : "empty", InternalFamilyInstance != null ? InternalFamilyInstance.Name : "empty");
         }
     }
 }

--- a/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
+++ b/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
@@ -436,6 +436,7 @@ namespace Revit.Elements
                 {
                     var fi = oldInstances.ElementAt(i);
                     Document.Delete(fi.Id);
+
                 }
 
                 // Create new adaptive components

--- a/src/Libraries/RevitServices/Persistence/ElementBinder.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementBinder.cs
@@ -102,7 +102,7 @@ namespace RevitServices.Persistence
             {
                 StringIDs.Add(element.UniqueId);
                 IntIDs.Add(element.Id.IntegerValue);
-            }            
+            }
         }
 
         /// <summary>
@@ -118,15 +118,15 @@ namespace RevitServices.Persistence
 
             for (int i = 0; i < numberOfElements; i++)
             {
-                string stringID = (string) info.GetValue("stringID-" + i, typeof (string));
-                int intID = (int) info.GetValue("intID-" + i, typeof (int));
+                string stringID = (string)info.GetValue("stringID-" + i, typeof(string));
+                int intID = (int)info.GetValue("intID-" + i, typeof(int));
 
                 StringIDs.Add(stringID);
                 IntIDs.Add(intID);
             }
 
         }
-        
+
         private void InitializeDataMembers()
         {
             StringIDs = new List<String>();
@@ -142,7 +142,7 @@ namespace RevitServices.Persistence
             }
 
             return this.IntIDs.SequenceEqual(mult.IntIDs) && this.StringIDs.SequenceEqual(mult.StringIDs);
-            
+
 
         }
 
@@ -152,16 +152,25 @@ namespace RevitServices.Persistence
             //concat the strings and int ids into one string and get hashcode and xor
             //a multiserializableID with same IDs in different order will return not equal  
             return (StringIDs == null ? 0 : StringIDs.Aggregate((i, j) => i + " " + j).GetHashCode()) ^
-             (IntIDs == null ? 0: IntIDs.Select(x => x.ToString()).Aggregate((i, j) => i + " " + j).GetHashCode());
+             (IntIDs == null ? 0 : IntIDs.Select(x => x.ToString()).Aggregate((i, j) => i + " " + j).GetHashCode());
 
-         }
         }
 
+        /// <summary>
+        /// this method tests if this multiSerializableId is contained in another
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public virtual bool isSubset(MultipleSerializableId other)
+        {
+            return !this.StringIDs.Except(other.StringIDs).Any();
+        }
 
-    /// <summary>
-    /// Class for handling unique ids in a typesafe ammner
-    /// </summary>
-    public class ElementUUID
+    }
+        /// <summary>
+        /// Class for handling unique ids in a typesafe ammner
+        /// </summary>
+        public class ElementUUID
     {
         public String UUID { get; set; }
 


### PR DESCRIPTION
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9341

I found that when a .dyn file contained data to rebind to, but a Revit file did not contain the elements, these elements might be deleted immediately after they had been created(on first run) if the elements shared the same elementIds as those there were in trace, this is **not** uncommon, as elementIds are not unique. The result is that we delete the elements and the graph is in a null state and appears to have done nothing and will soon crash.

I have modified PostTraceReconciliation to use uniqueIds instead of elementsIDs, so that in the case that the elementsIds in trace are the same as the ones for new elements being created we do not delete the new elements.

### updates:

I have also made some changes to handle some cases that @riteshchandawar found where elements where still being deleted on rerun of the graph if the number of inputs to the `AdaptiveComponent.ByPoints` node changed.

I've modified `PostTraceReconciliation` for the cases where `MultiSerialzableID` is found as an orphan, but  either is totally contained by the elements which are about to be created on the latest graph run Or cases where the elements which are about to be created are contained in an orphaned Id, in either of these cases the orphaned Ids will be deleted and thus the newly created elements will be null...

Instead we remove these ids which intersect between current Ids and orphaned Ids.

I have done this in PostTraceReconciliation opposed to the `GetOrphanedSerializables()` method to keep the Revit implementation details out of core
https://github.com/DynamoDS/Dynamo/blob/master/src/Engine/ProtoCore/Lang/CallSite.cs#L621

last I have added null checks to `abstractFamily` class `toString` since the new AdaptiveComponent for batching constructor sometimes deletes elements from the Revit Document there are cases where a wrapper is left in the elementLifeCycleManager and calling toString on the empty wrapper causes the graph to spit out all nulls.  Imagine the case where an element collector gathers ACs from the document, but the AC constructor destroys them, but this is just a stop gap, we should look into that case more specifically in a future task as the behavior is not well defined.


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] All tests pass using the self-service CI.


### Reviewers

@Randy-Ma or @Benglin 

### FYIs

@riteshchandawar 
@kronz 