### PR TITLE
MAGN-10068: Terminate the evaluation cycle due to transactions in Dynamo

### DIFF
--- a/src/Libraries/RevitServices/Elements/ModelUpdater.cs
+++ b/src/Libraries/RevitServices/Elements/ModelUpdater.cs
@@ -220,6 +220,10 @@ namespace RevitServices.Elements
 
         public void ApplicationDocumentChanged(object sender, DocumentChangedEventArgs args)
         {
+            //skip processing element modification for nodes modified due to Dynamo script transaction.
+            if (args.GetTransactionNames().Contains(RevitServices.Transactions.TransactionWrapper.TransactionName))
+                return;
+
             var doc = args.GetDocument();
             var added = args.GetAddedElementIds().Select(x => doc.GetElement(x).UniqueId);
             var addedIds = args.GetAddedElementIds();

--- a/src/Libraries/RevitServices/Elements/ModelUpdater.cs
+++ b/src/Libraries/RevitServices/Elements/ModelUpdater.cs
@@ -19,6 +19,7 @@ using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Events;
 using RevitServices.Persistence;
+using RevitServices.Transactions;
 
 namespace RevitServices.Elements
 {
@@ -221,7 +222,7 @@ namespace RevitServices.Elements
         public void ApplicationDocumentChanged(object sender, DocumentChangedEventArgs args)
         {
             //skip processing element modification for nodes modified due to Dynamo script transaction.
-            if (args.GetTransactionNames().Contains(RevitServices.Transactions.TransactionWrapper.TransactionName))
+            if (args.GetTransactionNames().All(x => string.Equals(x, TransactionWrapper.TransactionName)))
                 return;
 
             var doc = args.GetDocument();

--- a/src/Libraries/RevitServices/Transactions/TransactionManager.cs
+++ b/src/Libraries/RevitServices/Transactions/TransactionManager.cs
@@ -226,6 +226,7 @@ namespace RevitServices.Transactions
         internal Transaction Transaction { get; set; }
         private readonly WarningHandler handler;
         internal readonly TransactionHandle Handle;
+        public static readonly string TransactionName = "Dynamo Script";
 
         internal TransactionWrapper()
         {
@@ -299,7 +300,7 @@ namespace RevitServices.Transactions
                     Transaction.Dispose();
                 }
 
-                Transaction = new Transaction(document, "Dynamo Script");
+                Transaction = new Transaction(document, TransactionName);
                 Transaction.Start();
 
                 FailureHandlingOptions failOpt = Transaction.GetFailureHandlingOptions();

--- a/src/Libraries/RevitServices/Transactions/TransactionManager.cs
+++ b/src/Libraries/RevitServices/Transactions/TransactionManager.cs
@@ -226,7 +226,7 @@ namespace RevitServices.Transactions
         internal Transaction Transaction { get; set; }
         private readonly WarningHandler handler;
         internal readonly TransactionHandle Handle;
-        public static readonly string TransactionName = "Dynamo Script";
+        public static readonly string TransactionName = "Dynamo-51297CB5 Script";
 
         internal TransactionWrapper()
         {


### PR DESCRIPTION
### Purpose

This PR fixes the crash due to infinite evaluation cycle caused due to element modification by SetRotation node.

DynamoRevit listens to document changed event on Revit to track the elements modified in Revit and marks the nodes responsible for creating the affected elements dirty so that those nodes can take part in next evaluation cycle. This is to support the ownership of Dynamo over the elements created by Dynamo in Revit, so if a user modifies the elements created by Dynamo using Revit interface then Dynamo should react and re-execute to force the rule set in Dynamo.

In this case of the defect, `FamilyInstance.SetRotation` node modifies the elements created by Dynamo and hence another update is triggered and it creates an infinite evaluation cycle. In fact, if the elements are getting modified due to Dynamo graph evaluation, then Dynamo should not mark the nodes dirty for re-execution in next evaluation cycle. Every evaluation cycle should complete the evaluation clean and no nodes should be left dirty after the evaluation.

The evaluation cycle is now broken by putting a check if the `ApplicationDocumentChanged` event  is triggered by the transaction created by Dynamo. We don't need to process the elements if the notification was due to a transaction completed by Dynamo.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
- [ ] @Randy-Ma 
- [ ] @ikeough 

### FYIs
- [ ] @kronz 
- [ ] @riteshchandawar 
- [ ] @Benglin 