### PR TITLE
MAGN-7419 Revit/Category/Create/Category.ByName is busted (2015)

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Category.cs
+++ b/src/Libraries/RevitNodes/Elements/Category.cs
@@ -118,7 +118,7 @@ namespace Revit.Elements
 
             if (category == null)
             {
-                throw new Exception(Properties.Resources.InvalidCategory);
+                throw new ArgumentException(Properties.Resources.InvalidCategory);
             }
 
             return new Category(category);

--- a/src/Libraries/RevitNodes/Elements/Category.cs
+++ b/src/Libraries/RevitNodes/Elements/Category.cs
@@ -68,10 +68,29 @@ namespace Revit.Elements
                 throw new ArgumentNullException("name");
             }
 
+            // Find category using localized name
             Settings documentSettings = DocumentManager.Instance.CurrentDBDocument.Settings;
             var groups = documentSettings.Categories;
-            var builtInCat = (BuiltInCategory)Enum.Parse(typeof(BuiltInCategory), name);
-            var category = groups.get_Item(builtInCat);
+
+            Autodesk.Revit.DB.Category category = null;
+
+            if (groups.Contains(name))
+            {
+                category = groups.get_Item(name);
+            }
+
+            if(category == null)
+            {
+                // Fall back
+                // Use category enum name with or without OST_ prefix
+                var fullName = name.Length > 3 && name.Substring(0, 4) == "OST_" ? name : "OST_" + name;
+                var names = Enum.GetNames(typeof(BuiltInCategory));
+                if(System.Array.Exists(names, entry => entry == fullName))
+                {
+                    var builtInCat = (BuiltInCategory)Enum.Parse(typeof(BuiltInCategory), fullName);
+                    category = groups.get_Item(builtInCat);
+                }
+            }
 
             if (category == null)
             {

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -433,7 +433,7 @@ namespace DSRevitNodesUI
         public override void PopulateItems()
         {
             Items.Clear();
-            var document = DocumentManager.Instance.CurrentDBDocument;
+            var categories = DocumentManager.Instance.CurrentDBDocument.Settings.Categories;
 
             foreach (BuiltInCategory categoryId in Enum.GetValues(typeof(BuiltInCategory)))
             {
@@ -441,7 +441,7 @@ namespace DSRevitNodesUI
                 
                 try 
                 {
-                    category = Autodesk.Revit.DB.Category.GetCategory(document, categoryId);
+                    category = categories.get_Item(categoryId);
                 }
                 catch
                 {
@@ -461,9 +461,9 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            var document = DocumentManager.Instance.CurrentDBDocument;
-            BuiltInCategory categoryId = (BuiltInCategory) Items[SelectedIndex].Item;
-            Autodesk.Revit.DB.Category category = Autodesk.Revit.DB.Category.GetCategory(document, categoryId);
+            var categories = DocumentManager.Instance.CurrentDBDocument.Settings.Categories;
+            BuiltInCategory categoryId = (BuiltInCategory)Items[SelectedIndex].Item;
+            Autodesk.Revit.DB.Category category = categories.get_Item(categoryId);
             string name = getFullName(category);
 
             var args = new List<AssociativeNode>

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -448,9 +448,19 @@ namespace DSRevitNodesUI
                     continue;
                 }
 
-                if(category != null && category.Parent == null)
+                if(category != null)
                 {
-                    Items.Add(new DynamoDropDownItem(category.Name, categoryId));
+                    string name;
+                    if(category.Parent == null)
+                    {
+                        name = category.Name;
+                    }
+                    else
+                    {
+                        name = category.Parent.Name + " - " + category.Name;
+                    }
+
+                    Items.Add(new DynamoDropDownItem(name, categoryId));
                 }
             }
 

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -433,9 +433,25 @@ namespace DSRevitNodesUI
         public override void PopulateItems()
         {
             Items.Clear();
-            foreach (var constant in Enum.GetValues(typeof(BuiltInCategory)))
+            var document = DocumentManager.Instance.CurrentDBDocument;
+
+            foreach (BuiltInCategory categoryId in Enum.GetValues(typeof(BuiltInCategory)))
             {
-                Items.Add(new DynamoDropDownItem(constant.ToString().Substring(4), constant));
+                Autodesk.Revit.DB.Category category;
+                
+                try 
+                {
+                    category = Autodesk.Revit.DB.Category.GetCategory(document, categoryId);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if(category != null && category.Parent == null)
+                {
+                    Items.Add(new DynamoDropDownItem(category.Name, categoryId));
+                }
             }
 
             Items = Items.OrderBy(x => x.Name).ToObservableCollection();
@@ -443,15 +459,45 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
+            var document = DocumentManager.Instance.CurrentDBDocument;
+            BuiltInCategory categoryId = (BuiltInCategory) Items[SelectedIndex].Item;
+            Autodesk.Revit.DB.Category category = Autodesk.Revit.DB.Category.GetCategory(document, categoryId);
+
             var args = new List<AssociativeNode>
             {
-                AstFactory.BuildStringNode(((BuiltInCategory) Items[SelectedIndex].Item).ToString())
+                AstFactory.BuildStringNode(category.Name.ToString())
             };
 
             var func = new Func<string, Category>(Revit.Elements.Category.ByName);
             var functionCall = AstFactory.BuildFunctionCall(func, args);
 
             return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall) };
+        }
+        
+        protected override void DeserializeCore(XmlElement nodeElement, SaveContext context)
+        {
+            base.DeserializeCore(nodeElement, context);
+
+            if (SelectedIndex == -1)
+            {
+                var doc = DocumentManager.Instance.CurrentDBDocument;
+
+                var attrib = nodeElement.Attributes["index"];
+                if (attrib == null)
+                    return;
+
+                var index = attrib.Value;
+                var splits = index.Split(':');
+                if (splits.Count() > 1)
+                {
+                    var name = XmlUnescape(index.Substring(index.IndexOf(':') + 1));
+                    var newName = Revit.Elements.Category.ByName(name).Name;
+                    var item = Items.FirstOrDefault(i => i.Name == newName);
+                    SelectedIndex = item != null ?
+                        Items.IndexOf(item) :
+                        -1;
+                }
+            }
         }
     }
 

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -445,21 +445,13 @@ namespace DSRevitNodesUI
                 }
                 catch
                 {
+                    // We get here for internal/deprecated categories
                     continue;
                 }
 
