### PR TITLE
Apply material to BRep based direct shapes

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/DynamoToRevitBRep.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/DynamoToRevitBRep.cs
@@ -1,50 +1,52 @@
-﻿using System;
+﻿using Autodesk.DesignScript.Runtime;
+using Autodesk.Revit.DB;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Autodesk.Revit.DB;
-using Autodesk.DesignScript.Runtime;
-using CoEdge = Autodesk.DesignScript.Geometry.CoEdge;
 using Edge = Autodesk.DesignScript.Geometry.Edge;
 using Face = Autodesk.DesignScript.Geometry.Face;
-using ProtoPt = Autodesk.DesignScript.Geometry.Point;
 using Solid = Autodesk.DesignScript.Geometry.Solid;
 using Surface = Autodesk.DesignScript.Geometry.Surface;
 
 namespace Revit.GeometryConversion
 {
-   [SupressImportIntoVM]
-   public static class DynamoToRevitBRep
-   {
-       /// <summary>
-       /// this method attempts to construct a BRep from a closed solid.
-       /// </summary>
-       /// <param name="sol"></param>
-       /// <param name="performHostUnitConversion"></param>
-       /// <returns></returns>
-       public static GeometryObject ToRevitType(Solid sol,
-          bool performHostUnitConversion = true)
-       {
-            var geometry = ToRevitType(sol, performHostUnitConversion, BRepType.Solid);
+    [SupressImportIntoVM]
+    public static class DynamoToRevitBRep
+    {
+        /// <summary>
+        /// this method attempts to construct a BRep from a closed solid.
+        /// </summary>
+        /// <param name="sol"></param>
+        /// <param name="performHostUnitConversion"></param>
+        /// <param name="materialId"></param>
+        /// <returns></returns>
+        public static GeometryObject ToRevitType(Solid sol,
+          bool performHostUnitConversion = true,
+          ElementId materialId = null)
+        {
+            var geometry = ToRevitType(sol, performHostUnitConversion, BRepType.Solid, materialId);
 
-           if (geometry == null)
-           {
-               // An unexpected failure occurred when attempting to convert the solid into a Revit BRep.
-               throw new Exception(Properties.Resources.DynamoSolidToRevitBRepFailure);
-           }
+            if (geometry == null)
+            {
+                // An unexpected failure occurred when attempting to convert the solid into a Revit BRep.
+                throw new Exception(Properties.Resources.DynamoSolidToRevitBRepFailure);
+            }
 
             return geometry;
-       }
+        }
 
-       /// <summary>
-       /// this method attempts to construct a BRep from a surface.
-       /// </summary>
-       /// <param name="surf"></param>
-       /// <param name="performHostUnitConversion"></param>
-       /// <returns></returns>
-       public static GeometryObject ToRevitType(Surface surf,
-          bool performHostUnitConversion = true)
-       {
-            var geometry = ToRevitType(surf, performHostUnitConversion, BRepType.OpenShell);
+        /// <summary>
+        /// this method attempts to construct a BRep from a surface.
+        /// </summary>
+        /// <param name="surf"></param>
+        /// <param name="performHostUnitConversion"></param>
+        /// <param name="materialId"></param>
+        /// <returns></returns>
+        public static GeometryObject ToRevitType(Surface surf,
+          bool performHostUnitConversion = true,
+          ElementId materialId = null)
+        {
+            var geometry = ToRevitType(surf, performHostUnitConversion, BRepType.OpenShell, materialId);
 
             if (geometry == null)
             {
@@ -52,87 +54,93 @@ namespace Revit.GeometryConversion
                 throw new Exception(Properties.Resources.DynamoSurfaceToRevitBRepFailure);
             }
 
-           return geometry;
-       }
+            return geometry;
+        }
 
-       private static GeometryObject ToRevitType(Autodesk.DesignScript.Geometry.Topology topology,
-       bool performHostUnitConversion,
-       BRepType type)
-       {
-           var faces = topology.Faces.ToList();
-           var brb = new BRepBuilder(type);
-           var edge2EdgeId = new Dictionary<Edge, BRepBuilderGeometryId>();
+        private static GeometryObject ToRevitType(Autodesk.DesignScript.Geometry.Topology topology,
+        bool performHostUnitConversion,
+        BRepType type, ElementId materialId)
+        {
+            var faces = topology.Faces.ToList();
+            var brb = new BRepBuilder(type);
+            var edge2EdgeId = new Dictionary<Edge, BRepBuilderGeometryId>();
 
-           //foreach face in solid/surface
-           foreach (Face protoFace in faces)
-           {
-               using(var geom = protoFace.SurfaceGeometry())
-               {
-                   using(var ngeom = geom.ToNurbsSurface())
-                   {
-                       bool flipped = false;
-                       // Check if the nurbs surface has flipped compared to the original surface
-                       if (geom.NormalAtParameter(.5, .5).Dot(ngeom.NormalAtParameter(.5, .5)) < 0)
-                       {
-                           flipped = true;
-                       }
+            //foreach face in solid/surface
+            foreach (Face protoFace in faces)
+            {
+                using (var geom = protoFace.SurfaceGeometry())
+                {
+                    using (var ngeom = geom.ToNurbsSurface())
+                    {
+                        bool flipped = false;
+                        // Check if the nurbs surface has flipped compared to the original surface
+                        if (geom.NormalAtParameter(.5, .5).Dot(ngeom.NormalAtParameter(.5, .5)) < 0)
+                        {
+                            flipped = true;
+                        }
 
-                       // Create Revit nurbs surface
-                       var bbface = BRepBuilderSurfaceGeometry.CreateNURBSSurface(ngeom.DegreeU, ngeom.DegreeV,
+                        // Create Revit nurbs surface
+                        var bbface = BRepBuilderSurfaceGeometry.CreateNURBSSurface(ngeom.DegreeU, ngeom.DegreeV,
                            ngeom.UKnots(), ngeom.VKnots(), ngeom.ControlPoints().SelectMany(x => x.Select(y => y.ToXyz(performHostUnitConversion))).ToList(),
                            ngeom.Weights().SelectMany(x => x).ToList(),
                            false,
                            null);
 
-                       // Add face
-                       var faceId = brb.AddFace(bbface, flipped);
+                        // Add face
+                        var faceId = brb.AddFace(bbface, flipped);
 
-                       // add loops and connected edges
-                       foreach (var loop in protoFace.Loops)
-                       {
-                           var loopId = brb.AddLoop(faceId);
+                        // Set material
+                        if (materialId != null)
+                        {
+                            brb.SetFaceMaterialId(faceId, materialId);
+                        }
 
-                           foreach (var coedge in loop.CoEdges)
-                           {
-                               var edge = coedge.Edge;
-                               BRepBuilderGeometryId edgeId;
-                               if (edge2EdgeId.ContainsKey(edge))
-                               {
-                                   edgeId = edge2EdgeId[edge];
-                               }
-                               else
-                               {
-                                   var curve = edge.CurveGeometry;
-                                   // Revit is already projecting edges onto the surface after checking for loop consistency
-                                   // and is quite forgiving even when we use the nurbs surface instead of 
-                                   // the original surface.
-                                   //
-                                   // But there are cases when edges ends up slightly outside one of the surfaces and Revit fails.
-                                   //
-                                   // This is something that we can be improve going forward.
-                                   edgeId = brb.AddEdge(BRepBuilderEdgeGeometry.Create(curve.ToRevitType(performHostUnitConversion)));
-                                   edge2EdgeId[edge] = edgeId;
-                               }
-                               brb.AddCoEdge(loopId, edgeId, coedge.Reversed);
-                           }
+                        // add loops and connected edges
+                        foreach (var loop in protoFace.Loops)
+                        {
+                            var loopId = brb.AddLoop(faceId);
 
-                           brb.FinishLoop(loopId);
-                       }
+                            foreach (var coedge in loop.CoEdges)
+                            {
+                                var edge = coedge.Edge;
+                                BRepBuilderGeometryId edgeId;
+                                if (edge2EdgeId.ContainsKey(edge))
+                                {
+                                    edgeId = edge2EdgeId[edge];
+                                }
+                                else
+                                {
+                                    var curve = edge.CurveGeometry;
+                                    // Revit is already projecting edges onto the surface after checking for loop consistency
+                                    // and is quite forgiving even when we use the nurbs surface instead of 
+                                    // the original surface.
+                                    //
+                                    // But there are cases when edges ends up slightly outside one of the surfaces and Revit fails.
+                                    //
+                                    // This is something that we can be improve going forward.
+                                    edgeId = brb.AddEdge(BRepBuilderEdgeGeometry.Create(curve.ToRevitType(performHostUnitConversion)));
+                                    edge2EdgeId[edge] = edgeId;
+                                }
+                                brb.AddCoEdge(loopId, edgeId, coedge.Reversed);
+                            }
 
-                       brb.FinishFace(faceId);
-                   }
-               }
-           }
+                            brb.FinishLoop(loopId);
+                        }
 
-           //clean up everything
-           edge2EdgeId.ToList().ForEach(x => x.Key.Dispose());
-           faces.ForEach(x => x.Dispose());
+                        brb.FinishFace(faceId);
+                    }
+                }
+            }
 
-           // Get result
-           var outcome = brb.Finish();
-           var converted = brb.GetResult();
+            //clean up everything
+            edge2EdgeId.ToList().ForEach(x => x.Key.Dispose());
+            faces.ForEach(x => x.Dispose());
 
-           return converted;
-       }
-   }
+            // Get result
+            var outcome = brb.Finish();
+            var converted = brb.GetResult();
+
+            return converted;
+        }
+    }
 }

--- a/test/Libraries/RevitNodesTests/Elements/DirectShapeTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DirectShapeTests.cs
@@ -96,6 +96,8 @@ namespace RevitNodesTests.Elements
             Assert.AreEqual(10, geo.Faces.Size);
             // Check number of Edges
             Assert.AreEqual(24, geo.Edges.Size);
+            // Check that material is set
+            Assert.AreNotEqual(-1, geo.Faces.get_Item(0).MaterialElementId.IntegerValue);
 
             // Check bounding box to make sure we got unit conversion right
             ds.BoundingBox.MaxPoint.ShouldBeApproximately(10.0, 10.0, 10.0);
@@ -130,6 +132,8 @@ namespace RevitNodesTests.Elements
             Assert.AreEqual(1, geo.Faces.Size);
             // Check number of Edges
             Assert.AreEqual(6, geo.Edges.Size);
+            // Check that material is set
+            Assert.AreNotEqual(-1, geo.Faces.get_Item(0).MaterialElementId.IntegerValue);
 
             // Check bounding box to make sure we got unit conversion right
             ds.BoundingBox.MaxPoint.ShouldBeApproximately(10.0, 10.0, 0.0);


### PR DESCRIPTION
### Purpose

Apply material to BRep based direct shapes. We somehow missed this when we added support for BRep based direct shapes. This will fix MAGN-10141 Brep based direct shape doesn't display with material (#1004 Direct Shape Materials not Displaying in Revit 2017).

This fix is for Revit 2017 only.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@QilongTang 

### FYIs
@mjkkirschner @jnealb 


