### PR TITLE
ModelCurve fix.

### DIFF
--- a/src/Libraries/RevitNodes/Elements/CurveElement.cs
+++ b/src/Libraries/RevitNodes/Elements/CurveElement.cs
@@ -63,7 +63,7 @@ namespace Revit.Elements
         /// <param name="c"></param>
         protected void InternalSetCurve(Curve c)
         {
-            if (!CurveUtils.CurvesAreSimilar(InternalCurveElement.GeometryCurve, c))
+            if (CurveUtils.CurvesAreSimilar(InternalCurveElement.GeometryCurve, c))
                 return;
 
             if (!InternalCurveElement.GeometryCurve.IsBound && c.IsBound)

--- a/src/Libraries/RevitNodes/Elements/ModelCurve.cs
+++ b/src/Libraries/RevitNodes/Elements/ModelCurve.cs
@@ -128,7 +128,7 @@ namespace Revit.Elements
 
         #endregion
 
-        #region Private mutators
+        private readonly double tolerance = 0.01;
 
         /// <summary>
         /// Set the plane and the curve internally.
@@ -146,7 +146,7 @@ namespace Revit.Elements
             Autodesk.Revit.DB.SketchPlane sp = null;
 
             // Planes are different.
-            if (Math.Abs(angleBetweenPlanes) > CurveUtils.Tolerance || distanceBetweenOrigins > CurveUtils.Tolerance)
+            if (angleBetweenPlanes > tolerance || distanceBetweenOrigins > tolerance)
             {
                 sp = GetSketchPlaneFromCurve(newCurve);
                 InternalCurveElement.SetSketchPlaneAndCurve(sp, newCurve);
@@ -169,8 +169,6 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
         }
-
-        #endregion
 
         #region Public constructor
 


### PR DESCRIPTION
### Purpose

Link to YouTrack:
[MAGN-7162](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-7162) if grid is an input to ModelCurve.ByCurve hangs/Crash dynamo in Run automatic mode

Fix:
Rewrote `InternalSetSketchPlaneFromCurve`. Now, if planes are different old plane is updated with new one. If planes are similar, curve is updated with the new one.

Dynamo doesn't create new Revit element every time, when Run button is hit.
Dynamo updates old revit element, if it is presented.

### Declarations

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.


### Reviewers

@mjkkirschner 