-                if(category != null)
+                if (category != null)
                 {
-                    string name;
-                    if(category.Parent == null)
-                    {
-                        name = category.Name;
-                    }
-                    else
-                    {
-                        name = category.Parent.Name + " - " + category.Name;
-                    }
-
+                    string name = getFullName(category);
                     Items.Add(new DynamoDropDownItem(name, categoryId));
                 }
             }
@@ -472,10 +464,11 @@ namespace DSRevitNodesUI
             var document = DocumentManager.Instance.CurrentDBDocument;
             BuiltInCategory categoryId = (BuiltInCategory) Items[SelectedIndex].Item;
             Autodesk.Revit.DB.Category category = Autodesk.Revit.DB.Category.GetCategory(document, categoryId);
+            string name = getFullName(category);
 
             var args = new List<AssociativeNode>
             {
-                AstFactory.BuildStringNode(category.Name.ToString())
+                AstFactory.BuildStringNode(name)
             };
 
             var func = new Func<string, Category>(Revit.Elements.Category.ByName);
@@ -483,31 +476,64 @@ namespace DSRevitNodesUI
 
             return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall) };
         }
-        
-        protected override void DeserializeCore(XmlElement nodeElement, SaveContext context)
+
+        protected override int ParseSelectedIndex(string index, IList<DynamoDropDownItem> items)
         {
-            base.DeserializeCore(nodeElement, context);
+            int selectedIndex = -1;
 
-            if (SelectedIndex == -1)
+            var splits = index.Split(':');
+            if (splits.Count() > 1)
             {
-                var doc = DocumentManager.Instance.CurrentDBDocument;
+                var name = XmlUnescape(index.Substring(index.IndexOf(':') + 1));
 
-                var attrib = nodeElement.Attributes["index"];
-                if (attrib == null)
-                    return;
+                // Lookup by built in category enum name (without the OST_ prefix)
+                var item = items.FirstOrDefault(i => ((BuiltInCategory)i.Item).ToString().Substring(4) == name);
+                selectedIndex = item != null ?
+                    items.IndexOf(item) :
+                    -1;
+            }
 
-                var index = attrib.Value;
-                var splits = index.Split(':');
-                if (splits.Count() > 1)
+
+            return selectedIndex;
+        }
+
+        protected override string SaveSelectedIndex(int index, IList<DynamoDropDownItem> items)
+        {
+            // If nothing is selected or there are no
+            // items in the collection, than return -1
+            if (index == -1 || items.Count == 0)
+            {
+                return "-1";
+            }
+
+            // Save the enum name for the category (without the OST_ prefix)
+            var item = items[index];
+            BuiltInCategory categoryId = (BuiltInCategory)item.Item;
+            return string.Format("{0}:{1}", index, XmlEscape(categoryId.ToString().Substring(4)));
+        }
+
+        private static string getFullName(Autodesk.Revit.DB.Category category)
+        {
+            string name = string.Empty;
+
+            if(category != null)
+            {
+                var parent = category.Parent;
+                if (parent == null)
                 {
-                    var name = XmlUnescape(index.Substring(index.IndexOf(':') + 1));
-                    var newName = Revit.Elements.Category.ByName(name).Name;
-                    var item = Items.FirstOrDefault(i => i.Name == newName);
-                    SelectedIndex = item != null ?
-                        Items.IndexOf(item) :
-                        -1;
+                    // Top level category
+                    // For example "Cable Trays"
+                    name = category.Name.ToString();
+                }
+                else
+                {
+                    // Sub-category
+                    // For example "Cable Tray - Center Lines"
+                    name = parent.Name.ToString() + " - " + category.Name.ToString();
                 }
             }
+
+            return name;
         }
     }
 

