### PR TITLE
filter dynamo versions that support playlist on startup

### DIFF
--- a/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
+++ b/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
@@ -36,9 +36,11 @@ namespace Dynamo.Applications
     [Regeneration(RegenerationOption.Manual)]
     public class VersionLoader : IExternalApplication
     {
-        private static UIControlledApplication uiApplication;
+        private static UIControlledApplication uiControlledApplication;
         private AddInCommandBinding dynamoCommand;
+        private AddInCommandBinding dynamoPlayerCommand;
         internal List<DynamoProduct> Products { get; private set; }
+        internal List<DynamoProduct> PlaylistProducts { get; private set; }
 
         internal static string GetDynamoRevitPath(DynamoProduct product, string revitVersion)
         {
@@ -50,7 +52,7 @@ namespace Dynamo.Applications
 
         public Result OnStartup(UIControlledApplication application)
         {
-            uiApplication = application;
+            uiControlledApplication = application;
             var revitVersion = application.ControlledApplication.VersionNumber;
 
             var revitFolder =
@@ -60,6 +62,7 @@ namespace Dynamo.Applications
             var dynamoProducts = FindDynamoRevitInstallations(debugPath, revitVersion);
 
             Products = new List<DynamoProduct>();
+            PlaylistProducts = new List<DynamoProduct>();
             foreach (var p in dynamoProducts)
             {
                 var path = VersionLoader.GetDynamoRevitPath(p, revitVersion);
@@ -67,7 +70,20 @@ namespace Dynamo.Applications
                     continue;
 
                 Products.Add(p);
+
+                if (p.VersionInfo.Build >= 1 && p.VersionInfo.Major >= 1)
+                {
+                    if (Convert.ToInt64(revitVersion) >= 2017)
+                    {
+                        PlaylistProducts.Add(p);
+                    }
+                }
             }
+
+            if (Products.Count == 0)
+                return Result.Failed;
+
+            Result preliminaryLoadResult = Result.Succeeded;
 
             // If there are multiple versions installed, then do the command 
             // binding to prompt for version selector task dialog for user to 
@@ -79,27 +95,50 @@ namespace Dynamo.Applications
                 dynamoCommand.CanExecute += canExecute;
                 dynamoCommand.BeforeExecuted += beforeExecuted;
                 dynamoCommand.Executed += executed;
+
+                if (PlaylistProducts.Count >= 1)
+                {
+                    var dynamoPlayerCmdId = RevitCommandId.LookupCommandId("ID_PLAYLIST_DYNAMO");
+                    if (dynamoPlayerCmdId != null)
+                    {
+                        dynamoPlayerCommand = application.CreateAddInCommandBinding(dynamoPlayerCmdId);
+                        dynamoPlayerCommand.CanExecute += canExecute;
+                        dynamoPlayerCommand.BeforeExecuted += beforeExecuted;
+                        dynamoPlayerCommand.Executed += executedPlaylist;
+                    }
+                }
             }
             else //If only one product is installed load the Revit App directly
             {
-                string loadPath = GetDynamoRevitPath(Products.ElementAt(0), revitVersion);
-
-                if (String.IsNullOrEmpty(loadPath))
-                    return Result.Failed;
-
-                var ass = Assembly.LoadFrom(loadPath);
-                var revitApp = ass.CreateInstance("Dynamo.Applications.DynamoRevitApp");
-                revitApp.GetType().GetMethod("OnStartup").Invoke(revitApp, new object[] { application });
+                preliminaryLoadResult = loadProduct(Products.First(), revitVersion);
             }
 
-            return Result.Succeeded;
+            return preliminaryLoadResult;
         }
 
         void executed(object sender, ExecutedEventArgs e)
         {
-            var product = PromptVersionSelectorDialog();
+            var product = PromptVersionSelectorDialog(Products);
             if(product.HasValue)
                 LaunchDynamoCommand(product.Value, e);
+        }
+
+        void executedPlaylist(object sender, ExecutedEventArgs e)
+        {
+            if (PlaylistProducts.Count == 0)
+                return;
+
+            DynamoProduct productToLaunch = PlaylistProducts.First();
+            if (PlaylistProducts.Count > 1)
+            {
+                var product = PromptVersionSelectorDialog(PlaylistProducts);
+                if (product.HasValue)
+                {
+                    productToLaunch = product.Value;
+                }
+            }
+
+            LaunchDynamoCommand(productToLaunch, e, true);
         }
 
         void beforeExecuted(object sender, BeforeExecutedEventArgs e)
@@ -112,11 +151,25 @@ namespace Dynamo.Applications
             e.CanExecute = e.ActiveDocument != null;
         }
 
