### PR TITLE
Revit Categories Dropdown

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Category.cs
+++ b/src/Libraries/RevitNodes/Elements/Category.cs
@@ -124,6 +124,30 @@ namespace Revit.Elements
             return new Category(category);
         }
 
+        /// <summary>
+        /// Gets Revit Built-in category from current document based on category Id
+        /// </summary>
+        /// <param name="id">Category Id as Integer value</param>
+        /// <returns>Category if present in current document.</returns>
+        [IsVisibleInDynamoLibrary(false)]
+        public static Category ById(int id)
+        {
+            try
+            {
+                var document = DocumentManager.Instance.CurrentDBDocument;
+                BuiltInCategory categoryId = (BuiltInCategory)id;
+                Autodesk.Revit.DB.Category category = Autodesk.Revit.DB.Category.GetCategory(document, categoryId);
+                if(null == category)
+                    throw new ArgumentException(Properties.Resources.InvalidCategory);
+
+                return new Category(category);
+            }
+            catch
+            {
+                throw new ArgumentException(Properties.Resources.InvalidCategory);
+            }
+        }
+
         #endregion
 
         public override string ToString()

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -462,17 +462,18 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            var document = DocumentManager.Instance.CurrentDBDocument;
-            BuiltInCategory categoryId = (BuiltInCategory) Items[SelectedIndex].Item;
-            Autodesk.Revit.DB.Category category = Autodesk.Revit.DB.Category.GetCategory(document, categoryId);
-            string name = getFullName(category);
+            //Some of the legacy categories which were not working before will now be out of index.
+            if (SelectedIndex < 0 || SelectedIndex >= Items.Count)
+                return new[] { AstFactory.BuildNullNode() };
+
+            BuiltInCategory categoryId = (BuiltInCategory)Items[SelectedIndex].Item;
 
             var args = new List<AssociativeNode>
             {
-                AstFactory.BuildStringNode(name)
+                AstFactory.BuildIntNode((int)categoryId)
             };
 
-            var func = new Func<string, Category>(Revit.Elements.Category.ByName);
+            var func = new Func<int, Category>(Revit.Elements.Category.ById);
             var functionCall = AstFactory.BuildFunctionCall(func, args);
 
             return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall) };

--- a/test/Libraries/RevitIntegrationTests/RevitDropDownTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RevitDropDownTests.cs
@@ -1,0 +1,68 @@
+﻿using System.IO;
+using NUnit.Framework;
+using Revit.Elements;
+using RevitTestServices;
+using RTF.Framework;
+
+namespace RevitSystemTests
+{
+    [TestFixture]
+    class RevitDropDownTests : RevitSystemTestBase
+    {
+        [Test]
+        [TestModel(@".\empty.rvt")]
+        public void AllCategoriesHasValidValue()
+        {
+            var node = new DSRevitNodesUI.Categories();
+            Model.AddNodeToCurrentWorkspace(node, false);
+            RunCurrentModel();
+            int i = 0;
+            foreach (var item in node.Items)
+            {
+                node.SelectedIndex = i++;
+                //Since UI is not loaded, node modification will not be sent automatically.
+                node.MarkNodeAsModified(); 
+
+                RunCurrentModel();
+                //Node doesn't have any warning or error.
+                Assert.AreEqual(Dynamo.Graph.Nodes.ElementState.Active, node.State);
+                var category = this.GetPreviewValue(node.GUID.ToString()) as Category;
+                Assert.IsNotNull(category);
+                Assert.AreEqual(item.Name, category.Name);
+            }
+        }
+
+        [Test]
+        [TestModel(@".\empty.rvt")]
+        public void LegacyInvalidCategory()
+        {
+            string samplePath = Path.Combine(workingDirectory,
+                                               @".\RevitDropDown\ArcWallOpeningCategory.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+
+            AssertNoDummyNodes();
+
+            // evaluate  graph
+            RunCurrentModel();
+
+            var guid = "571c0a1e-4e26-40dc-85c5-e67cb9fa5507";
+            //Node has invalid selection, it must be in warning state.
+            Assert.IsTrue(IsNodeInErrorOrWarningState(guid));
+            Assert.IsNull(GetRuntimeMirror(guid));
+
+            var node = this.GetNode<DSRevitNodesUI.Categories>(guid) as DSRevitNodesUI.Categories;
+            Assert.IsNotNull(node);
+            Assert.AreEqual(-1, node.SelectedIndex);
+
+            node.SelectedIndex = 0;
+            node.MarkNodeAsModified();
+
+            RunCurrentModel();
+            Assert.AreEqual(Dynamo.Graph.Nodes.ElementState.Active, node.State);
+            var category = this.GetPreviewValue(node.GUID.ToString()) as Category;
+            Assert.IsNotNull(category);
+        }
+    }
+}

--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="DirectShapeTests.cs" />
     <Compile Include="DisplayTests.cs" />
     <Compile Include="GetFamilyParametersTests.cs" />
+    <Compile Include="RevitDropDownTests.cs" />
     <Compile Include="RevitLibraryTests.cs" />
     <Compile Include="ImportInstanceTests.cs" />
     <Compile Include="RevitWatch3DViewModelTests.cs" />

--- a/test/Libraries/RevitNodesTests/Elements/CategoryTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/CategoryTests.cs
@@ -47,5 +47,22 @@ namespace RevitNodesTests.Elements
             Assert.Throws<ArgumentException>(()=>Category.ByName("foo"));
             Assert.Throws<ArgumentNullException>(()=>Category.ByName(null));
         }
+
+        [Test]
+        [TestModel(@".\empty.rvt")]
+        public void CategoryById_ValidArgs()
+        {
+            var cat = Category.ById((int)Autodesk.Revit.DB.BuiltInCategory.OST_PointClouds);
+            Assert.NotNull(cat);
+            Assert.AreEqual(cat.Id, (int)Autodesk.Revit.DB.BuiltInCategory.OST_PointClouds);
+            Assert.AreEqual(cat.Name, @"Point Clouds");
+        }
+
+        [Test]
+        [TestModel(@".\empty.rvt")]
+        public void CategoryById_BadArgs()
+        {
+            Assert.Throws<ArgumentException>(() => Category.ById(-1));
+        }
     }
 }

--- a/test/System/RevitDropDown/ArcWallOpeningCategory.dyn
+++ b/test/System/RevitDropDown/ArcWallOpeningCategory.dyn
@@ -1,0 +1,13 @@
+<Workspace Version="0.9.0.3067" X="0" Y="0" zoom="1" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <DSRevitNodesUI.Categories guid="571c0a1e-4e26-40dc-85c5-e67cb9fa5507" type="DSRevitNodesUI.Categories" nickname="Categories" x="209" y="191" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" index="19:ArcWallRectOpening" />
+  </Elements>
+  <Connectors />
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose

This PR addresses https://github.com/DynamoDS/Dynamo/issues/4117, where some of the categories in the dropdown are not available in the current document. Most of the work related to this are already done in #854, however few categories, are still failing. 

This PR introduces a new method Category.ById(int id) which creates category using the category id and this method is called from the Categories node to evaluate the selected category consistently. 

### Reviewer
- [ ] @Randy-Ma 
- [ ] @QilongTang 

### FYI
- [ ] @riteshchandawar 