### PR TITLE
MAGN-10068 Fix evaluation cycle due to element modification in Dynamo.

### DIFF
--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -158,8 +158,7 @@ namespace Dynamo.Nodes
             SelectionObjectType selectionObjectType, string message, string prefix)
             : base(selectionType, selectionObjectType, message, prefix)
         {
-            RevitServicesUpdater.Instance.ElementsDeleted += Updater_ElementsDeleted;
-            RevitServicesUpdater.Instance.ElementsModified += Updater_ElementsModified;
+            RevitServicesUpdater.Instance.ElementsUpdated += Updater_ElementsUpdated;
             DynamoRevitApp.EventHandlerProxy.DocumentOpened += Controller_RevitDocumentChanged;
         }
 
@@ -180,8 +179,7 @@ namespace Dynamo.Nodes
         {
             base.Dispose();
 
-            RevitServicesUpdater.Instance.ElementsDeleted -= Updater_ElementsDeleted;
-            RevitServicesUpdater.Instance.ElementsModified -= Updater_ElementsModified;
+            RevitServicesUpdater.Instance.ElementsUpdated -= Updater_ElementsUpdated;
             DynamoRevitApp.EventHandlerProxy.DocumentOpened -= Controller_RevitDocumentChanged;
 
             if (revitDynamoModel != null)
@@ -203,6 +201,22 @@ namespace Dynamo.Nodes
         #endregion
 
         #region protected methods
+        private void Updater_ElementsUpdated(object sender, ElementUpdateEventArgs e)
+        {
+            switch (e.Operation)
+            {
+                case ElementUpdateEventArgs.UpdateType.Added:
+                    break;
+                case ElementUpdateEventArgs.UpdateType.Modified:
+                    Updater_ElementsModified(e.GetUniqueIds());
+                    break;
+                case ElementUpdateEventArgs.UpdateType.Deleted:
+                    Updater_ElementsDeleted(e.RevitDocument, e.Elements);
+                    break;
+                default:
+                    break;
+            }
+        }
 
         protected virtual void Updater_ElementsDeleted(
             Document document, IEnumerable<ElementId> deleted) { }

--- a/src/Libraries/RevitNodesUI/SiteLocation.cs
+++ b/src/Libraries/RevitNodesUI/SiteLocation.cs
@@ -59,7 +59,7 @@ namespace DSRevitNodesUI
             ArgumentLacing = LacingStrategy.Disabled;
 
             DynamoRevitApp.EventHandlerProxy.DocumentOpened += model_RevitDocumentChanged;
-            RevitServicesUpdater.Instance.ElementsModified += RevitServicesUpdater_ElementsModified;
+            RevitServicesUpdater.Instance.ElementsUpdated += RevitServicesUpdater_ElementsUpdated;
             
             DynamoRevitApp.AddIdleAction(() => Update());
         }
@@ -69,7 +69,7 @@ namespace DSRevitNodesUI
         public override void Dispose()
         {
             DynamoRevitApp.EventHandlerProxy.DocumentOpened -= model_RevitDocumentChanged;
-            RevitServicesUpdater.Instance.ElementsModified -= RevitServicesUpdater_ElementsModified;
+            RevitServicesUpdater.Instance.ElementsUpdated -= RevitServicesUpdater_ElementsUpdated;
             base.Dispose();
         }
 
@@ -106,11 +106,14 @@ namespace DSRevitNodesUI
 
         #region private methods
 
