### PR TITLE
Revit 2016: MAGN-10168 With Kepler, Dynamo can be loaded when the Project is in perspective View and then closing Dynamo and the project can crash Revit

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -146,6 +146,12 @@ namespace Dynamo.Applications.Models
             {
                 node.PropertyChanged += node_PropertyChanged;
             }
+
+            var dm = DocumentManager.Instance;
+            if (dm.CurrentDBDocument != null)
+            {
+                SetRunEnabledBasedOnContext(dm.CurrentUIDocument.ActiveView, false);
+            }
         }
 
         private void node_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -540,7 +546,7 @@ namespace Dynamo.Applications.Models
         /// <param name="e"></param>
         internal void OnApplicationViewActivating(object sender, ViewActivatingEventArgs e)
         {
-            SetRunEnabledBasedOnContext(e.NewActiveView);
+            SetRunEnabledBasedOnContext(e.NewActiveView, true);
         }
 
         /// <summary>
@@ -611,7 +617,7 @@ namespace Dynamo.Applications.Models
                 workspace.ResetEngine(EngineController, markNodesAsDirty);
         }
 
-        public void SetRunEnabledBasedOnContext(View newView)
+        public void SetRunEnabledBasedOnContext(View newView, bool doContextAvailable)
         {
             DocumentManager.Instance.HandleDocumentActivation(newView);
 
@@ -632,6 +638,11 @@ namespace Dynamo.Applications.Models
             {
                 Logger.Log(
                     string.Format("Active view is now {0}", newView.Name));
+
+                if(doContextAvailable)
+                {
+                    OnRevitContextAvailable();
+                }
 
                 // If there is a current document, then set the run enabled
                 // state based on whether the view just activated is 
@@ -736,7 +747,7 @@ namespace Dynamo.Applications.Models
             var uiDoc = DocumentManager.Instance.CurrentUIDocument;
             if (uiDoc != null)
             {
-                SetRunEnabledBasedOnContext(uiDoc.ActiveView);
+                SetRunEnabledBasedOnContext(uiDoc.ActiveView, false);
             }
         }
 

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -619,7 +619,7 @@ namespace Dynamo.Applications.Models
 
         /// <summary>
         /// Check if the Revit context is available based on 'newView' and
-        /// set the Runnsettings.RunEnabled flag on each HomeWorkspaceModel accordingly.
+        /// set the Runsettings.RunEnabled flag on each HomeWorkspaceModel accordingly.
         /// The Revit context is unavailable for perspective views only.
         /// Raise the RevitContextAvailable event if the context is about to be available and 
         /// 'raiseRevitContextAvailableEvent' is 'true'

--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -363,11 +363,21 @@ namespace Dynamo.Applications.ViewModel
         /// </summary>
         private void DeleteKeeperElement()
         {
+            // Only try to delete the keeper element when we have been initialized (e.g. we have a valid keeperId).
+            // Check for this condition before trying to access the current Revit document because there
+            // are cases when we get here uninitialized with a document that is gone already. 
+            if (keeperId == ElementId.InvalidElementId)
+            {
+                return;
+            }
+   
+            // Never access the current document with an invalid keeperId
+            // See comment at the beginning of this method.
             var dbDoc = DocumentManager.Instance.CurrentDBDocument;
             if (null == dbDoc)
+            {
                 return;
-
-            if (keeperId == ElementId.InvalidElementId) return;
+            }
 
             TransactionManager.Instance.EnsureInTransaction(dbDoc);
             DocumentManager.Instance.CurrentUIDocument.Document.Delete(keeperId);

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -284,7 +284,7 @@ namespace RevitTestServices
 
         private void CurrentUIApplication_ViewActivating(object sender, ViewActivatingEventArgs e)
         {
-            ((RevitDynamoModel)this.ViewModel.Model).SetRunEnabledBasedOnContext(e.NewActiveView, true);
+            ((RevitDynamoModel)this.ViewModel.Model).SetRunEnabledBasedOnContext(e.NewActiveView);
         }
 
         /// <summary>

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -284,7 +284,7 @@ namespace RevitTestServices
 
         private void CurrentUIApplication_ViewActivating(object sender, ViewActivatingEventArgs e)
         {
-            ((RevitDynamoModel)this.ViewModel.Model).SetRunEnabledBasedOnContext(e.NewActiveView);
+            ((RevitDynamoModel)this.ViewModel.Model).SetRunEnabledBasedOnContext(e.NewActiveView, true);
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose
Cherry picking from #1031 MAGN-10168 With Kepler, Dynamo can be loaded when the Project is in perspective View and then closing Dynamo and the project can crash Revit.

For Revit 2016.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

### FYIs

@mjkkirschner 