--- a/test/Libraries/RevitNodesTests/Elements/CategoryTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/CategoryTests.cs
@@ -24,6 +24,24 @@ namespace RevitNodesTests.Elements
 
         [Test]
         [TestModel(@".\empty.rvt")]
+        public void CategoryByName_ValidArgsShort()
+        {
+            var cat = Category.ByName("PointClouds");
+            Assert.NotNull(cat);
+            Assert.AreEqual(cat.Id, cat.InternalCategory.Id.IntegerValue);
+        }
+
+        [Test]
+        [TestModel(@".\empty.rvt")]
+        public void CategoryByName_ValidArgsLong()
+        {
+            var cat = Category.ByName("Point Clouds");
+            Assert.NotNull(cat);
+            Assert.AreEqual(cat.Id, cat.InternalCategory.Id.IntegerValue);
+        }
+
+        [Test]
+        [TestModel(@".\empty.rvt")]
         public void CategoryByName_BadArgs()
         {
             Assert.Throws<ArgumentException>(()=>Category.ByName("foo"));


### PR DESCRIPTION
### Purpose

###### Allow Category.ByName to accept the category name, the category enum name or the truncated category enum name. For example:
"Cable Trays"
"OST_CableTray"
"CableTray"
![image](https://cloud.githubusercontent.com/assets/7033002/13319487/ec3e76e8-db8f-11e5-944a-d8925b5b856c.png)


* Only the category enum name has been supported before.

###### Display the category name with proper display of subcategories in the Categories combo:

![image](https://cloud.githubusercontent.com/assets/7033002/13319393/65076d74-db8f-11e5-97d6-e4088ff80dac.png)

* Subcategories are displayed as "Parent Category - Subcategory".
* Serialization has not changed. The truncated enum name is still used.
* Internal/deprecated categories are now filtered out. This will fix "MAGN-6909 Categories drop down fails for several categories".


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.


### Reviewers

@mjkkirschner 
@QilongTang 

* This PR is for Revit 2014

### FYIs

@jnealb 