### PR TITLE
manage dynamoRevitModel startup sequence

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -23,6 +23,7 @@ using Dynamo.Applications.Models;
 using Dynamo.Applications.ViewModel;
 using Dynamo.Controls;
 using Dynamo.Core;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Logging;
 using Dynamo.Models;
 using Dynamo.Updates;
@@ -112,42 +113,85 @@ namespace Dynamo.Applications
         public IDictionary<string, string> JournalData { get; set; }
     }
 
-    [Transaction(TransactionMode.Manual),
-     Regeneration(RegenerationOption.Manual)]
-    public class DynamoRevit : IExternalCommand
+    /// <summary>
+    /// Defines startup parameters for DynamoRevitModel
+    /// </summary>
+    public class DynamoRevitJournalKeys
     {
-        private static List<Action> idleActions = new List<Action>();
-        enum Versions { ShapeManager = 222 }
-
-        private static DynamoRevitCommandData extCommandData;
-        private static DynamoViewModel dynamoViewModel;
-        private static RevitDynamoModel revitDynamoModel;
-        private static bool handledCrash;
-
-        private static List<Exception> preLoadExceptions = new List<Exception>();
-
-        // These fields are used to store information that
-        // is pulled from the journal file.
-        private static bool shouldShowUi = true;
-        private static bool isAutomationMode;
-
         /// <summary>
         /// The journal file can use this key to specify whether
         /// the Dynamo UI should be visible at run time.
         /// </summary>
-        private const string JournalShowUiKey = "dynShowUI";
+        public const string JournalShowUiKey = "dynShowUI";
 
         /// <summary>
         /// If the journal file specifies automation mode, 
         /// Dynamo will run on the main thread without the idle loop.
         /// </summary>
-        private const string JounralAutomationModeKey = "dynAutomation";
+        public const string JournalAutomationModeKey = "dynAutomation";
 
         /// <summary>
-        /// The journal file can specify a Dynamo workspace to 
-        /// be opened (and executed) at run time.
+        /// The journal file can specify a Dynamo workspace to be opened 
+        /// (and executed if we are in automation mode) at run time.
         /// </summary>
-        private const string JournalDynPathKey = "dynPath";
+        public const string JournalDynPathKey = "dynPath";
+
+        /// <summary>
+        /// The journal file can specify if the Dynamo workspace opened 
+        /// from JournalDynPathKey will be executed or not. 
+        /// If we are in automation mode the workspace will be executed regardless of this key.
+        /// </summary>
+        public const string JournalDynPathExecuteKey = "dynPathExecute";
+
+        /// <summary>
+        /// The journal file can specify if the Dynamo workspace opened
+        /// from JournalDynPathKey will be forced in manual mode.
+        /// </summary>
+        public const string JournalForceManualRun = "dynForceManualRun";
+    }
+
+
+    [Transaction(TransactionMode.Manual),
+     Regeneration(RegenerationOption.Manual)]
+    public class DynamoRevit : IExternalCommand
+    {
+        enum Versions { ShapeManager = 222 };
+
+        /// <summary>
+        /// Based on the RevitDynamoModelState a dependent component can take certain 
+        /// decisions regarding its UI and functionality.
+        /// In order to be able to run a specified graph , revitDynamoModel needs to be 
+        /// at least in StartedUIless state. 
+        /// </summary>
+        public enum RevitDynamoModelState { NotStarted, StartedUIless, StartedUI };
+
+        private static List<Action> idleActions;
+        private static DynamoRevitCommandData extCommandData;
+        private static DynamoViewModel dynamoViewModel;
+        private static RevitDynamoModel revitDynamoModel;
+        private static bool handledCrash;
+        private static List<Exception> preLoadExceptions;
+
+        /// <summary>
+        /// The modelState tels us if the RevitDynamoModel was started and if has the
+        /// the Dynamo UI attached to it or not 
+        /// </summary>
+        public static RevitDynamoModelState ModelState
+        {
+            get;
+            private set;
+        }
+
+        static DynamoRevit()
+        {
+            idleActions = new List<Action>();
+            extCommandData = null;
+            dynamoViewModel = null;
+            revitDynamoModel = null;
+            handledCrash = false;
+            ModelState = RevitDynamoModelState.NotStarted;
+            preLoadExceptions = new List<Exception>();
+        }
 
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
@@ -159,38 +203,60 @@ namespace Dynamo.Applications
             //push any exceptions generated before DynamoLoad to this list
             preLoadExceptions.AddRange(StartupUtils.CheckAssemblyForVersionMismatches(args.LoadedAssembly));
         }
