### PR TITLE
Cones are tricky

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/SurfaceExtractor.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/SurfaceExtractor.cs
@@ -108,7 +108,7 @@ namespace Revit.GeometryConversion
 
             // Construct the radius
             var rad = Math.Tan(ang) * height;
-            var cone = Cone.ByCoordinateSystemHeightRadius(baseCS, height, rad);
+            var cone = Cone.ByPointsRadius(baseCS.Origin,baseCS.Origin.Translate(baseCS.ZAxis.Scale(height)) as Point , rad);
 
             // PB: this is iffy code - we need to extract the surface that's not touching the origin
             //return cone.Faces.Select(f => f.SurfaceGeometry()).First(s => s.DistanceTo(o) > 1e-5);

--- a/src/Libraries/RevitNodes/GeometryConversion/SurfaceExtractor.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/SurfaceExtractor.cs
@@ -114,7 +114,7 @@ namespace Revit.GeometryConversion
             //return cone.Faces.Select(f => f.SurfaceGeometry()).First(s => s.DistanceTo(o) > 1e-5);
 
             // the flat face of the cone is currently the second face in the Faces enumeration
-            return cone.Faces[1].SurfaceGeometry(); 
+            return cone.Faces[0].SurfaceGeometry(); 
         }
 
         public static Surface ExtractSurface(Autodesk.Revit.DB.HermiteFace face, IEnumerable<PolyCurve> edgeLoops)

--- a/src/Libraries/RevitNodes/GeometryConversion/SurfaceExtractor.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/SurfaceExtractor.cs
@@ -107,7 +107,7 @@ namespace Revit.GeometryConversion
             var baseCS = CoordinateSystem.ByOriginVectors(o, x, y.Reverse());
 
             // Construct the radius
-            var rad = Math.Cos(ang)*height;
+            var rad = Math.Tan(ang) * height;
             var cone = Cone.ByCoordinateSystemHeightRadius(baseCS, height, rad);
 
             // PB: this is iffy code - we need to extract the surface that's not touching the origin


### PR DESCRIPTION
### Purpose
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9564

This PR fixes an issue exposed by a particular revit file where conical faces in Revit were not being converted to ASM geometry correctly.

There were three issues in the conical face conversion code... I'm not sure it worked previously.

* We used Cos(half angle) * height  to compute the radius - this is incorrect it should be Tan(halfAngle) * height. It would be Cos(half angle) * slanted height.

* The constructor for Cones using a coordinateSystem does not flip the cone if the Z is 0,0,-1... it just creates a cone in world space and then sets the CS Z axis to 0,0,-1, this means the conical face is upside down from the expected result.

* We were returning the flat cone bottom, there is a comment in the code that the second face returned from a cone solid in ASM is the flat face, and we were returning this... thats a planar face, not the conical one.

this pr fixes these issues:

<img width="1803" alt="screen shot 2016-03-27 at 4 39 51 pm" src="https://cloud.githubusercontent.com/assets/508936/14067801/8e7846d2-f43b-11e5-914d-f4bf886bcca7.png">
<img width="1724" alt="screen shot 2016-03-27 at 4 39 24 pm" src="https://cloud.githubusercontent.com/assets/508936/14067802/8e823ec6-f43b-11e5-8944-3dd92702d7ba.png">


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate


### Reviewers

@sm6srw 
@pboyer  
### FYIs

@jnealb 
@pbidenko 