### PR TITLE
Update test cases because of the change of replication behavior

### DIFF
--- a/test/System/AdaptiveComponent/AdaptiveComponentByCurve.dyn
+++ b/test/System/AdaptiveComponent/AdaptiveComponentByCurve.dyn
@@ -6,7 +6,7 @@
     </Dynamo.Nodes.DSModelElementSelection>
     <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="e83c14bb-864f-4730-900f-0905dac6dcad" nickname="AdaptiveComponent.ByParametersOnCurveReference" x="811.261830929377" y="372.132597952746" isVisible="true" isUpstreamVisible="true" lacing="Longest" assembly="..\..\..\..\..\..\..\..\..\Program%20Files\Dynamo%200.7\Revit_2014\RevitNodes.dll" function="Revit.Elements.AdaptiveComponent.ByParametersOnCurveReference@double[],var,Revit.Elements.FamilySymbol" />
     <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="a3f48358-9871-4f7e-8da6-b1700a917359" nickname="CurveElement.Curve" x="584.532526757906" y="395.624850858758" isVisible="true" isUpstreamVisible="true" lacing="Longest" assembly="..\..\..\..\..\..\..\..\..\Program%20Files\Dynamo%200.7\Revit_2014\RevitNodes.dll" function="Revit.Elements.CurveElement.Curve" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="cd3fa904-8507-4fd1-a073-3658e76b90d5" nickname="Code Block" x="638.451611694758" y="272.588424244163" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0..1..#10;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="cd3fa904-8507-4fd1-a073-3658e76b90d5" nickname="Code Block" x="638.451611694758" y="272.588424244163" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{0..1..#10};" ShouldFocus="false" />
     <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="272d86db-a124-48dd-9c41-6a3b17200e10" nickname="Flatten" x="1195.51217405465" y="374.325228146728" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="Flatten@var[]..[]" />
   </Elements>
   <Connectors>

--- a/test/System/Level/Level.dyn
+++ b/test/System/Level/Level.dyn
@@ -1,29 +1,36 @@
-<Workspace Version="0.8.0.706" X="30.0000000000001" Y="181.881967213115" zoom="1.07868852459016" Name="Home" RunType="Manual" RunPeriod="100">
+<Workspace Version="1.0.0.460" X="30.0000000000001" Y="181.881967213115" zoom="1.07868852459016" Name="Home" Description="" RunType="Manual" RunPeriod="100" HasRunWithoutCrash="False">
   <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.DSFunction guid="4011b605-3673-4019-8b3c-776598cae7d9" type="Dynamo.Nodes.DSFunction" nickname="Level.ByElevationAndName" x="733" y="108" isVisible="true" isUpstreamVisible="true" lacing="Longest" assembly="RevitNodes.dll" function="Revit.Elements.Level.ByElevationAndName@double,string" />
-    <Dynamo.Nodes.DoubleInput guid="7b6a0adf-b097-42b9-8f70-ef2cbc170f1f" type="Dynamo.Nodes.DoubleInput" nickname="Number" x="0" y="37" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="4011b605-3673-4019-8b3c-776598cae7d9" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Level.ByElevationAndName" x="733" y="108" isVisible="true" isUpstreamVisible="true" lacing="Longest" isSelectedInput="False" IsFrozen="false" assembly="RevitNodes.dll" function="Revit.Elements.Level.ByElevationAndName@double,string" />
+    <CoreNodeModels.Input.DoubleInput guid="7b6a0adf-b097-42b9-8f70-ef2cbc170f1f" type="CoreNodeModels.Input.DoubleInput" nickname="Number" x="0" y="37" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
       <System.Double value="0..10..2" />
-    </Dynamo.Nodes.DoubleInput>
-    <Dynamo.Nodes.StringInput guid="e20d6c2f-6ed2-4f40-b982-52463054a42b" type="Dynamo.Nodes.StringInput" nickname="String" x="0" y="120" isVisible="true" isUpstreamVisible="true" lacing="Disabled">
+    </CoreNodeModels.Input.DoubleInput>
+    <CoreNodeModels.Input.StringInput guid="e20d6c2f-6ed2-4f40-b982-52463054a42b" type="CoreNodeModels.Input.StringInput" nickname="String" x="0" y="120" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false">
       <System.String>Level </System.String>
       <System.String value="Level " />