-      
+
         public Result ExecuteCommand(DynamoRevitCommandData commandData)
         {
+            if (ModelState == RevitDynamoModelState.StartedUIless)
+            {
+                if (CheckJournalForUiDisplay(commandData))
+                {
+                    //When we move from UIless to UI we prefer to start with a fresh revitDynamoModel
+                    //in order to benefit from a startup sequence similar to Dynamo Revit UI launch.                    
+                    revitDynamoModel.ShutDown(false);
+                    ModelState = RevitDynamoModelState.NotStarted;
+                }
+                else
+                {
+                    TryOpenAndExecuteWorkspaceInCommandData(commandData);
+                    return Result.Succeeded;
+                }
+            }
+
+            if(ModelState == RevitDynamoModelState.StartedUI)
+            {
+                revitDynamoModel.Logger.LogError("Dynamo UI already started");
+                return Result.Failed;
+            }
+
             HandleDebug(commandData);
 
             InitializeCore(commandData);
             //subscribe to the assembly load
             AppDomain.CurrentDomain.AssemblyLoad += AssemblyLoad;
 
-
             try
             {
                 extCommandData = commandData;
-                shouldShowUi = CheckJournalForUiDisplay(extCommandData);
-                isAutomationMode = CheckJournalForAutomationMode(extCommandData);
 
                 UpdateSystemPathForProcess();
 
                 // create core data models
                 revitDynamoModel = InitializeCoreModel(extCommandData);
                 revitDynamoModel.UpdateManager.RegisterExternalApplicationProcessId(Process.GetCurrentProcess().Id);
-                dynamoViewModel = InitializeCoreViewModel(revitDynamoModel);
-
                 revitDynamoModel.Logger.Log("SYSTEM", string.Format("Environment Path:{0}", Environment.GetEnvironmentVariable("PATH")));
 
                 // handle initialization steps after RevitDynamoModel is created.
                 revitDynamoModel.HandlePostInitialization();
+                ModelState = RevitDynamoModelState.StartedUIless;
 
                 // show the window
-                if (shouldShowUi)
+                if (CheckJournalForUiDisplay(extCommandData))
                 {
+                    dynamoViewModel = InitializeCoreViewModel(revitDynamoModel);
                     InitializeCoreView().Show();
+                    ModelState = RevitDynamoModelState.StartedUI;
+                    // Disable the Dynamo button to prevent a re-run
+                    DynamoRevitApp.DynamoButtonEnabled = false;
                 }
 
                 //foreach preloaded exception send a notification to the Dynamo Logger
@@ -201,10 +267,7 @@ namespace Dynamo.Applications
                 DynamoApplications.Properties.Resources.MismatchedAssemblyVersionShortMessage,
                 x.Message));
 
-                TryOpenWorkspaceInCommandData(extCommandData);
-
-                // Disable the Dynamo button to prevent a re-run
-                DynamoRevitApp.DynamoButtonEnabled = false;
+                TryOpenAndExecuteWorkspaceInCommandData(extCommandData);
 
                 //unsubscribe to the assembly load
                 AppDomain.CurrentDomain.AssemblyLoad -= AssemblyLoad;
@@ -293,6 +356,8 @@ namespace Dynamo.Applications
                 Environment.SpecialFolder.CommonApplicationData), 
                 "Dynamo", "Dynamo Revit");
 
+            bool isAutomationMode = CheckJournalForAutomationMode(extCommandData);
+
             return RevitDynamoModel.Start(
                 new RevitDynamoModel.RevitStartConfiguration()
                 {
@@ -370,13 +435,30 @@ namespace Dynamo.Applications
 
         #region Helpers
 
-        private void HandleDebug(DynamoRevitCommandData commandData)
+        private static void HandleDebug(DynamoRevitCommandData commandData)
         {
             if (commandData.JournalData != null && commandData.JournalData.ContainsKey("debug"))
             {
                 if (Boolean.Parse(commandData.JournalData["debug"]))
                     Debugger.Launch();
             }
+        }
+
+        private static bool CheckJournalForForceManualRun(DynamoRevitCommandData commandData)
+        {
+            var result = false;
+
+            if (commandData.JournalData == null)
+            {
+                return result;
+            }
+
+            if (commandData.JournalData.ContainsKey(DynamoRevitJournalKeys.JournalForceManualRun))
+            {
+                bool.TryParse(commandData.JournalData[DynamoRevitJournalKeys.JournalForceManualRun], out result);
+            }
+
+            return result;
         }
 
         private static bool CheckJournalForUiDisplay(DynamoRevitCommandData commandData)
@@ -388,9 +470,9 @@ namespace Dynamo.Applications
                 return result;
             }
 
-            if (commandData.JournalData.ContainsKey(JournalShowUiKey))
+            if (commandData.JournalData.ContainsKey(DynamoRevitJournalKeys.JournalShowUiKey))
             {
-                bool.TryParse(commandData.JournalData[JournalShowUiKey], out result);
+                bool.TryParse(commandData.JournalData[DynamoRevitJournalKeys.JournalShowUiKey], out result);
             }
 
             return result;
@@ -405,25 +487,54 @@ namespace Dynamo.Applications
                 return result;
             }
 
