### PR TITLE
Resolve to a higher version of Dynamo Core (Revit2015)

### DIFF
--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -62,27 +62,16 @@ namespace Dynamo.Applications
             var dynamoRoot = GetDynamoRoot(dynamoRevitRootDirectory);
             
             var assembly = Assembly.LoadFrom(Path.Combine(dynamoRevitRootDirectory, "DynamoInstallDetective.dll"));
-            var type = assembly.GetType("DynamoInstallDetective.Utilities");
+            var type = assembly.GetType("DynamoInstallDetective.DynamoProducts");
 
-            var installationsMethod = type.GetMethod(
-                "FindDynamoInstallations",
-                BindingFlags.Public | BindingFlags.Static);
-
-            if (installationsMethod == null)
+            var methodToInvoke = type.GetMethod("GetDynamoPath", BindingFlags.Public | BindingFlags.Static);
+            if (methodToInvoke == null)
             {
-                throw new MissingMethodException("Method 'DynamoInstallDetective.Utilities.FindDynamoInstallations' not found");
+                throw new MissingMethodException("Method 'DynamoInstallDetective.DynamoProducts.GetDynamoPath' not found");
             }
 
-            var methodParams = new object[] { dynamoRoot };
-
-            var installs = installationsMethod.Invoke(null, methodParams) as IEnumerable;
-            if (null == installs)
-                return string.Empty;
-
-            return installs.Cast<KeyValuePair<string, Tuple<int, int, int, int>>>()
-                .Where(p => p.Value.Item1 == version.Major && p.Value.Item2 == version.Minor)
-                .Select(p=>p.Key)
-                .LastOrDefault();
+            var methodParams = new object[] { version, dynamoRoot };
+            return methodToInvoke.Invoke(null, methodParams) as string;
         }
 
         /// <summary>
@@ -342,11 +331,11 @@ namespace Dynamo.Applications
             if (string.IsNullOrEmpty(DynamoCorePath))
             {
                 var fvi = FileVersionInfo.GetVersionInfo(assemblyName);
+                var shortversion = fvi.FileMajorPart + "." + fvi.FileMinorPart;
 
                 if (MessageBoxResult.OK ==
                     System.Windows.MessageBox.Show(
-                        string.Format(Resources.DynamoCoreNotFoundDialogMessage,
-                            fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart),
+                        string.Format(Resources.DynamoCoreNotFoundDialogMessage, shortversion),
                         Resources.DynamoCoreNotFoundDialogTitle,
                         MessageBoxButton.OKCancel,
                         MessageBoxImage.Error))

--- a/src/DynamoRevit/Properties/Resources.Designer.cs
+++ b/src/DynamoRevit/Properties/Resources.Designer.cs
@@ -133,9 +133,9 @@ namespace Dynamo.Applications.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Revit is not able to find an installation of Dynamo Core version {0}.{1}.{2}.
+        ///   Looks up a localized string similar to Dynamo Add-In is not able to find an installation of Dynamo Core version {0} or higher.
         ///
-        ///Would you like to download and reinstall DynamoCore.msi from http://dynamobim.org now?.
+        ///Would you like to download the latest version of DynamoCore.msi from http://dynamobim.org now?.
         /// </summary>
         internal static string DynamoCoreNotFoundDialogMessage {
             get {

--- a/src/DynamoRevit/Properties/Resources.en-US.resx
+++ b/src/DynamoRevit/Properties/Resources.en-US.resx
@@ -155,9 +155,9 @@
     <value>Revit Background Preview</value>
   </data>
   <data name="DynamoCoreNotFoundDialogMessage" xml:space="preserve">
-    <value>Revit is not able to find an installation of Dynamo Core version {0}.{1}.{2}.
+    <value>Dynamo Add-In is not able to find an installation of Dynamo Core version {0} or higher.
 
-Would you like to download and reinstall DynamoCore.msi from http://dynamobim.org now?</value>
+Would you like to download the latest version of DynamoCore.msi from http://dynamobim.org now?</value>
   </data>
   <data name="DynamoCoreNotFoundDialogTitle" xml:space="preserve">
     <value>Dynamo Core component could not be found</value>

--- a/src/DynamoRevit/Properties/Resources.resx
+++ b/src/DynamoRevit/Properties/Resources.resx
@@ -155,9 +155,9 @@
     <value>Revit Background Preview</value>
   </data>
   <data name="DynamoCoreNotFoundDialogMessage" xml:space="preserve">
-    <value>Revit is not able to find an installation of Dynamo Core version {0}.{1}.{2}.
+    <value>Dynamo Add-In is not able to find an installation of Dynamo Core version {0} or higher.
 
-Would you like to download and reinstall DynamoCore.msi from http://dynamobim.org now?</value>
+Would you like to download the latest version of DynamoCore.msi from http://dynamobim.org now?</value>
   </data>
   <data name="DynamoCoreNotFoundDialogTitle" xml:space="preserve">
     <value>Dynamo Core component could not be found</value>


### PR DESCRIPTION
### Purpose

- Requires PR [Dynamo#6771](https://github.com/DynamoDS/Dynamo/pull/6771): A portion of code to resolve Dynamo Core and determine a matching version was duplicated between Dynamo Sandbox, Dynamo Revit, and Dynamo Studio. Now it is refactored to be inside *DynamoInstallDetective.dll*

- The Dynamo Add-In should be able to resolve an installation of **Dynamo Core minor-versioned equal to or higher** than the mentioned Dynamo Revit installation. If it is not able to resolve, display a message. It should not crash or just disappear.

- Any suggestions for better/concise message text is more than welcome - since the current wording does not really convey clearly about the major/minor version numbers.

### Screenshot

The following dialog will appear when opening the Dynamo Add-In but without an existing Dynamo Core installation in `%PROGRAMFILES%\Dynamo\Dynamo Core\1.0`.

![image](https://cloud.githubusercontent.com/assets/6386550/16296318/3dee6cc4-395e-11e6-97f3-18494f3efd7d.png)

![image](https://cloud.githubusercontent.com/assets/6386550/16296130/53a56aaa-395d-11e6-8ff3-f0d26c30316f.png)

### Declarations

- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@jaiswas

### FYIs

@chandar