### PR TITLE
Revit2016: MAGN-9757 Turning off "Revit Background Preview" causes Dynamo "Background Preview" on relaunch of Dynamo.

### DIFF
--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -28,6 +28,8 @@ namespace Dynamo.Applications.ViewModel
         private ElementId directShapeId = ElementId.InvalidElementId;
         private MethodInfo method;
 
+        public override string PreferenceWatchName { get { return "IsRevitBackgroundPreviewActive"; } }
+
         public RevitWatch3DViewModel(Watch3DViewModelStartupParams parameters) : base(parameters)
         {
             Name = Resources.BackgroundPreviewName;


### PR DESCRIPTION
### Purpose

Add a name for RevitWatch3DViewModel to be saved in preference settings.

### Dependencies

To work correctly, it requires changes in Dynamo: https://github.com/DynamoDS/Dynamo/pull/6649

### Declarations

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 