### PR TITLE
Add two test cases for element binding related to re-opening the graph

### DIFF
--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -243,6 +243,64 @@ namespace RevitSystemTests
 
         [Test]
         [TestModel(@".\empty.rfa")]
+        public void CreateInDynamoCloseGraphReopenGraphRerun()
+        {
+            //Create a reference point at (0.0, 0.0, 0.0);
+            string dynFilePath = Path.Combine(workingDirectory, @".\ElementBinding\CreateOneReferencePoint.dyn");
+            string testPath = Path.GetFullPath(dynFilePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+
+            RunCurrentModel();
+
+            //Close the current graph
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            //Open the same graph 
+            ViewModel.OpenCommand.Execute(testPath);
+
+            //Run the graph once again
+            RunCurrentModel();
+
+            var points = GetAllReferencePointElements(true);
+            Assert.AreEqual(2, points.Count);
+            var pnt = points[0] as ReferencePoint;
+            Assert.IsTrue(pnt.Position.IsAlmostEqualTo(new XYZ(0.0, 0.0, 0.0)));
+        }
+
+        [Test]
+        [TestModel(@".\empty.rfa")]
+        public void CreateInDynamoSaveCloseGraphReopenGraphRerun()
+        {
+            //Create a reference point at (0.0, 0.0, 0.0);
+            string dynFilePath = Path.Combine(workingDirectory, @".\ElementBinding\CreateOneReferencePoint.dyn");
+            string testPath = Path.GetFullPath(dynFilePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+
+            RunCurrentModel();
+
+            //Save the current graph
+            string tempPath = Path.Combine(Path.GetTempPath(), "CreateOneReferencePoint.dyn");
+            ViewModel.SaveAsCommand.Execute(tempPath);
+
+            //Close the current graph
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            //Open the saved graph 
+            ViewModel.OpenCommand.Execute(tempPath);
+
+            //Run the graph once again
+            RunCurrentModel();
+
+            var points = GetAllReferencePointElements(true);
+            Assert.AreEqual(1, points.Count);
+            var pnt = points[0] as ReferencePoint;
+            Assert.IsTrue(pnt.Position.IsAlmostEqualTo(new XYZ(0.0, 0.0, 0.0)));
+        }
+
+        [Test]
+        [TestModel(@".\empty.rfa")]
         public void CreateInDynamoDeleteInRevit()
         {
             //This test case is to test that elements can be created via Dynamo.

--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -266,6 +266,8 @@ namespace RevitSystemTests
             Assert.AreEqual(2, points.Count);
             var pnt = points[0] as ReferencePoint;
             Assert.IsTrue(pnt.Position.IsAlmostEqualTo(new XYZ(0.0, 0.0, 0.0)));
+            pnt = points[1] as ReferencePoint;
+            Assert.IsTrue(pnt.Position.IsAlmostEqualTo(new XYZ(0.0, 0.0, 0.0)));
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

This is to add two element binding test cases:
1). Run a graph, then close the graph and then open the same graph and run again;
2). Run a graph, then save and close the graph, and then open the same graph and run again.

The graph in use is simply to add one reference point at (0, 0, 0).

For test case 1, finally there will be two reference points; while for test case 2, finally there will be one reference points.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@QilongTang 

### FYIs

@kronz @sharadkjaiswal @riteshchandawar 

