### PR TITLE
fix freeze for multiSerializeableIds

### DIFF
--- a/src/Libraries/RevitServices/Persistence/ElementBinder.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementBinder.cs
@@ -574,25 +574,35 @@ namespace RevitServices.Persistence
 
                             if (sid != null)
                             {
-                                //Get the Autodesk.Revit.Element.
-                                Element el;
-                                DocumentManager.Instance.CurrentDBDocument.TryGetElement(new ElementId(sid.IntID),
-                                    out el);
+                                setEachElementFreezeState(node.IsFrozen, sid.IntID);
 
-                                //Get the Revit Element wrapper.
-                                if (el != null)
-                                {
-                                    dynamic elem =
-                                        ElementIDLifecycleManager<int>.GetInstance().GetFirstWrapper(el.Id.IntegerValue);
-                                    if (elem != null)
-                                    {
-                                        elem.IsFrozen = node.IsFrozen;
-                                    }
-                                }
+                            }
 
+                            else if (thingy is MultipleSerializableId)
+                            {
+                                (thingy as MultipleSerializableId).IntIDs.ForEach(x => setEachElementFreezeState(node.IsFrozen, x));
                             }
                         }
                     }
+                }
+            }
+        }
+
+        private static void setEachElementFreezeState(bool frozen, int elementId)
+        {
+            //Get the Autodesk.Revit.Element.
+            Element el;
+            DocumentManager.Instance.CurrentDBDocument.TryGetElement(new ElementId(elementId),
+                out el);
+
+            //Get the Revit Element wrapper.
+            if (el != null)
+            {
+                dynamic elem =
+                    ElementIDLifecycleManager<int>.GetInstance().GetFirstWrapper(el.Id.IntegerValue);
+                if (elem != null)
+                {
+                    elem.IsFrozen = frozen;
                 }
             }
         }

--- a/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
+++ b/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
@@ -108,6 +108,53 @@ namespace RevitSystemTests
         }
 
         [Test]
+        [TestModel(@".\AdaptiveComponent\AdaptiveComponentsByPoints.rfa")]
+        public void CreateAdaptiveComponentsByPointsFrozen()
+        {
+            var model = ViewModel.Model;
+
+            string testFilePath = Path.Combine(workingDirectory, @".\AdaptiveComponent\AdaptiveComponentsByPoints.dyn");
+            string testPath = Path.GetFullPath(testFilePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+
+            AssertNoDummyNodes();
+
+            // Check all the nodes and connectors are loaded
+            Assert.AreEqual(4, model.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(3, model.CurrentWorkspace.Connectors.Count());
+
+            RunCurrentModel();
+
+            // Check the number of the created adaptive components is correct
+            var adapID = "79637f91-d35b-49fc-bc54-4f5a1922633e";
+            AssertPreviewCount(adapID, 6);
+            for (int i = 0; i < 6; i++)
+            {
+                var adapValue = GetPreviewValueAtIndex(adapID, i) as AdaptiveComponent;
+                Assert.IsNotNull(adapValue);
+            }
+
+            //delete the adaptive components
+            for (int i = 0; i < 6; i++)
+            {
+                var adapValue = GetPreviewValueAtIndex(adapID, i) as AdaptiveComponent;
+                adapValue.Dispose();
+            }
+
+            //now freeze adaptive component node
+            var adaptnode = model.CurrentWorkspace.NodeFromWorkspace(adapID);
+            adaptnode.IsFrozen = true;
+
+            //rereun the graph;
+            RunCurrentModel();
+
+            //assert no adaptive components in the model
+            Assert.AreEqual(0, GetAllFamilyInstances(true).Count);
+
+        }
+
+        [Test]
         [TestModel(@".\AdaptiveComponent\AdaptiveComponentsByPointsOnFace.rfa")]
         public void CreateAdaptiveComponentsByPointsOnFace()
         {


### PR DESCRIPTION
### Purpose
http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10285

Freeze stopped working on nodes that saved multiple element ids into trace. This PR does the right thing when setting the freeze state of an element if the object that comes back out of trace for the node callsite is a `MultiSerializeableID`


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@ramramps 

### FYIs

@kronz 