### PR TITLE
MAGN-8915 Wrong description text for Wall Type selection node

### DIFF
--- a/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
@@ -351,9 +351,9 @@ namespace DSRevitNodesUI.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Select multiple faces from the Revit document..
         /// </summary>
-        internal static string SelectFacesDesciption {
+        internal static string SelectFacesDescription {
             get {
-                return ResourceManager.GetString("SelectFacesDesciption", resourceCulture);
+                return ResourceManager.GetString("SelectFacesDescription", resourceCulture);
             }
         }
         

--- a/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
@@ -177,7 +177,7 @@
     <value>Select a face.</value>
     <comment>Description for Select Face</comment>
   </data>
-  <data name="SelectFacesDesciption" xml:space="preserve">
+   <data name="SelectFacesDescription" xml:space="preserve">
     <value>Select multiple faces from the Revit document.</value>
     <comment>Description for Select Faces</comment>
   </data>

--- a/src/Libraries/RevitNodesUI/Properties/Resources.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.resx
@@ -177,7 +177,7 @@
     <value>Select a face.</value>
     <comment>Description for Select Face</comment>
   </data>
-  <data name="SelectFacesDesciption" xml:space="preserve">
+  <data name="SelectFacesDescription" xml:space="preserve">
     <value>Select multiple faces from the Revit document.</value>
     <comment>Description for Select Faces</comment>
   </data>


### PR DESCRIPTION
References: [MAGN-8915](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8915#)

Purpose
This PR is to correct the string description for Select Faces Description.

Declarations

Check these if you believe they are true

The code base is in a better state after this PR
Is documented according to the standards
The level of testing this PR includes is appropriate
User facing strings, if any, are extracted into *.resx files
All tests pass using the self-service CI.
Snapshot of UI changes, if any.
##Reviewers

@aparajit-pratap