### PR TITLE
Enable DynamoRevit to run from a folder outside DynamoCore

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyCompany("Autodesk, Inc")]
-[assembly: AssemblyProduct("Dynamo")]
-[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2015")]
+[assembly: AssemblyProduct("Dynamo For Revit")]
+[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2015-2016")]
 [assembly: AssemblyTrademark("")]
 
 //In order to begin building localizable applications, set 

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -209,16 +209,10 @@ namespace Dynamo.Applications
         /// </summary>
         private static void UpdateSystemPathForProcess()
         {
-            var assemblyLocation = Assembly.GetExecutingAssembly().Location;
-            var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
-            var parentDirectory = Directory.GetParent(assemblyDirectory);
-            var corePath = parentDirectory.FullName;
-
-            
             var path =
                     Environment.GetEnvironmentVariable(
                         "Path",
-                        EnvironmentVariableTarget.Process) + ";" + corePath;
+                        EnvironmentVariableTarget.Process) + ";" + DynamoRevitApp.DynamoCorePath;
             Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Process);
         }
 
@@ -263,10 +257,7 @@ namespace Dynamo.Applications
 
         private static RevitDynamoModel InitializeCoreModel(DynamoRevitCommandData commandData)
         {
-            var assemblyLocation = Assembly.GetExecutingAssembly().Location;
-            var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
-            var parentDirectory = Directory.GetParent(assemblyDirectory);
-            var corePath = parentDirectory.FullName;
+            var corePath = DynamoRevitApp.DynamoCorePath;
 
             var umConfig = UpdateManagerConfiguration.GetSettings(new DynamoRevitLookUp());
             Debug.Assert(umConfig.DynamoLookUp != null);

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -22,6 +22,7 @@ using RevitServices.Transactions;
 using MessageBox = System.Windows.Forms.MessageBox;
 using Dynamo.Models;
 using RevitServices.EventHandler;
+using System.Collections;
 
 namespace Dynamo.Applications
 {
@@ -36,7 +37,75 @@ namespace Dynamo.Applications
         public static ControlledApplication ControlledApplication;
         public static UIControlledApplication UIControlledApplication;
         public static List<IUpdater> Updaters = new List<IUpdater>();
+        public static string DynamoCorePath
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(dynamopath))
+                {
+                    dynamopath = GetDynamoCorePath();
+                }
+                return dynamopath;
+            }
+        }
 
+        /// <summary>
+        /// Finds the Dynamo Core path by looking into registery or potentially a config file.
+        /// </summary>
+        /// <returns>The root folder path of Dynamo Core.</returns>
+        private static string GetDynamoCorePath()
+        {
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
+            var dynamoRevitRootDirectory = Path.GetDirectoryName(Path.GetDirectoryName(assemblyName));
+            var dynamoRoot = GetDynamoRoot(dynamoRevitRootDirectory);
+            
+            var assembly = Assembly.LoadFrom(Path.Combine(dynamoRevitRootDirectory, "DynamoInstallDetective.dll"));
+            var type = assembly.GetType("DynamoInstallDetective.Utilities");
+
+            var installationsMethod = type.GetMethod(
+                "FindDynamoInstallations",
+                BindingFlags.Public | BindingFlags.Static);
+
+            if (installationsMethod == null)
+            {
+                throw new MissingMethodException("Method 'DynamoInstallDetective.Utilities.FindDynamoInstallations' not found");
+            }
+
+            var methodParams = new object[] { dynamoRoot };
+
+            var installs = installationsMethod.Invoke(null, methodParams) as IEnumerable;
+            if (null == installs)
+                return string.Empty;
+
+            return installs.Cast<KeyValuePair<string, Tuple<int, int, int, int>>>()
+                .Where(p => p.Value.Item1 == version.Major && p.Value.Item2 == version.Minor)
+                .Select(p=>p.Key)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets Dynamo Root folder from the given DynamoRevit root.
+        /// </summary>
+        /// <param name="dynamoRevitRoot">The root folder of DynamoRevit binaries</param>
+        /// <returns>The root folder path of Dynamo Core</returns>
+        private static string GetDynamoRoot(string dynamoRevitRoot)
+        {
+            //TODO: use config file to setup Dynamo Path for debug builds.
+
+            //When there is no config file, just replace DynamoRevit by Dynamo 
+            //from the 'dynamoRevitRoot' folder.
+            var parent = new DirectoryInfo(dynamoRevitRoot);
+            var path =  string.Empty;
+            while(null != parent && parent.Name != @"DynamoRevit")
+            {
+                path = Path.Combine(parent.Name, path);
+                parent = Directory.GetParent(parent.FullName);
+            }
+            
+            return parent != null ? Path.Combine(Path.GetDirectoryName(parent.FullName), @"Dynamo", path) : dynamoRevitRoot;
+        }
+
+        private static string dynamopath;
         private static readonly Queue<Action> idleActionQueue = new Queue<Action>(10);
         private static EventHandlerProxy proxy;
         private AddInCommandBinding dynamoCommand;
@@ -254,6 +323,12 @@ namespace Dynamo.Applications
 
             try
             {
+                assemblyPath = Path.Combine(DynamoRevitApp.DynamoCorePath, assemblyName);
+                if(File.Exists(assemblyPath))
+                {
+                    return Assembly.LoadFrom(assemblyPath);
+                }
+
                 var assemblyLocation = Assembly.GetExecutingAssembly().Location;
                 var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
 


### PR DESCRIPTION
### Purpose

This PR enables DynamoRevit to run from a different folder than Dynamo core folder. 

1. The class `DynamoRevitApp` has a static property DynamoCorePath to get the Dynamo core path. The Dynamo core path is obtained from the registry by searching the appropriate Dynamo installation as required by the DynamoRevit.

2. The version selector now looks for DynamoRevit installation instead of Dynamo core to list all the available versions.

3. `PATH` environment variable is updated with correct DynamoCore path so that helix3d components can be loaded properly.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @Randy-Ma 

### FYIs
@ikeough 