### PR TITLE
MAGN-10248 Dynamo cannot start after changing Revit file

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -606,6 +606,14 @@ namespace Dynamo.Applications.Models
             ElementIDLifecycleManager<int>.DisposeInstance();
         }
 
+        protected override void PostShutdownCore(bool shutdownHost)
+        {
+            base.PostShutdownCore(shutdownHost);
+            
+            // Always reset current UI document on shutdown
+            DocumentManager.Instance.CurrentUIDocument = null;
+        }
+
         /// <summary>
         /// This event handler is called if 'markNodesAsDirty' in a 
         /// prior call to RevitDynamoModel.ResetEngine was set to 'true'.


### PR DESCRIPTION
### Purpose

Always reset the Revit UI document on shutdown.

This is a regression introduced in #1031 

This is for Revit 2017... 

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 

### FYIs

@ke-yu 

