### PR TITLE
Set DynamoHostPath as Revit_xxxx folder where DynamoRevit lives.

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -259,6 +259,8 @@ namespace Dynamo.Applications
         private static RevitDynamoModel InitializeCoreModel(DynamoRevitCommandData commandData)
         {
             var corePath = DynamoRevitApp.DynamoCorePath;
+            var dynamoRevitExePath = Assembly.GetExecutingAssembly().Location;
+            var dynamoRevitRoot = Path.GetDirectoryName(dynamoRevitExePath);// ...\Revit_xxxx\ folder
 
             var umConfig = UpdateManagerConfiguration.GetSettings(new DynamoRevitLookUp());
             Debug.Assert(umConfig.DynamoLookUp != null);
@@ -273,6 +275,8 @@ namespace Dynamo.Applications
             return RevitDynamoModel.Start(
                 new RevitDynamoModel.RevitStartConfiguration()
                 {
+                    DynamoCorePath = corePath,
+                    DynamoHostPath = dynamoRevitRoot,
                     GeometryFactoryPath = GetGeometryFactoryPath(corePath),
                     PathResolver = new RevitPathResolver(userDataFolder, commonDataFolder),
                     Context = GetRevitContext(commandData),

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -44,6 +44,7 @@ namespace Dynamo.Applications.Models
         {
             public string Context { get; set; }
             public string DynamoCorePath { get; set; }
+            public string DynamoHostPath { get; set; }
             public IPathResolver PathResolver { get; set; }
             public IPreferences Preferences { get; set; }
             public bool StartInTestMode { get; set; }


### PR DESCRIPTION
### Purpose

Provide DynamoHostPath so that additional extensions and viewExtensions can be loaded from host application path.

### Reviewer

- [ ] @Randy-Ma 

### FYI
@pboyer 
@Benglin 