+        private Result loadProduct(DynamoProduct product, string revitVersion)
+        {
+            string loadPath = GetDynamoRevitPath(product, revitVersion);
+
+            if (String.IsNullOrEmpty(loadPath))
+                return Result.Failed;
+
+            var ass = Assembly.LoadFrom(loadPath);
+            var revitApp = ass.CreateInstance("Dynamo.Applications.DynamoRevitApp");
+            revitApp.GetType().GetMethod("OnStartup").Invoke(revitApp, new object[] { uiControlledApplication });
+
+            return Result.Succeeded;
+        }
+
         /// <summary>
         /// Prompts for version selection task dialog
         /// </summary>
         /// <returns>DynamoProduct to launch or null</returns>
-        private DynamoProduct? PromptVersionSelectorDialog()
+        private DynamoProduct? PromptVersionSelectorDialog(List<DynamoProduct> availableProducts)
         {
             // Creates a Revit task dialog to communicate information to the user.
             TaskDialog mainDialog = new TaskDialog(Resources.DynamoVersions);
@@ -125,12 +178,12 @@ namespace Dynamo.Applications
 
             // Add commmandLink options to task dialog
             int id = (int)TaskDialogCommandLinkId.CommandLink1;
-            var revitVersion = uiApplication.ControlledApplication.VersionNumber;
+            var revitVersion = uiControlledApplication.ControlledApplication.VersionNumber;
             //Get the default selection data
             var selectorData = VersionSelectorData.ReadFromRegistry(revitVersion);
             var selectedVersion = selectorData.SelectedVersion.ToString(2);
             TaskDialogResult defaultResult = TaskDialogResult.CommandLink1;
-            foreach (var item in Products)
+            foreach (var item in availableProducts)
             {
                 var versionText = String.Format(Resources.DynamoVersionText, item.VersionInfo.ToString(3));
                 mainDialog.AddCommandLink((TaskDialogCommandLinkId)id, versionText, item.InstallLocation);
@@ -150,21 +203,23 @@ namespace Dynamo.Applications
                 return null;
 
             var index = (int)tResult - (int)TaskDialogCommandLinkId.CommandLink1;
-            return Products[index];
+            return availableProducts[index];
         }
+
 
         /// <summary>
         /// Launches specific version of Dynamo command
         /// </summary>
         /// <param name="product">DynamoProduct to launch</param>
         /// <param name="e">Command executed event argument</param>
+        /// <param name="playlist">Launch the Playlist app or just Dynamo</param>
         /// <returns>true for success</returns>
-        private bool LaunchDynamoCommand(DynamoProduct product, ExecutedEventArgs e)
+        private bool LaunchDynamoCommand(DynamoProduct product, ExecutedEventArgs e,bool playlist = false)
         {
-            if (uiApplication == null)
+            if (uiControlledApplication == null)
                 throw new InvalidOperationException();
 
-            var revitVersion = uiApplication.ControlledApplication.VersionNumber;
+            var revitVersion = uiControlledApplication.ControlledApplication.VersionNumber;
             var path = GetDynamoRevitPath(product, revitVersion);
             var data = new VersionSelectorData() { RevitVersion = revitVersion, SelectedVersion = product.VersionInfo };
             data.WriteToRegistry();
@@ -174,24 +229,35 @@ namespace Dynamo.Applications
             var revitApp = ass.CreateInstance("Dynamo.Applications.DynamoRevitApp");
             if (null == revitApp)
                 return false;
-
+            
             //Remove the command binding, because now DynamoRevitApp will 
             //do the command binding for DynamoRevit command.
             RemoveCommandBinding();
 
             var type = revitApp.GetType();
-            var result = type.GetMethod("OnStartup").Invoke(revitApp, new object[] { uiApplication });
+            var result = type.GetMethod("OnStartup").Invoke(revitApp, new object[] { uiControlledApplication });
             if ((Result)result != Result.Succeeded)
                 return false;
 
-            //Invoke command
-            string message = string.Empty;
-            result = type.GetMethod("ExecuteDynamoCommand")
-                .Invoke(revitApp, new object[] { e.GetJournalData(), new UIApplication(e.ActiveDocument.Application) });
-            if ((Result)result != Result.Succeeded)
-                return false;
+            UIApplication uiApp = new UIApplication(e.ActiveDocument.Application);
 
-            uiApplication = null; //release application, no more needed.
+            if (!playlist)
+            {
+                //Invoke command
+                string message = string.Empty;
+                result = type.GetMethod("ExecuteDynamoCommand").Invoke(revitApp, new object[] { e.GetJournalData(), uiApp });
+                if ((Result)result != Result.Succeeded)
+                    return false;
+            }
+            else
+            {
+                //search it again since it was re-binded in dependent components
+                var dynamoPlayerCmdId = RevitCommandId.LookupCommandId("ID_PLAYLIST_DYNAMO");
+                if (dynamoPlayerCmdId != null)
+                    uiApp.PostCommand(dynamoPlayerCmdId);
+            }
+
+            uiControlledApplication = null; //release application, no more needed.
             return true;
         }
 
@@ -203,14 +269,24 @@ namespace Dynamo.Applications
 
         private void RemoveCommandBinding()
         {
-            if (null == dynamoCommand)
-                return;
+            if (null != dynamoCommand)
+            {
+                uiControlledApplication.RemoveAddInCommandBinding(dynamoCommand.RevitCommandId);
+                dynamoCommand.BeforeExecuted -= beforeExecuted;
+                dynamoCommand.CanExecute -= canExecute;
+                dynamoCommand.Executed -= executed;
+                dynamoCommand = null;
+            }
 
-            uiApplication.RemoveAddInCommandBinding(dynamoCommand.RevitCommandId);
-            dynamoCommand.BeforeExecuted -= beforeExecuted;
-            dynamoCommand.CanExecute -= canExecute;
-            dynamoCommand.Executed -= executed;
-            dynamoCommand = null;
+            if (null != dynamoPlayerCommand)
+            {
+                uiControlledApplication.RemoveAddInCommandBinding(dynamoPlayerCommand.RevitCommandId);
+                dynamoPlayerCommand.BeforeExecuted -= beforeExecuted;
+                dynamoPlayerCommand.CanExecute -= canExecute;
+                dynamoPlayerCommand.Executed -= executedPlaylist;
+                dynamoPlayerCommand = null;
+            }                
+
         }
 
         private static IEnumerable<DynamoProduct> FindDynamoRevitInstallations(string debugPath, string revitVersion)

--- a/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
+++ b/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
@@ -79,7 +79,7 @@ namespace Dynamo.Applications
                 Products.Add(p);
 
                 if (p.VersionInfo.Major >= MinDynamoMajorVersionForPlaylist
-                    && p.VersionInfo.Major >= MinDynamoMinorVersionForPlaylist)
+                    && p.VersionInfo.Minor >= MinDynamoMinorVersionForPlaylist)
                 {
                     if (Convert.ToInt64(revitVersion) >= MinRevitVersionForPlaylist)
                     {


### PR DESCRIPTION
### Purpose

When I start Revit I want to see the Playlist button enabled if there is at least one version of Dynamo installed that supports Playlist feature. 
If there are more than 1 version , then I'll see the usual version selector dialog when I press the Playlist button. The dialog will show only Dynamo versions that support Playlist and not all Dynamo versions installed ( as it is the case for Dynamo button ).

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@mjkkirschner 

### FYIs

@kronz 

