### PR TITLE
Change file open to be executed immediate.

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -877,7 +877,9 @@ namespace Dynamo.Applications.Models
 
         protected override void OpenFileImpl(OpenFileCommand command)
         {
-            IdlePromise.ExecuteOnIdleAsync(() => base.OpenFileImpl(command));
+            // MAGN-9824 changed file open to be executed right away instead of queue up.
+            // This is to make sure DynamoRevit is consistent with DynamoStudio on file open.
+            base.OpenFileImpl(command);
         }
 
         #endregion


### PR DESCRIPTION
### Purpose

MAGN-9824 First File, Open fails silently with Dynamo4Revit
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9824

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.

### Reviewers


### FYIs

@mjkkirschner @ramramps @sm6srw 

File open and Revit close with Dynamo tested in R2015.
Change file open to be executed immediate for R2015.
Details can be found in the PR for R2017:https://github.com/DynamoDS/DynamoRevit/pull/950