-            if (commandData.JournalData.ContainsKey(JounralAutomationModeKey))
+            if (commandData.JournalData.ContainsKey(DynamoRevitJournalKeys.JournalAutomationModeKey))
             {
-                result = bool.TryParse(commandData.JournalData[JounralAutomationModeKey], out result);
+                result = bool.TryParse(commandData.JournalData[DynamoRevitJournalKeys.JournalAutomationModeKey], out result);
             }
 
             return result;
         }
 
-        private static void TryOpenWorkspaceInCommandData(DynamoRevitCommandData commandData)
+        private static void TryOpenAndExecuteWorkspaceInCommandData(DynamoRevitCommandData commandData)
         {
-            if(commandData.JournalData == null)
+            if (commandData.JournalData == null)
             {
                 return;
             }
 
-            if (commandData.JournalData.ContainsKey(JournalDynPathKey))
+            if (commandData.JournalData.ContainsKey(DynamoRevitJournalKeys.JournalDynPathKey))
             {
-                revitDynamoModel.OpenFileFromPath(commandData.JournalData[JournalDynPathKey]);
-            }  
+                bool isAutomationMode = CheckJournalForAutomationMode(commandData);
+                bool forceManualRun = CheckJournalForForceManualRun(commandData);                
+
+                if (ModelState == RevitDynamoModelState.StartedUIless)
+                {
+                    revitDynamoModel.OpenFileFromPath(commandData.JournalData[DynamoRevitJournalKeys.JournalDynPathKey], forceManualRun);
+                }
+                else
+                {
+                    dynamoViewModel.ExecuteCommand(new DynamoModel.OpenFileCommand(commandData.JournalData[DynamoRevitJournalKeys.JournalDynPathKey], forceManualRun));
+                    dynamoViewModel.ShowStartPage = false;
+                }
+
+                //If we are in automation mode the model will run anyway (on the main thread 
+                //without the idle loop) regardless of the JournalDynPathExecuteKey.
+                if (!isAutomationMode && commandData.JournalData.ContainsKey(DynamoRevitJournalKeys.JournalDynPathExecuteKey))
+                {
+                    bool executePath = false;
+                    bool.TryParse(commandData.JournalData[DynamoRevitJournalKeys.JournalDynPathExecuteKey], out executePath);
+                    if (executePath)
+                    {
+                        HomeWorkspaceModel modelToRun = revitDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
+                        if (modelToRun != null)
+                        {
+                            modelToRun.Run();
+                            return;
+                        }
+                    }
+                }
+
+            }
         }
 
         private static string GetRevitContext(DynamoRevitCommandData commandData)
@@ -512,6 +623,9 @@ namespace Dynamo.Applications
                 Analyze.Render.AssemblyHelper.ResolveAssemblies;
 
             DynamoRevitApp.DynamoButtonEnabled = true;
+
+            //the model is shutdown when DynamoView is closed
+            ModelState = RevitDynamoModelState.NotStarted;
         }
 
         #endregion

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -116,38 +116,38 @@ namespace Dynamo.Applications
     /// <summary>
     /// Defines startup parameters for DynamoRevitModel
     /// </summary>
