### PR TITLE
Revit 2015: MAGN-10168 With Kepler, Dynamo can be loaded when the Project is in perspective View and then closing Dynamo and the project can crash Revit

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -645,7 +645,7 @@ namespace Dynamo.Applications.Models
 
         /// <summary>
         /// Check if the Revit context is available based on 'newView' and
-        /// set the Runnsettings.RunEnabled flag on each HomeWorkspaceModel accordingly.
+        /// set the Runsettings.RunEnabled flag on each HomeWorkspaceModel accordingly.
         /// The Revit context is unavailable for perspective views only.
         /// Raise the RevitContextAvailable event if the context is about to be available and 
         /// 'raiseRevitContextAvailableEvent' is 'true'

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -171,7 +171,7 @@ namespace Dynamo.Applications.Models
             var dm = DocumentManager.Instance;
             if (dm.CurrentDBDocument != null)
             {
-                SetRunEnabledBasedOnContext(dm.CurrentUIDocument.ActiveView, false);
+                SetRunEnabledBasedOnContext(dm.CurrentUIDocument.ActiveView);
             }
         }
 
@@ -643,7 +643,17 @@ namespace Dynamo.Applications.Models
                 workspace.ResetEngine(EngineController, markNodesAsDirty);
         }
 
-        public void SetRunEnabledBasedOnContext(View newView, bool doContextAvailable)
+        /// <summary>
+        /// Check if the Revit context is available based on 'newView' and
+        /// set the Runnsettings.RunEnabled flag on each HomeWorkspaceModel accordingly.
+        /// The Revit context is unavailable for perspective views only.
+        /// Raise the RevitContextAvailable event if the context is about to be available and 
+        /// 'raiseRevitContextAvailableEvent' is 'true'
+        /// Raise the RevitContextUnavilable event if the the context is about to be unavailable.
+        /// /// </summary>
+        /// <param name="newView"></param>
+        /// <param name="raiseRevitContextAvailableEvent"></param>
+        public void SetRunEnabledBasedOnContext(View newView, bool raiseRevitContextAvailableEvent = false)
         {
             DocumentManager.Instance.HandleDocumentActivation(newView);
 
@@ -652,7 +662,22 @@ namespace Dynamo.Applications.Models
             if (view != null && view.IsPerspective
                 && Context != Configuration.Context.VASARI_2014)
             {
-                OnRevitContextUnavailable();
+                // Pick up current state
+                bool currentState = false;
+                foreach (HomeWorkspaceModel ws in Workspaces.OfType<HomeWorkspaceModel>())
+                {
+                    if (ws.RunSettings.RunEnabled)
+                    {
+                        currentState = true;
+                        break;
+                    }
+                }
+
+                // Only notify if we are changing state e.g. the Revit context becomes unavailable
+                if (currentState)
+                {
+                    OnRevitContextUnavailable();
+                }
 
                 foreach (
                     var ws in Workspaces.OfType<HomeWorkspaceModel>())
@@ -665,9 +690,24 @@ namespace Dynamo.Applications.Models
                 Logger.Log(
                     string.Format("Active view is now {0}", newView.Name));
 
-                if(doContextAvailable)
+                if(raiseRevitContextAvailableEvent)
                 {
-                    OnRevitContextAvailable();
+                    // Pick up current state
+                    bool currentState = true;
+                    foreach (HomeWorkspaceModel ws in Workspaces.OfType<HomeWorkspaceModel>())
+                    {
+                        if(!ws.RunSettings.RunEnabled)
+                        {
+                            currentState = false;
+                            break;
+                        }
+                    }
+
+                    // Only notify if we are changing state e.g. the Revit context becomes available
+                    if (!currentState)
+                    {
+                        OnRevitContextAvailable();
+                    }
                 }
 
                 // If there is a current document, then set the run enabled
@@ -773,7 +813,7 @@ namespace Dynamo.Applications.Models
             var uiDoc = DocumentManager.Instance.CurrentUIDocument;
             if (uiDoc != null)
             {
-                SetRunEnabledBasedOnContext(uiDoc.ActiveView, false);
+                SetRunEnabledBasedOnContext(uiDoc.ActiveView);
             }
         }
 

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -167,6 +167,12 @@ namespace Dynamo.Applications.Models
             {
                 node.PropertyChanged += node_PropertyChanged;
             }
+
+            var dm = DocumentManager.Instance;
+            if (dm.CurrentDBDocument != null)
+            {
+                SetRunEnabledBasedOnContext(dm.CurrentUIDocument.ActiveView, false);
+            }
         }
 
         private void node_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -563,7 +569,7 @@ namespace Dynamo.Applications.Models
         /// <param name="e"></param>
         internal void OnApplicationViewActivating(object sender, ViewActivatingEventArgs e)
         {
-            SetRunEnabledBasedOnContext(e.NewActiveView);
+            SetRunEnabledBasedOnContext(e.NewActiveView, true);
         }
 
         /// <summary>
