### PR TITLE
MAGN-8993 Correct UTC offset for Solar Radiation workflow from Revit (for 2015)

### DIFF
--- a/src/Libraries/RevitNodes/Elements/SunSettings.cs
+++ b/src/Libraries/RevitNodes/Elements/SunSettings.cs
@@ -124,13 +124,8 @@ namespace Revit.Elements
         /// </summary>
         internal static DateTime TranslateTime(DateTime utc)
         {
-            // Get user local hours offset.
-            var offset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow).Hours;
-
-            if (TimeZoneInfo.Local.IsDaylightSavingTime(DateTime.UtcNow))
-            {
-                offset--;
-            }
+            // Get local hours offset for the given time.
+            var offset = TimeZoneInfo.Local.GetUtcOffset(utc).Hours;
 
             // Remove user local offset. Just leave pure revit datetime.
             return utc.AddHours(offset);

--- a/src/Libraries/RevitNodes/Elements/SunSettings.cs
+++ b/src/Libraries/RevitNodes/Elements/SunSettings.cs
@@ -86,7 +86,6 @@ namespace Revit.Elements
 
         /// <summary>
         ///     Gets the Start Date and Time of the solar study given in the local time of the solar study location.  
-        ///     Some regions may have a Daylight Savings (-1 hour) Time inaccuracy.
         /// </summary>
         public DateTime StartDateTime
         {
@@ -95,7 +94,6 @@ namespace Revit.Elements
 
         /// <summary>
         ///     Gets the End Date and Time of the solar study given in the local time of the solar study location.  
-        ///     Some regions may have a Daylight Savings (-1 hour) Time inaccuracy.
         /// </summary>
         public DateTime EndDateTime
         {
@@ -104,7 +102,6 @@ namespace Revit.Elements
 
         /// <summary>
         ///     Gets the Date and Time for the current frame of the solar study given in the local time of the solar study location.  
-        ///     Some regions may have a Daylight Savings (-1 hour) Time inaccuracy.
         /// </summary>
         public DateTime CurrentDateTime
         {


### PR DESCRIPTION
### Purpose

Bug fix: Get the local offset for the given time, not the current time

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.


### Reviewers

@aosyatnik 

### FYIs

@jnealb 