-    public class DynamoRevitJournalKeys
+    public class JournalKeys
     {
         /// <summary>
         /// The journal file can use this key to specify whether
         /// the Dynamo UI should be visible at run time.
         /// </summary>
-        public const string JournalShowUiKey = "dynShowUI";
+        public const string ShowUiKey = "dynShowUI";
 
         /// <summary>
         /// If the journal file specifies automation mode, 
         /// Dynamo will run on the main thread without the idle loop.
         /// </summary>
-        public const string JournalAutomationModeKey = "dynAutomation";
+        public const string AutomationModeKey = "dynAutomation";
 
         /// <summary>
         /// The journal file can specify a Dynamo workspace to be opened 
         /// (and executed if we are in automation mode) at run time.
         /// </summary>
-        public const string JournalDynPathKey = "dynPath";
+        public const string DynPathKey = "dynPath";
 
         /// <summary>
         /// The journal file can specify if the Dynamo workspace opened 
-        /// from JournalDynPathKey will be executed or not. 
+        /// from DynPathKey will be executed or not. 
         /// If we are in automation mode the workspace will be executed regardless of this key.
         /// </summary>
-        public const string JournalDynPathExecuteKey = "dynPathExecute";
+        public const string DynPathExecuteKey = "dynPathExecute";
 
         /// <summary>
         /// The journal file can specify if the Dynamo workspace opened
-        /// from JournalDynPathKey will be forced in manual mode.
+        /// from DynPathKey will be forced in manual mode.
         /// </summary>
-        public const string JournalForceManualRun = "dynForceManualRun";
+        public const string ForceManualRunKey = "dynForceManualRun";
     }
 
 
@@ -453,9 +453,9 @@ namespace Dynamo.Applications
                 return result;
             }
 
-            if (commandData.JournalData.ContainsKey(DynamoRevitJournalKeys.JournalForceManualRun))
+            if (commandData.JournalData.ContainsKey(JournalKeys.ForceManualRunKey))
             {
-                bool.TryParse(commandData.JournalData[DynamoRevitJournalKeys.JournalForceManualRun], out result);
+                bool.TryParse(commandData.JournalData[JournalKeys.ForceManualRunKey], out result);
             }
 
             return result;
@@ -470,9 +470,9 @@ namespace Dynamo.Applications
                 return result;
             }
 
-            if (commandData.JournalData.ContainsKey(DynamoRevitJournalKeys.JournalShowUiKey))
+            if (commandData.JournalData.ContainsKey(JournalKeys.ShowUiKey))
             {
-                bool.TryParse(commandData.JournalData[DynamoRevitJournalKeys.JournalShowUiKey], out result);
+                bool.TryParse(commandData.JournalData[JournalKeys.ShowUiKey], out result);
             }
 
             return result;
@@ -487,9 +487,9 @@ namespace Dynamo.Applications
                 return result;
             }
 
-            if (commandData.JournalData.ContainsKey(DynamoRevitJournalKeys.JournalAutomationModeKey))
+            if (commandData.JournalData.ContainsKey(JournalKeys.AutomationModeKey))
             {
-                result = bool.TryParse(commandData.JournalData[DynamoRevitJournalKeys.JournalAutomationModeKey], out result);
+                result = bool.TryParse(commandData.JournalData[JournalKeys.AutomationModeKey], out result);
             }
 
             return result;
@@ -502,27 +502,27 @@ namespace Dynamo.Applications
                 return;
             }
 
