### PR TITLE
Fix the test case failure in CanOpenAndRunOtherFilesAfterOpeningFileWithSelectNode

### DIFF
--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -790,7 +790,7 @@ namespace RevitSystemTests
             AssertNoDummyNodes();
             RunCurrentModel();
 
-            filePath = Path.Combine(workingDirectory, @".\Samples\MAGN_7679.dyn");
+            filePath = Path.Combine(workingDirectory, @".\Samples\Revit_Color.dyn");
             testPath = Path.GetFullPath(filePath);
 
             ViewModel.OpenCommand.Execute(testPath);


### PR DESCRIPTION
Purpose
This PR is to fix the test case failure in CanOpenAndRunOtherFilesAfterOpeningFileWithSelectNode under BugTest.cs. The problem was due to the wrong file name being used for the test case. 
Fixed the issue by changing the file name to Sample/Revit_color.dyn.

Reviewers:
@Randy-Ma 

FYI:
@sharadkjaiswal 