### PR TITLE
MAGN-9543 revit model updater throws exception when modifying sun settings (for Revit 2015 0.9.2)

### DIFF
--- a/src/Libraries/RevitServices/Elements/ModelUpdater.cs
+++ b/src/Libraries/RevitServices/Elements/ModelUpdater.cs
@@ -160,6 +160,12 @@ namespace RevitServices.Elements
         void RevitServicesUpdater_Updated(object sender, UpdaterArgs args)
         {
             var doc = DocumentManager.Instance.CurrentDBDocument;
+
+            // Are we loaded yet?
+            if (doc == null)
+                // No
+                return;
+
             var added = args.Added.Select(x => doc.GetElement(x).UniqueId);
             var addedIds = args.Added;
             var modified = args.Modified.Select(x => doc.GetElement(x).UniqueId).ToList();


### PR DESCRIPTION
### Purpose

Dynamo is watching for changes in the Revit model using an updater. The updater is activated when Dynamo loads but the relationship with the Revit model is established when Dynamo loads a document.

This PR is simply adding a null document check to the updater preventing the updater to do anything bad before Dynamo is ready.

This is for Revit 2015 0.9.2.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.


### Reviewers

@mjkkirschner 


### FYIs

@jnealb 