-            if (commandData.JournalData.ContainsKey(DynamoRevitJournalKeys.JournalDynPathKey))
+            if (commandData.JournalData.ContainsKey(JournalKeys.DynPathKey))
             {
                 bool isAutomationMode = CheckJournalForAutomationMode(commandData);
                 bool forceManualRun = CheckJournalForForceManualRun(commandData);                
 
                 if (ModelState == RevitDynamoModelState.StartedUIless)
                 {
-                    revitDynamoModel.OpenFileFromPath(commandData.JournalData[DynamoRevitJournalKeys.JournalDynPathKey], forceManualRun);
+                    revitDynamoModel.OpenFileFromPath(commandData.JournalData[JournalKeys.DynPathKey], forceManualRun);
                 }
                 else
                 {
-                    dynamoViewModel.ExecuteCommand(new DynamoModel.OpenFileCommand(commandData.JournalData[DynamoRevitJournalKeys.JournalDynPathKey], forceManualRun));
+                    dynamoViewModel.ExecuteCommand(new DynamoModel.OpenFileCommand(commandData.JournalData[JournalKeys.DynPathKey], forceManualRun));
                     dynamoViewModel.ShowStartPage = false;
                 }
 
                 //If we are in automation mode the model will run anyway (on the main thread 
-                //without the idle loop) regardless of the JournalDynPathExecuteKey.
-                if (!isAutomationMode && commandData.JournalData.ContainsKey(DynamoRevitJournalKeys.JournalDynPathExecuteKey))
+                //without the idle loop) regardless of the DynPathExecuteKey.
+                if (!isAutomationMode && commandData.JournalData.ContainsKey(JournalKeys.DynPathExecuteKey))
                 {
                     bool executePath = false;
-                    bool.TryParse(commandData.JournalData[DynamoRevitJournalKeys.JournalDynPathExecuteKey], out executePath);
+                    bool.TryParse(commandData.JournalData[JournalKeys.DynPathExecuteKey], out executePath);
                     if (executePath)
                     {
                         HomeWorkspaceModel modelToRun = revitDynamoModel.CurrentWorkspace as HomeWorkspaceModel;

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -112,12 +112,7 @@ namespace Dynamo.Applications
 
         private Result loadDependentComponents()
         {
-            var dynamoRevitRootDirectory = Path.GetDirectoryName(Path.GetDirectoryName(assemblyName));
-            var versionNumber = ControlledApplication.VersionNumber;
-
-            var dynamoRevitAditionsPath = Path.Combine(dynamoRevitRootDirectory,
-                string.Format("Revit_{0}", versionNumber), "DynamoRevitAdditions.dll");
-
+            var dynamoRevitAditionsPath = Path.Combine(Path.GetDirectoryName(assemblyName), "DynamoRevitAdditions.dll");
             if (File.Exists(dynamoRevitAditionsPath))
             {
                 try

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -110,6 +110,39 @@ namespace Dynamo.Applications
         private static EventHandlerProxy proxy;
         private AddInCommandBinding dynamoCommand;
 
+        private Result loadDependentComponents()
+        {
+            var dynamoRevitRootDirectory = Path.GetDirectoryName(Path.GetDirectoryName(assemblyName));
+            var versionNumber = ControlledApplication.VersionNumber;
+
+            var dynamoRevitAditionsPath = Path.Combine(dynamoRevitRootDirectory,
+                string.Format("Revit_{0}", versionNumber), "DynamoRevitAdditions.dll");
+
+            if (File.Exists(dynamoRevitAditionsPath))
+            {
+                try
+                {
+                    var dynamoRevitAditionsAss = Assembly.LoadFrom(dynamoRevitAditionsPath);
+                    if (dynamoRevitAditionsAss != null)
+                    {
+                        var dynamoRevitAditionsLoader = dynamoRevitAditionsAss.CreateInstance("DynamoRevitAdditions.LoadManager");
+                        if (dynamoRevitAditionsLoader != null)
+                        {
+                            dynamoRevitAditionsLoader.GetType().GetMethod("Initialize").Invoke(dynamoRevitAditionsLoader, null);
+                            return Result.Succeeded;
+                        }
+                    }
+                }
+                catch(Exception ex)
+                {
+                    return Result.Failed;
+                }
+
+            }
+
+            return Result.Failed;
+        }
+
         public Result OnStartup(UIControlledApplication application)
         {
             // Revit2015+ has disabled hardware acceleration for WPF to
@@ -146,6 +179,8 @@ namespace Dynamo.Applications
                 RevitServicesUpdater.Initialize(DynamoRevitApp.Updaters);
                 SubscribeDocumentChangedEvent();
 
+                loadDependentComponents();
+
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -168,6 +203,7 @@ namespace Dynamo.Applications
                 JournalData = journalData,
                 Application = application
             };
+
             var cmd = new DynamoRevit();
             return cmd.ExecuteCommand(data);
         }
@@ -304,7 +340,6 @@ namespace Dynamo.Applications
             AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
         }
 
-      
         private void UnsubscribeAssemblyEvents()
         {
             AppDomain.CurrentDomain.AssemblyResolve -= ResolveAssembly;
@@ -353,7 +388,7 @@ namespace Dynamo.Applications
                 throw new Exception(string.Format("The location of the assembly, {0} could not be resolved for loading.", assemblyPath), ex);
             }
         }
-        
+
         private void SubscribeDocumentChangedEvent()
         {
             ControlledApplication.DocumentChanged += RevitServicesUpdater.Instance.ApplicationDocumentChanged;


### PR DESCRIPTION
### Purpose

Mange dynamorevitModel startup sequence based on input JournalKeys.
Expose dynamoRevitModel state so dependent components can take decisions based on it regarding their UI and functionality.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 
@sharadkjaiswal 



