### PR TITLE
2015: UTC offset

### DIFF
--- a/src/Libraries/RevitNodes/Elements/SunSettings.cs
+++ b/src/Libraries/RevitNodes/Elements/SunSettings.cs
@@ -124,6 +124,11 @@ namespace Revit.Elements
             // Get user local hours offset.
             var offset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow).Hours;
 
+            if (TimeZoneInfo.Local.IsDaylightSavingTime(DateTime.UtcNow))
+            {
+                offset--;
+            }
+
             // Remove user local offset. Just leave pure revit datetime.
             return utc.AddHours(offset);
         }

--- a/src/Libraries/RevitNodes/Elements/SunSettings.cs
+++ b/src/Libraries/RevitNodes/Elements/SunSettings.cs
@@ -89,7 +89,7 @@ namespace Revit.Elements
         /// </summary>
         public DateTime StartDateTime
         {
-            get { return InternalSunAndShadowSettings.StartDateAndTime; }
+            get { return TranslateTime(InternalSunAndShadowSettings.StartDateAndTime); }
         }
         
         /// <summary>
@@ -97,7 +97,7 @@ namespace Revit.Elements
         /// </summary>
         public DateTime EndDateTime
         {
-            get { return InternalSunAndShadowSettings.EndDateAndTime; }
+            get { return TranslateTime(InternalSunAndShadowSettings.EndDateAndTime); }
         }
 
         /// <summary>
@@ -105,8 +105,27 @@ namespace Revit.Elements
         /// </summary>
         public DateTime CurrentDateTime
         {
-            get { return InternalSunAndShadowSettings.ActiveFrameTime; }
+            get { return TranslateTime(InternalSunAndShadowSettings.ActiveFrameTime); }
         }
 
+        /// <summary>
+        /// Fix for: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8993
+        /// 
+        /// StartDateAndTime, EndDateAndTime and ActiveFrameTime should return local datetime,
+        /// that is set in Revit project configuration.
+        /// But it returns customized datetime + user timezone offset, which is incorrect.
+        /// Althought in documentation it's said, 
+        /// that "The output value will be in Coordinated Universal Time (UTC), 
+        /// but input may be in local time as well."
+        /// There is no means to return local time.
+        /// </summary>
+        internal static DateTime TranslateTime(DateTime utc)
+        {
+            // Get user local hours offset.
+            var offset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow).Hours;
+
+            // Remove user local offset. Just leave pure revit datetime.
+            return utc.AddHours(offset);
+        }
     }
 }

--- a/src/Libraries/RevitNodes/Elements/SunSettings.cs
+++ b/src/Libraries/RevitNodes/Elements/SunSettings.cs
@@ -85,15 +85,15 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        ///     Gets the Start Date and Time of the solar study.
+        ///     Gets the Start Date and Time of the solar study given in the local time of the solar study location.  
         /// </summary>
         public DateTime StartDateTime
         {
             get { return TranslateTime(InternalSunAndShadowSettings.StartDateAndTime); }
         }
-        
+
         /// <summary>
-        ///     Gets the End Date and Time of the solar study.
+        ///     Gets the End Date and Time of the solar study given in the local time of the solar study location.  
         /// </summary>
         public DateTime EndDateTime
         {
@@ -101,7 +101,7 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        ///     Gets the Date and Time for the current frame of the solar study.
+        ///     Gets the Date and Time for the current frame of the solar study given in the local time of the solar study location.  
         /// </summary>
         public DateTime CurrentDateTime
         {

--- a/test/Libraries/RevitNodesTests/Elements/SunSettingsTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/SunSettingsTests.cs
@@ -44,7 +44,8 @@ namespace RevitNodesTests.Elements
         public void StartDateTime()
         {
             Assert.AreEqual(
-                DocumentManager.Instance.CurrentDBDocument.ActiveView.SunAndShadowSettings.StartDateAndTime,
+                SunSettings.TranslateTime(
+                DocumentManager.Instance.CurrentDBDocument.ActiveView.SunAndShadowSettings.StartDateAndTime),
                 SunSettings.Current().StartDateTime);
         }
 
@@ -52,7 +53,8 @@ namespace RevitNodesTests.Elements
         public void EndDateTime()
         {
             Assert.AreEqual(
-                DocumentManager.Instance.CurrentDBDocument.ActiveView.SunAndShadowSettings.EndDateAndTime,
+                SunSettings.TranslateTime(
+                DocumentManager.Instance.CurrentDBDocument.ActiveView.SunAndShadowSettings.EndDateAndTime),
                 SunSettings.Current().EndDateTime);
         }
 
@@ -60,7 +62,8 @@ namespace RevitNodesTests.Elements
         public void CurrentDateTime()
         {
             Assert.AreEqual(
-                DocumentManager.Instance.CurrentDBDocument.ActiveView.SunAndShadowSettings.ActiveFrameTime,
+                SunSettings.TranslateTime(
+                DocumentManager.Instance.CurrentDBDocument.ActiveView.SunAndShadowSettings.ActiveFrameTime),
                 SunSettings.Current().CurrentDateTime);
         }
     }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8993](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8993) Correct UTC offset for Solar Radiation workflow from Revit.

If I understood the issue correct... This is an old bug, that was first mentioned here in 2014 year: http://dynamobim.com/forums/topic/sunsettings-current/

SunSettings.CurrentDateTime as well as SunSettings.StartDateTime and SunSettings.EndDateTime return wrong datetime value. This value has some strange offset.

![image](https://cloud.githubusercontent.com/assets/8158404/12852534/151fb5e8-cc38-11e5-9bed-7660a33e3ed9.png)

For me this offset is 3 hours. But it depends on user's time zone. That's why MOHAMMAD RAHMANI (user from link above) had the same wrong offset, but for 5 hours.

This is bug of Revit API. It returns custom time - user time zone offset.
I found old API(2014) here: http://revitapisearch.com/html/e50880d2-cab4-3cb5-56c8-6a7faaa0725b.htm

It's said, that: "The date and time. The output value will be in Coordinated Universal Time (UTC), but input may be in local time as well." But I couldn't find any way to return local time.
So, I made some workaround:
I get users local timezone offset and add it to datetime, that provide Revit API.

Results:
![image](https://cloud.githubusercontent.com/assets/8158404/12852911/0b7478ba-cc3a-11e5-8cb0-9069daa674eb.png)
![image](https://cloud.githubusercontent.com/assets/8158404/12852998/5dda02e6-cc3a-11e5-81e6-f58d8607da25.png)

NB! Sometimes Sunsettings are null or wrong... For now problem is not found. And I can't reproduce it consistently.
![image](https://cloud.githubusercontent.com/assets/8158404/12853063/ad53778a-cc3a-11e5-8f6f-f6f79a3b6bea.png)

### Declarations

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.


### Reviewers

Could you try this fix in your time zone?
@mjkkirschner 
@ramramps 

### FYIs

@ikeough , I believe Ian knows more about it, then anyone else.