-        private void RevitServicesUpdater_ElementsModified(IEnumerable<string> updated)
+        private void RevitServicesUpdater_ElementsUpdated(object sender, ElementUpdateEventArgs e)
         {
+            if (e.Operation != ElementUpdateEventArgs.UpdateType.Modified)
+                return;
+
             var locUuid = DocumentManager.Instance.CurrentDBDocument.SiteLocation.UniqueId;
 
-            if (updated.Contains(locUuid))
+            if (e.GetUniqueIds().Contains(locUuid))
             {
                 Update();
             }

--- a/src/Libraries/RevitNodesUI/SunPath.cs
+++ b/src/Libraries/RevitNodesUI/SunPath.cs
@@ -33,7 +33,7 @@ namespace DSRevitNodesUI
 
             RegisterAllPorts();
 
-            RevitServicesUpdater.Instance.ElementsModified += Updater_ElementsModified;
+            RevitServicesUpdater.Instance.ElementsUpdated += Updater_ElementsUpdated;
             DynamoRevitApp.EventHandlerProxy.ViewActivated += CurrentUIApplication_ViewActivated;
 
             DynamoRevitApp.AddIdleAction(() => CurrentUIApplicationOnViewActivated());
@@ -41,7 +41,7 @@ namespace DSRevitNodesUI
 
         public override void Dispose()
         {
-            RevitServicesUpdater.Instance.ElementsModified -= Updater_ElementsModified;
+            RevitServicesUpdater.Instance.ElementsUpdated -= Updater_ElementsUpdated;
             DynamoRevitApp.EventHandlerProxy.ViewActivated -= CurrentUIApplication_ViewActivated;
 
             base.Dispose();
@@ -59,9 +59,11 @@ namespace DSRevitNodesUI
             OnNodeModified(forceExecute:true);
         }
 
-        private void Updater_ElementsModified(IEnumerable<string> updated)
+        private void Updater_ElementsUpdated(object sender, ElementUpdateEventArgs e)
         {
-            if (updated.Contains(settingsID))
+            if (e.Operation != ElementUpdateEventArgs.UpdateType.Modified) return;
+
+            if (e.GetUniqueIds().Contains(settingsID))
             {
                 OnNodeModified(forceExecute:true);
             }

--- a/src/Libraries/RevitServices/Elements/ModelUpdater.cs
+++ b/src/Libraries/RevitServices/Elements/ModelUpdater.cs
@@ -29,36 +29,50 @@ namespace RevitServices.Elements
 
         private readonly HashSet<IUpdater> registeredUpdaters;
 
+        [Obsolete("Use ElementsUpdated event")]
         public event ElementUpdateDelegate ElementsAdded;
+        [Obsolete("Use ElementsUpdated event")]
         public event ElementUpdateDelegateElementId ElementAddedForID;
+        [Obsolete("Use ElementsUpdated event")]
         public event ElementUpdateDelegate ElementsModified;
+        [Obsolete("Use ElementsUpdated event")]
         public event ElementDeleteDelegate ElementsDeleted;
 
+        public event EventHandler<ElementUpdateEventArgs> ElementsUpdated;
         #region Event Invokers
 
-        protected virtual void OnElementsAdded(IEnumerable<string> updated)
+        protected virtual void OnElementsAdded(ElementUpdateEventArgs e)
         {
             var handler = ElementsAdded;
-            if (handler != null) handler(updated);
+            if (handler != null) handler(e.GetUniqueIds());
         }
 
-        protected virtual void OnElementsAdded(Document doc, IEnumerable<ElementId> updated)
+        protected virtual void OnElementIdsAdded(ElementUpdateEventArgs e)
         {
             var handler = ElementAddedForID;
-            if (handler != null) handler(doc, updated);
+            if (handler != null) handler(e.RevitDocument, e.Elements);
+            
+            var updateHandler = ElementsUpdated;
+            if (updateHandler != null) updateHandler(this, e);
         }
 
 
-        protected virtual void OnElementsModified(IEnumerable<string> updated)
+        protected virtual void OnElementsModified(ElementUpdateEventArgs e)
         {
             var handler = ElementsModified;
-            if (handler != null) handler(updated);
+            if (handler != null) handler(e.GetUniqueIds());
+            
+            var updateHandler = ElementsUpdated;
+            if (updateHandler != null) updateHandler(this, e);
         }
 
-        protected virtual void OnElementsDeleted(Document document, IEnumerable<ElementId> deleted)
+        protected virtual void OnElementsDeleted(ElementUpdateEventArgs e)
         {
             var handler = ElementsDeleted;
-            if (handler != null) handler(document, deleted);
+            if (handler != null) handler(e.RevitDocument, e.Elements);
+            
+            var updateHandler = ElementsUpdated;
+            if (updateHandler != null) updateHandler(this, e);
         }
 
         #endregion
@@ -174,11 +188,10 @@ namespace RevitServices.Elements
                 // No
                 return;
 
-            var added = args.Added.Select(x => doc.GetElement(x).UniqueId);
             var addedIds = args.Added;
-            var modified = args.Modified.Select(x => doc.GetElement(x).UniqueId).ToList();
+            var modified = args.Modified;
             var deleted = args.Deleted;
-            ProcessUpdates(doc, modified, deleted, added, addedIds);
+            ProcessUpdates(doc, modified, deleted, addedIds, Enumerable.Empty<string>());
         }
 
         private void Dispose()
@@ -206,32 +219,27 @@ namespace RevitServices.Elements
         public void RollBack(Document doc, ICollection<ElementId> deleted)
         {
             var empty = new List<string>();
-            ProcessUpdates(doc, empty, deleted, empty, new List<ElementId>());
+            ProcessUpdates(doc, Enumerable.Empty<ElementId>(), deleted, Enumerable.Empty<ElementId>(), empty);
         }
 
-        private void ProcessUpdates(Document doc, IEnumerable<string> modified, 
-            IEnumerable<ElementId> deleted, IEnumerable<string> added, 
-            IEnumerable<ElementId> addedIds )
+        private void ProcessUpdates(Document doc, IEnumerable<ElementId> modified, 
+            IEnumerable<ElementId> deleted, IEnumerable<ElementId> addedIds, 
+            IEnumerable<string> transactions)
         {
-            OnElementsDeleted(doc, deleted.Distinct());
-            OnElementsModified(modified.Distinct());
-            OnElementsAdded(added.Distinct());
-            OnElementsAdded(doc, addedIds);
+            OnElementsDeleted(new ElementUpdateEventArgs(doc, deleted.Distinct(), transactions, ElementUpdateEventArgs.UpdateType.Deleted));
+            OnElementsModified(new ElementUpdateEventArgs(doc, modified.Distinct(), transactions, ElementUpdateEventArgs.UpdateType.Modified));
+            OnElementsAdded(new ElementUpdateEventArgs(doc, addedIds.Distinct(), transactions, ElementUpdateEventArgs.UpdateType.Added));
+            OnElementIdsAdded(new ElementUpdateEventArgs(doc, addedIds.Distinct(), transactions, ElementUpdateEventArgs.UpdateType.Added));
         }
 
         public void ApplicationDocumentChanged(object sender, DocumentChangedEventArgs args)
         {
-            //skip processing element modification for nodes modified due to Dynamo script transaction.
-            if (args.GetTransactionNames().All(x => string.Equals(x, TransactionWrapper.TransactionName)))
-                return;
-
             var doc = args.GetDocument();
-            var added = args.GetAddedElementIds().Select(x => doc.GetElement(x).UniqueId);
             var addedIds = args.GetAddedElementIds();
-            var modified = args.GetModifiedElementIds().Select(x => doc.GetElement(x).UniqueId).ToList();
+            var modified = args.GetModifiedElementIds();
             var deleted = args.GetDeletedElementIds();
 
-            ProcessUpdates(doc, modified, deleted, added, addedIds);
+            ProcessUpdates(doc, modified, deleted, addedIds, args.GetTransactionNames());
         }
 
         /// <summary>
@@ -241,9 +249,63 @@ namespace RevitServices.Elements
         public void UnRegisterAllChangeHooks()
         {
             ElementsAdded = null;
+            ElementAddedForID = null;
             ElementsModified = null;
             ElementsDeleted = null;
+            ElementsUpdated = null;
         }
+    }
+
+    /// <summary>
+    /// Contains context data for an element update event.
+    /// </summary>
+    public class ElementUpdateEventArgs : EventArgs
+    {
+        public enum UpdateType
+        {
+            Added,
+            Modified,
+            Deleted,
+        }
+        /// <summary>
+        /// Constructor for ElementUpdateEventArgs
+        /// </summary>
+        /// <param name="doc">Revit Document involved in the event.</param>
+        /// <param name="elements">List of elements involved in the event.</param>
+        /// <param name="transactions">Name of transactions involved in the event.</param>
+        public ElementUpdateEventArgs(Document doc, IEnumerable<ElementId> elements, IEnumerable<string> transactions, UpdateType operation)
+        {
+            RevitDocument = doc;
+            Elements = elements;
+            Transactions = transactions;
+            Operation = operation;
+        }
+
+        /// <summary>
+        /// Returns unique ids for the elements involved in the event.
+        /// </summary>
+        /// <returns>List of unique id strings</returns>
+        public IEnumerable<string> GetUniqueIds() { return Elements.Select(x => RevitDocument.GetElement(x).UniqueId); }
+
+        /// <summary>
+        /// List of elements involved in the event.
+        /// </summary>
+        public IEnumerable<ElementId> Elements { get; private set; }
+
+        /// <summary>
+        /// The Revit document involved in the event.
+        /// </summary>
+        public Document RevitDocument { get; private set; }
+
+        /// <summary>
+        /// The name of transactions involved in the event.
+        /// </summary>
+        public IEnumerable<string> Transactions { get; set; }
+
+        /// <summary>
+        /// Gets update operation type.
+        /// </summary>
+        public UpdateType Operation { get; private set; }
     }
 
     /// <summary>


### PR DESCRIPTION
### Purpose
This PR is in continuation of #991 where element modification caused by SetFamilyRotation triggers an infinite evaluation cycle. This happens because ElementsModified event marks all the nodes related to modified element dirty and forces re-execution. In fact, the constructor nodes are the one that causes this issue. In this case FamilyInstance.ByPoint() node creates a new family instance and resets the rotation value and when SetRotation is called it modifies the family instance again to get back the desired rotation.

In order to avoid re-execution of constructor nodes in Dynamo Transaction context, we need to pass the transaction-specific context to the event handlers so that the event handlers can take a decision on when to skip constructor nodes.

- RevitServicesUpdater now provides a new event `ElementsUpdated(object sender, ElementUpdateEventArgs args)` and marks all the other events such as ElementsAdded, ElementsModified and ElementsDeleted as Obsolete to maintain the binary compatibility. 
- This PR also updates all the other clients of the Obsolete events to use ElementsUpdated event.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

- [ ] @mjkkirschner 
- [ ] @Randy-Ma 
- [ ] @ikeough 