### PR TITLE
Added exclusion of a specified path during addin generation

### DIFF
--- a/src/Tools/DynamoAddInGenerator/Program.cs
+++ b/src/Tools/DynamoAddInGenerator/Program.cs
@@ -69,6 +69,7 @@ namespace DynamoAddinGenerator
         /// This method will delete addins like Dynamo.addin and 
         /// DynamoVersionSelector.addin
         /// </summary>
+        /// <param name="products">A collection of revit installs.</param>
         internal static void DeleteExistingAddins(IRevitProductCollection products)
         {
             Console.WriteLine("Deleting all exisitng addins...");
@@ -113,6 +114,7 @@ namespace DynamoAddinGenerator
         /// versions of Revit.
         /// </summary>
         /// <param name="products">A collection of revit installs.</param>
+        /// <param name="excludePath">The path that will not be used to search for Dynamo Revit installations</param>
         internal static void GenerateAddins(IRevitProductCollection products, string excludePath = null)
         {
             Console.WriteLine("Generating addins...");

--- a/src/Tools/DynamoAddInGenerator/Program.cs
+++ b/src/Tools/DynamoAddInGenerator/Program.cs
@@ -20,15 +20,20 @@ namespace DynamoAddinGenerator
             foreach (string s in args)
             {
                 if (s == @"/uninstall")
+                {
                     uninstall = true;
+                }
                 else if (Directory.Exists(s))
+                {
                     debugPath = s;
+                }
             }
+
             if (uninstall && string.IsNullOrEmpty(debugPath))
             {
                 //just use the executing assembly location
-                var assemblyPath = Assembly.GetExecutingAssembly().Location;         
-                debugPath = Path.GetDirectoryName(assemblyPath);              
+                var assemblyPath = Assembly.GetExecutingAssembly().Location;
+                debugPath = Path.GetDirectoryName(assemblyPath);
             }
 
             var allProducts = RevitProductUtility.GetAllInstalledRevitProducts();
@@ -49,9 +54,14 @@ namespace DynamoAddinGenerator
 
             DeleteExistingAddins(prodCollection);
 
-            if(!uninstall)
+            if (uninstall)
+            {
+                GenerateAddins(prodCollection, debugPath);
+            }
+            else
+            {
                 GenerateAddins(prodCollection);
-
+            }
         }
 
         /// <summary>
@@ -103,7 +113,7 @@ namespace DynamoAddinGenerator
         /// versions of Revit.
         /// </summary>
         /// <param name="products">A collection of revit installs.</param>
-        internal static void GenerateAddins(IRevitProductCollection products)
+        internal static void GenerateAddins(IRevitProductCollection products, string excludePath = null)
         {
             Console.WriteLine("Generating addins...");
             foreach (var prod in products.Products)
@@ -118,7 +128,12 @@ namespace DynamoAddinGenerator
                 }
                 foreach (KeyValuePair<string, Tuple<int, int, int, int>> dynRevitProd in dynRevitProducts)
                 {
+                    if (dynRevitProd.Key == excludePath)
+                    {
+                        continue;
+                    }
                     var path = Path.Combine(dynRevitProd.Key, subfolder, "DynamoRevitVersionSelector.dll");
+                    Console.WriteLine(path);
                     if (File.Exists(path))
                     {
                         var addinData = DynamoAddinData.Create(prod, dynRevitProd.Key);
@@ -128,8 +143,8 @@ namespace DynamoAddinGenerator
                 }
             }
         }
-        
-        
+
+
         /// <summary>
         /// Generate a Dynamo.addin file.
         /// </summary>


### PR DESCRIPTION
### Purpose

YouTrack: http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9740#
Dependent on: https://git.autodesk.com/Dynamo/DynamoForRevit/pull/15

Dynamo.addin file gets deleted when current version of Dynamo Revit gets uninstall.
It should roll back to a previous version.

### Reviewers

@sharadkjaiswal 

### FYIs

@Benglin 