### PR TITLE
Check IsValidObject for DirectShape.

### DIFF
--- a/src/Libraries/RevitNodes/Elements/DirectShape.cs
+++ b/src/Libraries/RevitNodes/Elements/DirectShape.cs
@@ -439,8 +439,8 @@ namespace Revit.Elements
         /// Please see InternalSetName method
         /// </summary>
         public override string ToString()
-        { 
-            return InternalDirectShape.Name;
+        {
+            return InternalDirectShape.IsValidObject ? InternalDirectShape.Name : String.Empty;
         }
     }
 }


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-8309](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8309) sometimes after some Revit direct shape element is deleted in manual mode, after a Revit API exception this exception crashes Dynamo

In task it's said, that: "The referenced object is not valid, possibly because it has been deleted from the database, or its creation was undone".

Although we couldn't reproduce this bug, we decided to add some checks in order to prevent this bug in future.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.


### Reviewers

@mjkkirschner 
