### PR TITLE
Fixed element types node error

### DIFF
--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -684,10 +684,22 @@ namespace DSRevitNodesUI
     {
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            var typeName = AstFactory.BuildStringNode(Items[SelectedIndex].Name);
-            var assemblyName = AstFactory.BuildStringNode("RevitAPI");
-            var functionCall = AstFactory.BuildFunctionCall(new Func<string,string,object>(Types.FindTypeByNameInAssembly) , new List<AssociativeNode>(){typeName, assemblyName});
-            return new []{AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall)};
+            AssociativeNode node;
+            if (SelectedIndex == -1)
+            {
+                node = AstFactory.BuildNullNode();
+            }
+            else
+            {
+               var typeName = AstFactory.BuildStringNode(Items[SelectedIndex].Name);
+               var assemblyName = AstFactory.BuildStringNode("RevitAPI");
+
+               node =
+                     AstFactory.BuildFunctionCall(
+                        new Func<string, string, object>(Types.FindTypeByNameInAssembly),
+                        new List<AssociativeNode>() { typeName, assemblyName });
+            }
+            return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), node) };
         }
     }
     

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -685,7 +685,7 @@ namespace DSRevitNodesUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             AssociativeNode node;
-            if (SelectedIndex == -1)
+            if(SelectedIndex < 0 || SelectedIndex >= Items.Count)
             {
                 node = AstFactory.BuildNullNode();
             }


### PR DESCRIPTION
Purpose

This PR is for the fix for the [following issue](https://github.com/DynamoDS/Dynamo/issues/6380).
The problem was because the case where the SelectedIndex is -1 is not taken care of in the BuildOutputAst method for element types node.
The solution was to include a check to prevent the error.

Reviewers
@ke-yu 

FYIs

@Benglin  