### PR TITLE
DynamoCore version selector fix and show error dialog (Revit2015)

### DIFF
--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -82,7 +82,7 @@ namespace Dynamo.Applications
             return installs.Cast<KeyValuePair<string, Tuple<int, int, int, int>>>()
                 .Where(p => p.Value.Item1 == version.Major && p.Value.Item2 == version.Minor)
                 .Select(p=>p.Key)
-                .FirstOrDefault();
+                .LastOrDefault();
         }
 
         /// <summary>

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -123,6 +123,9 @@ namespace Dynamo.Applications
 
             try
             {
+                if (false == TryResolveDynamoCore())
+                    return Result.Failed;
+
                 UIControlledApplication = application;
                 ControlledApplication = application.ControlledApplication;
 
@@ -332,6 +335,27 @@ namespace Dynamo.Applications
         {
             get { return DynamoButton.Enabled; }
             set { DynamoButton.Enabled = value; }
+        }
+
+        private bool TryResolveDynamoCore()
+        {
+            if (string.IsNullOrEmpty(DynamoCorePath))
+            {
+                var fvi = FileVersionInfo.GetVersionInfo(assemblyName);
+
+                if (MessageBoxResult.OK ==
+                    System.Windows.MessageBox.Show(
+                        string.Format(Resources.DynamoCoreNotFoundDialogMessage,
+                            fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart),
+                        Resources.DynamoCoreNotFoundDialogTitle,
+                        MessageBoxButton.OKCancel,
+                        MessageBoxImage.Error))
+                {
+                    System.Diagnostics.Process.Start("http://dynamobim.org/download/");
+                }
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/src/DynamoRevit/Properties/Resources.Designer.cs
+++ b/src/DynamoRevit/Properties/Resources.Designer.cs
@@ -133,6 +133,26 @@ namespace Dynamo.Applications.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Revit is not able to find an installation of Dynamo Core version {0}.{1}.{2}.
+        ///
+        ///Would you like to download and reinstall DynamoCore.msi from http://dynamobim.org now?.
+        /// </summary>
+        internal static string DynamoCoreNotFoundDialogMessage {
+            get {
+                return ResourceManager.GetString("DynamoCoreNotFoundDialogMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dynamo Core component could not be found.
+        /// </summary>
+        internal static string DynamoCoreNotFoundDialogTitle {
+            get {
+                return ResourceManager.GetString("DynamoCoreNotFoundDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap logo_square_32x32 {

--- a/src/DynamoRevit/Properties/Resources.en-US.resx
+++ b/src/DynamoRevit/Properties/Resources.en-US.resx
@@ -154,4 +154,12 @@
   <data name="BackgroundPreviewName" xml:space="preserve">
     <value>Revit Background Preview</value>
   </data>
+  <data name="DynamoCoreNotFoundDialogMessage" xml:space="preserve">
+    <value>Revit is not able to find an installation of Dynamo Core version {0}.{1}.{2}.
+
+Would you like to download and reinstall DynamoCore.msi from http://dynamobim.org now?</value>
+  </data>
+  <data name="DynamoCoreNotFoundDialogTitle" xml:space="preserve">
+    <value>Dynamo Core component could not be found</value>
+  </data>
 </root>

--- a/src/DynamoRevit/Properties/Resources.resx
+++ b/src/DynamoRevit/Properties/Resources.resx
@@ -154,4 +154,12 @@
   <data name="BackgroundPreviewName" xml:space="preserve">
     <value>Revit Background Preview</value>
   </data>
+  <data name="DynamoCoreNotFoundDialogMessage" xml:space="preserve">
+    <value>Revit is not able to find an installation of Dynamo Core version {0}.{1}.{2}.
+
+Would you like to download and reinstall DynamoCore.msi from http://dynamobim.org now?</value>
+  </data>
+  <data name="DynamoCoreNotFoundDialogTitle" xml:space="preserve">
+    <value>Dynamo Core component could not be found</value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose

#### Change 1

`GetDynamoCorePath()` was mistakenly choosing the *first* (smallest number, oldest version) of the installed product list. It should choose the *last* (biggest number, newest version) matching product.

*Example:*

- You have Dynamo Core 1.0.0 installed on your machine
- You have Dynamo Core 1.0.1 built on your development folder and pointed by the *.addin* file
- You choose to open Dynamo 1.0.1 (debug build) in Revit
- ~~*Old behavior:*~~  DynamoRevit loads the first in the list of Dynamo Core builds/installations that matches major and minor numbers of the selected version, which is 1.0.0 (installer build)
- *Expected new behavior:*  DynamoRevit should load the newest Dynamo Core that matches major and minor numbers of the selected version, which is 1.0.1 (debug build)

#### Change 2

After this PR, DynamoRevit should also display a clearer error message if the version selected is not available. This scenario might happen if the user had attempted to uninstall Dynamo Core.

![image](https://cloud.githubusercontent.com/assets/6386550/14781028/91a57f94-0b12-11e6-981d-2e138e1936ee.png)

**Required to-do:** [MAGN-9981](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-9981) *DynamoCore.msi* should be provided on the website as a separate download.

### Reviewers

@sharadkjaiswal 

### FYIs

@ritesh @Benglin 