-    </Dynamo.Nodes.StringInput>
-    <DSCore.CartesianProduct guid="660f08a6-be25-436d-9071-61b280cabd7c" type="DSCore.CartesianProduct" nickname="List.CartesianProduct" x="470" y="134" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="3" />
-    <Dynamo.Nodes.DSVarArgFunction guid="24e7414f-2de8-4369-9047-14baa5e16560" type="Dynamo.Nodes.DSVarArgFunction" nickname="String.Concat" x="0" y="204" isVisible="true" isUpstreamVisible="true" lacing="Disabled" assembly="DSCoreNodes.dll" function="DSCore.String.Concat@string[]" inputcount="2" />
-    <DSCoreNodesUI.CreateList guid="517aa1a8-9f82-4e19-b4d5-475da4cd10d8" type="DSCoreNodesUI.CreateList" nickname="Create List" x="244" y="119" isVisible="true" isUpstreamVisible="true" lacing="Disabled" inputcount="1" />
-    <Dynamo.Nodes.DSFunction guid="353973c3-3d95-4441-bb5e-bcc14b407b3d" type="Dynamo.Nodes.DSFunction" nickname="List.Count" x="733" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" assembly="DSCoreNodes.dll" function="DSCore.List.Count@var[]..[]" />
-    <DSCoreNodesUI.StringNodes.FromObject guid="fddb5e91-1d8c-461d-822b-e5b3b45ab9f8" type="DSCoreNodesUI.StringNodes.FromObject" nickname="String from Object" x="243.4726443769" y="223.650455927052" isVisible="true" isUpstreamVisible="true" lacing="Disabled" />
+    </CoreNodeModels.Input.StringInput>
+    <CoreNodeModels.HigherOrder.CartesianProduct guid="660f08a6-be25-436d-9071-61b280cabd7c" type="CoreNodeModels.HigherOrder.CartesianProduct" nickname="List.CartesianProduct" x="470" y="134" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" inputcount="3" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction guid="24e7414f-2de8-4369-9047-14baa5e16560" type="Dynamo.Graph.Nodes.ZeroTouch.DSVarArgFunction" nickname="String.Concat" x="0" y="204" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.String.Concat@string[]" inputcount="2" />
+    <CoreNodeModels.CreateList guid="517aa1a8-9f82-4e19-b4d5-475da4cd10d8" type="CoreNodeModels.CreateList" nickname="Create List" x="244" y="119" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" inputcount="1" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="353973c3-3d95-4441-bb5e-bcc14b407b3d" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="List.Count" x="733" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" assembly="DSCoreNodes.dll" function="DSCore.List.Count@var[]..[]" />
+    <CoreNodeModels.FromObject guid="fddb5e91-1d8c-461d-822b-e5b3b45ab9f8" type="CoreNodeModels.FromObject" nickname="String from Object" x="243.4726443769" y="223.650455927052" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="a6fd4423-071a-465d-86c0-1004cc3df576" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="Flatten" x="677.272036474167" y="224.516717325229" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" assembly="BuiltIn" function="Flatten@var[]..[]" />
   </Elements>
   <Connectors>
-    <Dynamo.Models.ConnectorModel start="7b6a0adf-b097-42b9-8f70-ef2cbc170f1f" start_index="0" end="4011b605-3673-4019-8b3c-776598cae7d9" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="7b6a0adf-b097-42b9-8f70-ef2cbc170f1f" start_index="0" end="353973c3-3d95-4441-bb5e-bcc14b407b3d" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="7b6a0adf-b097-42b9-8f70-ef2cbc170f1f" start_index="0" end="fddb5e91-1d8c-461d-822b-e5b3b45ab9f8" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="e20d6c2f-6ed2-4f40-b982-52463054a42b" start_index="0" end="517aa1a8-9f82-4e19-b4d5-475da4cd10d8" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="660f08a6-be25-436d-9071-61b280cabd7c" start_index="0" end="4011b605-3673-4019-8b3c-776598cae7d9" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="24e7414f-2de8-4369-9047-14baa5e16560" start_index="0" end="660f08a6-be25-436d-9071-61b280cabd7c" end_index="0" portType="0" />
-    <Dynamo.Models.ConnectorModel start="517aa1a8-9f82-4e19-b4d5-475da4cd10d8" start_index="0" end="660f08a6-be25-436d-9071-61b280cabd7c" end_index="1" portType="0" />
-    <Dynamo.Models.ConnectorModel start="fddb5e91-1d8c-461d-822b-e5b3b45ab9f8" start_index="0" end="660f08a6-be25-436d-9071-61b280cabd7c" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7b6a0adf-b097-42b9-8f70-ef2cbc170f1f" start_index="0" end="353973c3-3d95-4441-bb5e-bcc14b407b3d" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7b6a0adf-b097-42b9-8f70-ef2cbc170f1f" start_index="0" end="fddb5e91-1d8c-461d-822b-e5b3b45ab9f8" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="7b6a0adf-b097-42b9-8f70-ef2cbc170f1f" start_index="0" end="4011b605-3673-4019-8b3c-776598cae7d9" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="e20d6c2f-6ed2-4f40-b982-52463054a42b" start_index="0" end="517aa1a8-9f82-4e19-b4d5-475da4cd10d8" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="660f08a6-be25-436d-9071-61b280cabd7c" start_index="0" end="a6fd4423-071a-465d-86c0-1004cc3df576" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="24e7414f-2de8-4369-9047-14baa5e16560" start_index="0" end="660f08a6-be25-436d-9071-61b280cabd7c" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="517aa1a8-9f82-4e19-b4d5-475da4cd10d8" start_index="0" end="660f08a6-be25-436d-9071-61b280cabd7c" end_index="1" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="fddb5e91-1d8c-461d-822b-e5b3b45ab9f8" start_index="0" end="660f08a6-be25-436d-9071-61b280cabd7c" end_index="2" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="a6fd4423-071a-465d-86c0-1004cc3df576" start_index="0" end="4011b605-3673-4019-8b3c-776598cae7d9" end_index="1" portType="0" />
   </Connectors>
   <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
 </Workspace>


### PR DESCRIPTION
### Purpose

This PR updates two test cases `RevitSystemTests.LevelTests.Level` and `RevitSystemTests.AdaptiveComponentTests.AdaptiveComponentByCurve` because of the change of replication behavior in https://github.com/DynamoDS/Dynamo/pull/6110.

In test case `RevitSystemTests.LevelTests.Level`, the second argument of `Level.ByElevationAndName` was a two-dimensional list while the first argument is one-dimensional list. As this node uses longest lacing, because of the change in https://github.com/DynamoDS/Dynamo/pull/6110, zip replication applies. This PR flattens the second argument.

In test case `RevitSystemTests.AdaptiveComponentTests.AdaptiveComponentByCurve`, the first argument of `AdaptiveComponent.ByParametersOnCurveReference` was a one-dimensional list. As the rank of first parameter is `double[][]` and the node uses longest lacing, zip replication applies so that the first argument won't be promoted to two-dimensional list before replication. This PR updates the first argument to two-dimensional list.

### FYIs
@riteshchandawar 