### PR TITLE
Change file open to be executed immediate.

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -853,7 +853,9 @@ namespace Dynamo.Applications.Models
 
         protected override void OpenFileImpl(OpenFileCommand command)
         {
-            DynamoRevitApp.AddIdleAction(() => base.OpenFileImpl(command));
+            // MAGN-9824 changed file open to be executed right away instead of queue up.
+            // This is to make sure DynamoRevit is consistent with DynamoStudio on file open.
+            base.OpenFileImpl(command);
         }
 
     }


### PR DESCRIPTION
### Purpose

MAGN-9824 First File, Open fails silently with Dynamo4Revit
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9824

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers
@sm6srw 

### FYIs

@mjkkirschner @ramramps 

Change file open to be executed immediate.
Instead of putting the file open action into the idleActionQueue, execute it immediately so that exception handling will be consistent with DynamoStudio. Since file open right now does not call Revit API, so execution should be fairly safe.

Making the change in R2017 branch first, if everything is good, submissions to other branches will follow.

