### PR TITLE
MAGN-7419 Revit/Category/Create/Category.ByName is busted (2016)

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Category.cs
+++ b/src/Libraries/RevitNodes/Elements/Category.cs
@@ -118,7 +118,7 @@ namespace Revit.Elements
 
             if (category == null)
             {
-                throw new Exception(Properties.Resources.InvalidCategory);
+                throw new ArgumentException(Properties.Resources.InvalidCategory);
             }
 
             return new Category(category);

--- a/src/Libraries/RevitNodes/Elements/Category.cs
+++ b/src/Libraries/RevitNodes/Elements/Category.cs
@@ -68,10 +68,29 @@ namespace Revit.Elements
                 throw new ArgumentNullException("name");
             }
 
+            // Find category using localized name
             Settings documentSettings = DocumentManager.Instance.CurrentDBDocument.Settings;
             var groups = documentSettings.Categories;
-            var builtInCat = (BuiltInCategory)Enum.Parse(typeof(BuiltInCategory), name);
-            var category = groups.get_Item(builtInCat);
+
+            Autodesk.Revit.DB.Category category = null;
+
+            if (groups.Contains(name))
+            {
+                category = groups.get_Item(name);
+            }
+
+            if(category == null)
+            {
+                // Fall back
+                // Use category enum name with or without OST_ prefix
+                var fullName = name.Length > 3 && name.Substring(0, 4) == "OST_" ? name : "OST_" + name;
+                var names = Enum.GetNames(typeof(BuiltInCategory));
+                if(System.Array.Exists(names, entry => entry == fullName))
+                {
+                    var builtInCat = (BuiltInCategory)Enum.Parse(typeof(BuiltInCategory), fullName);
+                    category = groups.get_Item(builtInCat);
+                }
+            }
 
             if (category == null)
             {

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -449,9 +449,19 @@ namespace DSRevitNodesUI
                     continue;
                 }
 
-                if(category != null && category.Parent == null)
+                if(category != null)
                 {
-                    Items.Add(new DynamoDropDownItem(category.Name, categoryId));
+                    string name;
+                    if(category.Parent == null)
+                    {
+                        name = category.Name;
+                    }
+                    else
+                    {
+                        name = category.Parent.Name + " - " + category.Name;
+                    }
+
+                    Items.Add(new DynamoDropDownItem(name, categoryId));
                 }
             }
 

--- a/test/Libraries/RevitNodesTests/Elements/CategoryTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/CategoryTests.cs
@@ -24,6 +24,24 @@ namespace RevitNodesTests.Elements
 
         [Test]
         [TestModel(@".\empty.rvt")]
+        public void CategoryByName_ValidArgsShort()
+        {
+            var cat = Category.ByName("PointClouds");
+            Assert.NotNull(cat);
+            Assert.AreEqual(cat.Id, cat.InternalCategory.Id.IntegerValue);
+        }
+
+        [Test]
+        [TestModel(@".\empty.rvt")]
+        public void CategoryByName_ValidArgsLong()
+        {
+            var cat = Category.ByName("Point Clouds");
+            Assert.NotNull(cat);
+            Assert.AreEqual(cat.Id, cat.InternalCategory.Id.IntegerValue);
+        }
+
+        [Test]
+        [TestModel(@".\empty.rvt")]
         public void CategoryByName_BadArgs()
         {
             Assert.Throws<ArgumentException>(()=>Category.ByName("foo"));


### PR DESCRIPTION
### Purpose

###### Allow Category.ByName to accept the category name, the category enum name or the truncated category enum name. For example:
"Cable Trays"
"OST_CableTray"
"CableTray"
![image](https://cloud.githubusercontent.com/assets/7033002/13319487/ec3e76e8-db8f-11e5-944a-d8925b5b856c.png)


* Only the category enum name has been supported before.

###### Display the category name with proper display of subcategories in the Categories combo:

![image](https://cloud.githubusercontent.com/assets/7033002/13319393/65076d74-db8f-11e5-97d6-e4088ff80dac.png)

* Subcategories are displayed as "Parent Category - Subcategory".
* Serialization has not changed. The truncated enum name is still used.
* Internal/deprecated categories are now filtered out. This will fix "MAGN-6909 Categories drop down fails for several categories".


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.


### Reviewers

@mjkkirschner 
@QilongTang 

* This PR is for Revit 2016

### FYIs

@jnealb 