### PR TITLE
Fix the failing test case

### DIFF
--- a/test/System/AdaptiveComponent/AdaptiveComponentByCurve.dyn
+++ b/test/System/AdaptiveComponent/AdaptiveComponentByCurve.dyn
@@ -6,7 +6,7 @@
     </Dynamo.Nodes.DSModelElementSelection>
     <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="e83c14bb-864f-4730-900f-0905dac6dcad" nickname="AdaptiveComponent.ByParametersOnCurveReference" x="811.261830929377" y="372.132597952746" isVisible="true" isUpstreamVisible="true" lacing="Longest" assembly="..\..\..\..\..\..\..\..\..\Program%20Files\Dynamo%200.7\Revit_2014\RevitNodes.dll" function="Revit.Elements.AdaptiveComponent.ByParametersOnCurveReference@double[],var,Revit.Elements.FamilySymbol" />
     <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="a3f48358-9871-4f7e-8da6-b1700a917359" nickname="CurveElement.Curve" x="584.532526757906" y="395.624850858758" isVisible="true" isUpstreamVisible="true" lacing="Longest" assembly="..\..\..\..\..\..\..\..\..\Program%20Files\Dynamo%200.7\Revit_2014\RevitNodes.dll" function="Revit.Elements.CurveElement.Curve" />
-    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="cd3fa904-8507-4fd1-a073-3658e76b90d5" nickname="Code Block" x="638.451611694758" y="272.588424244163" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="{0..1..#10};" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel type="Dynamo.Nodes.CodeBlockNodeModel" guid="cd3fa904-8507-4fd1-a073-3658e76b90d5" nickname="Code Block" x="638.451611694758" y="272.588424244163" isVisible="true" isUpstreamVisible="true" lacing="Disabled" CodeText="0..1..#10;" ShouldFocus="false" />
     <Dynamo.Nodes.DSFunction type="Dynamo.Nodes.DSFunction" guid="272d86db-a124-48dd-9c41-6a3b17200e10" nickname="Flatten" x="1195.51217405465" y="374.325228146728" isVisible="true" isUpstreamVisible="true" lacing="Shortest" assembly="" function="Flatten@var[]..[]" />
   </Elements>
   <Connectors>


### PR DESCRIPTION
### Purpose

This is to fix the failing test case. The cause is that https://github.com/DynamoDS/DynamoRevit/pull/1056 has changed the parameters of AdaptiveComponent.ByParametersOnCurveReference. Thus we need to change back the input of the node in the dyn file from `"{0..1..#10};"` to `"0..1..#10;"`.

### Reviewers
@Benglin 

### FYIs
@sharadkjaiswal @kronz 