@@ -637,7 +643,7 @@ namespace Dynamo.Applications.Models
                 workspace.ResetEngine(EngineController, markNodesAsDirty);
         }
 
-        public void SetRunEnabledBasedOnContext(View newView)
+        public void SetRunEnabledBasedOnContext(View newView, bool doContextAvailable)
         {
             DocumentManager.Instance.HandleDocumentActivation(newView);
 
@@ -658,6 +664,11 @@ namespace Dynamo.Applications.Models
             {
                 Logger.Log(
                     string.Format("Active view is now {0}", newView.Name));
+
+                if(doContextAvailable)
+                {
+                    OnRevitContextAvailable();
+                }
 
                 // If there is a current document, then set the run enabled
                 // state based on whether the view just activated is 
@@ -762,7 +773,7 @@ namespace Dynamo.Applications.Models
             var uiDoc = DocumentManager.Instance.CurrentUIDocument;
             if (uiDoc != null)
             {
-                SetRunEnabledBasedOnContext(uiDoc.ActiveView);
+                SetRunEnabledBasedOnContext(uiDoc.ActiveView, false);
             }
         }
 

--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -363,11 +363,21 @@ namespace Dynamo.Applications.ViewModel
         /// </summary>
         private void DeleteKeeperElement()
         {
+            // Only try to delete the keeper element when we have been initialized (e.g. we have a valid keeperId).
+            // Check for this condition before trying to access the current Revit document because there
+            // are cases when we get here uninitialized with a document that is gone already. 
+            if (keeperId == ElementId.InvalidElementId)
+            {
+                return;
+            }
+   
+            // Never access the current document with an invalid keeperId
+            // See comment at the beginning of this method.
             var dbDoc = DocumentManager.Instance.CurrentDBDocument;
             if (null == dbDoc)
+            {
                 return;
-
-            if (keeperId == ElementId.InvalidElementId) return;
+            }
 
             TransactionManager.Instance.EnsureInTransaction(dbDoc);
             DocumentManager.Instance.CurrentUIDocument.Document.Delete(keeperId);

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -284,7 +284,7 @@ namespace RevitTestServices
 
         private void CurrentUIApplication_ViewActivating(object sender, ViewActivatingEventArgs e)
         {
-            ((RevitDynamoModel)this.ViewModel.Model).SetRunEnabledBasedOnContext(e.NewActiveView, true);
+            ((RevitDynamoModel)this.ViewModel.Model).SetRunEnabledBasedOnContext(e.NewActiveView);
         }
 
         /// <summary>

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -284,7 +284,7 @@ namespace RevitTestServices
 
         private void CurrentUIApplication_ViewActivating(object sender, ViewActivatingEventArgs e)
         {
-            ((RevitDynamoModel)this.ViewModel.Model).SetRunEnabledBasedOnContext(e.NewActiveView);
+            ((RevitDynamoModel)this.ViewModel.Model).SetRunEnabledBasedOnContext(e.NewActiveView, true);
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

Cherry picking from #1031 MAGN-10168 With Kepler, Dynamo can be loaded when the Project is in perspective View and then closing Dynamo and the project can crash Revit

For Revit 2015.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

### FYIs

@mjkkirschner 
