### PR TITLE
Update failed test case AdaptiveComponentTests.AdaptiveComponentByCurve

### DIFF
--- a/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
+++ b/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
@@ -71,7 +71,7 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             // Check for number of Family Instance Creation
-            var allElements = "e83c14bb-864f-4730-900f-0905dac6dcad";
+            var allElements = "272d86db-a124-48dd-9c41-6a3b17200e10";
             AssertPreviewCount(allElements, 10);
 
         }


### PR DESCRIPTION
### Purpose

It is failing because the test case tries to verify node `AdaptiveComponent.ByParametersOnCurveReference()` generates 10 items, but as this node generates a list of list, it only has 1 item. Updating this test case to verify the result in `Flatten()` node.