### PR TITLE
Fix MAGN-9229 Crash after running Core_AttractorPoint.dyn sample

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitMesh.cs
@@ -139,6 +139,76 @@ namespace Revit.GeometryConversion
 
             return result.GetGeometricalObjects();
         }
+        
+        /// <summary>
+        /// This is to create a bounding box mesh for geometries which have errors during the tessellating process
+        /// </summary>
+        /// <param name="minPoint"></param>
+        /// <param name="maxPoint"></param>
+        /// <param name="performHostUnitConversion"></param>
+        /// <returns></returns>
+        public static IList<GeometryObject> CreateBoundingBoxMeshForErrors(Autodesk.DesignScript.Geometry.Point minPoint,
+            Autodesk.DesignScript.Geometry.Point maxPoint, bool performHostUnitConversion = true)
+        {
+            double x0 = minPoint.X;
+            double y0 = minPoint.Y;
+            double z0 = minPoint.Z;
+            double x1 = maxPoint.X;
+            double y1 = maxPoint.Y;
+            double z1 = maxPoint.Z;
+
+            x0 -= 1.0;
+            y0 -= 1.0;
+            z0 -= 1.0;
+            x1 += 1.0;
+            y1 += 1.0;
+            z1 += 1.0;
+
+            var tsb = new TessellatedShapeBuilder() { Fallback = TessellatedShapeBuilderFallback.Salvage,
+                                                      Target = TessellatedShapeBuilderTarget.Mesh,
+                                                      GraphicsStyleId = ElementId.InvalidElementId
+            };
+            tsb.OpenConnectedFaceSet(false);
+
+            var p0 = new XYZ(x0, y0, z0);
+            var p1 = new XYZ(x1, y0, z0);
+            var p2 = new XYZ(x1, y1, z0);
+            var p3 = new XYZ(x0, y1, z0);
+            var p4 = new XYZ(x0, y0, z1);
+            var p5 = new XYZ(x1, y0, z1);
+            var p6 = new XYZ(x1, y1, z1);
+            var p7 = new XYZ(x0, y1, z1);
+
+            var f1 = new TessellatedFace(new List<XYZ>() { p0, p1, p2 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f1);
+            var f2 = new TessellatedFace(new List<XYZ>() { p2, p3, p0 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f2);
+            var f3 = new TessellatedFace(new List<XYZ>() { p0, p1, p5 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f3);
+            var f4 = new TessellatedFace(new List<XYZ>() { p5, p4, p0 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f4);
+            var f5 = new TessellatedFace(new List<XYZ>() { p1, p2, p6 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f5);
+            var f6 = new TessellatedFace(new List<XYZ>() { p6, p5, p1 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f6);
+            var f7 = new TessellatedFace(new List<XYZ>() { p2, p3, p7 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f7);
+            var f8 = new TessellatedFace(new List<XYZ>() { p7, p6, p2 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f8);
+            var f9 = new TessellatedFace(new List<XYZ>() { p3, p0, p4 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f9);
+            var f10 = new TessellatedFace(new List<XYZ>() { p4, p7, p3 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f10);
+            var f11 = new TessellatedFace(new List<XYZ>() { p4, p5, p6 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f11);
+            var f12 = new TessellatedFace(new List<XYZ>() { p6, p7, p4 }, MaterialsManager.Instance.DynamoErrorMaterialId);
+            tsb.AddFace(f12);
+
+            tsb.CloseConnectedFaceSet();
+            tsb.Build();
+            var result = tsb.GetBuildResult();
+            return result.GetGeometricalObjects();
+        }
 
         /// <summary>
         /// this method converts a ProtoGeometry IndexGroup and Points to a Revit tessellated face, and adds it


### PR DESCRIPTION
### Purpose

This fix is to address some crashes when the Revit background preview is turned on. In the case when the solids/surfaces are very small, in the process of building geoemtries from the facets, there will be exceptions thrown. For the case in MAGN-9229, the solids are really small and exceptions are thrown when geometries are attempted to be created out of the facets.

The fix here strengthens the tessellation process for geometries involved in Revit background preview by providing fallback mechanisms if exceptions are thrown in the process. 

The following logic is implemented for tessellating solids:
1). Try to build geometries out of solids;
2). If there are exceptions, then try to build geometries out of surface geometries of the solids;
3). If there are exceptions, then try to build geometries out of curve geometries of the solids' edges;

The followin logic is implemented for tessellating surfaces:
1). Try to build geometries out of surfaces;
2). If there are exceptions, then try to build geometries out of curve geometries of the surfaces' edges;

The followin logic is implemented for tessellating curves:
1). Try to build polylines/lines from tessellated points of curves;
2). If there are exceptions, try to create a line from the start point and end point;
3). If there are exceptions, try to create a point from the start point;
4). If there are exceptions, do not create any geometries;

As you can see, there are some loss of geometry information for tiny geometries and geometries in some edge cases(e.g. points with infinite X, Y or Z). But the stability will be improved a lot.

For geometries which are not drawn completely, a light red bounding box which is bigger than the original bounding box of the geometry is drawn around it to identify that something wrong has happened. (But this does not include point with infinite X, Y or Z value).

The following graph is trying to draw some cuboids and some tiny spheres:
![image](https://cloud.githubusercontent.com/assets/5584246/13315132/f1259264-dbe3-11e5-81af-9c938e3254df.png)

The spheres can not be faceted correctly and are not drawn, instead a light red bounding box is drawn around it:
![image](https://cloud.githubusercontent.com/assets/5584246/13315110/ca145de0-dbe3-11e5-8488-840f6514bfc9.png)

The fix will also fix the crashes in MAGN-6024 and MAGN-9486 which are related to Revit background preview.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR

### Reviewers

@sharadkjaiswal 

### FYIs

@kronz @mccrone @Racel @riteshchandawar @monikaprabhu 