### PR TITLE
Revit 2016: Added warning in description of SunSettings nodes.

### DIFF
--- a/src/Libraries/RevitNodes/Elements/SunSettings.cs
+++ b/src/Libraries/RevitNodes/Elements/SunSettings.cs
@@ -89,6 +89,7 @@ namespace Revit.Elements
 
         /// <summary>
         ///     Gets the Start Date and Time of the solar study given in the local time of the solar study location.
+        ///     Some regions may have a Daylight Savings (-1 hour) Time inaccuracy.
         /// </summary>
         public DateTime StartDateTime
         {
@@ -98,6 +99,7 @@ namespace Revit.Elements
         
         /// <summary>
         ///     Gets the End Date and Time of the solar study given in the local time of the solar study location.
+        ///     Some regions may have a Daylight Savings (-1 hour) Time inaccuracy.
         /// </summary>
         public DateTime EndDateTime
         {
@@ -106,6 +108,7 @@ namespace Revit.Elements
 
         /// <summary>
         ///     Gets the Date and Time for the current frame of the solar study given in the local time of the solar study location.
+        ///     Some regions may have a Daylight Savings (-1 hour) Time inaccuracy.
         /// </summary>
         public DateTime CurrentDateTime
         {


### PR DESCRIPTION
### Purpose

Link to Youtrack:
[MAGN-8993](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8993) Correct UTC offset for Solar Radiation workflow from Revit.

Results:

![image](https://cloud.githubusercontent.com/assets/8158404/13348706/b5c3f1c6-dc7d-11e5-8179-cbbfa750fe6a.png)

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.


### Reviewers

@marimano 
