### PR TITLE
MAGN-10290 - Fix Hardware Acceleration Crash in Revit 2017

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -35,7 +35,7 @@ using RevitServices.Threading;
 using MessageBox = System.Windows.Forms.MessageBox;
 using DynUpdateManager = Dynamo.Updates.UpdateManager;
 using Microsoft.Win32;
-
+using System.Windows.Media;
 
 namespace RevitServices.Threading
 {
@@ -253,7 +253,13 @@ namespace Dynamo.Applications
                 if (CheckJournalForUiDisplay(extCommandData))
                 {
                     dynamoViewModel = InitializeCoreViewModel(revitDynamoModel);
+
+                    // Let the host (e.g. Revit) control the rendering mode
+                    var save = RenderOptions.ProcessRenderMode;
                     InitializeCoreView().Show();
+                    RenderOptions.ProcessRenderMode = save;
+                    revitDynamoModel.Logger.Log("WPF Render Mode: " + RenderOptions.ProcessRenderMode.ToString());
+
                     ModelState = RevitDynamoModelState.StartedUI;
                     // Disable the Dynamo button to prevent a re-run
                     DynamoRevitApp.DynamoButtonEnabled = false;

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -20,6 +20,7 @@ using Autodesk.Revit.UI;
 
 using Dynamo.Applications;
 using Dynamo.Applications.Models;
+using Dynamo.Applications.Properties;
 using Dynamo.Applications.ViewModel;
 using Dynamo.Controls;
 using Dynamo.Core;
@@ -258,7 +259,7 @@ namespace Dynamo.Applications
                     var save = RenderOptions.ProcessRenderMode;
                     InitializeCoreView().Show();
                     RenderOptions.ProcessRenderMode = save;
-                    revitDynamoModel.Logger.Log("WPF Render Mode: " + RenderOptions.ProcessRenderMode.ToString());
+                    revitDynamoModel.Logger.Log(Dynamo.Applications.Properties.Resources.WPFRenderMode + RenderOptions.ProcessRenderMode.ToString());
 
                     ModelState = RevitDynamoModelState.StartedUI;
                     // Disable the Dynamo button to prevent a re-run

--- a/src/DynamoRevit/DynamoRevitApp.cs
+++ b/src/DynamoRevit/DynamoRevitApp.cs
@@ -129,14 +129,6 @@ namespace Dynamo.Applications
 
         public Result OnStartup(UIControlledApplication application)
         {
-            // Revit2015+ has disabled hardware acceleration for WPF to
-            // avoid issues with rendering certain elements in the Revit UI. 
-            // Here we get it back, by setting the ProcessRenderMode to Default,
-            // signifying that we want to use hardware rendering if it's 
-            // available.
-
-            RenderOptions.ProcessRenderMode = RenderMode.Default;
-
             try
             {
                 if (false == TryResolveDynamoCore())

--- a/src/DynamoRevit/Properties/Resources.Designer.cs
+++ b/src/DynamoRevit/Properties/Resources.Designer.cs
@@ -188,5 +188,14 @@ namespace Dynamo.Applications.Properties {
                 return ResourceManager.GetString("RevitValidContextMessage", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to WPF Render Mode: .
+        /// </summary>
+        public static string WPFRenderMode {
+            get {
+                return ResourceManager.GetString("WPFRenderMode", resourceCulture);
+            }
+        }
     }
 }

--- a/src/DynamoRevit/Properties/Resources.en-US.resx
+++ b/src/DynamoRevit/Properties/Resources.en-US.resx
@@ -162,4 +162,7 @@ Would you like to download the latest version of DynamoCore.msi from http://dyna
   <data name="DynamoCoreNotFoundDialogTitle" xml:space="preserve">
     <value>Dynamo Core component could not be found</value>
   </data>
+  <data name="WPFRenderMode" xml:space="preserve">
+    <value>WPF Render Mode: </value>
+  </data>
 </root>

--- a/src/DynamoRevit/Properties/Resources.resx
+++ b/src/DynamoRevit/Properties/Resources.resx
@@ -162,4 +162,7 @@ Would you like to download the latest version of DynamoCore.msi from http://dyna
   <data name="DynamoCoreNotFoundDialogTitle" xml:space="preserve">
     <value>Dynamo Core component could not be found</value>
   </data>
+  <data name="WPFRenderMode" xml:space="preserve">
+    <value>WPF Render Mode: </value>
+  </data>
 </root>


### PR DESCRIPTION
### Purpose

By default, Dynamo4Revit has WPF Hardware Acceleration turned on when Dynamo loads and when the Dynamo button is clicked. This is causing crashes in Revit 2017.

The proposed fix from our end is to let Revit decide if WPF Hardware acceleration should be on or off. The default is off. Hardware Acceleration can then be turned on in Revit 2017 SP2 or later by adding "UseHardwareAcceleration=1" to the [UserInterface] section of the Revit.ini. UI for controlling this setting will be provided in Revit 2018 or later.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@QilongTang 

### FYIs

@mjkkirschner @jnealb 
