### PR TITLE
Display Dynamo Revit Version alongside with Dynamo Core Version in DynamoRevit

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -362,7 +362,7 @@ namespace Dynamo.Applications
 
             var utilities = assembly.GetType("DynamoShapeManager.Utilities");
             var getGeometryFactoryPath = utilities.GetMethod("GetGeometryFactoryPath");
-
+            
             return (getGeometryFactoryPath.Invoke(null,
                 new object[] { corePath, Versions.ShapeManager }) as string);
         }
@@ -373,7 +373,12 @@ namespace Dynamo.Applications
             var dynamoRevitExePath = Assembly.GetExecutingAssembly().Location;
             var dynamoRevitRoot = Path.GetDirectoryName(dynamoRevitExePath);// ...\Revit_xxxx\ folder
 
+            var revitFilePath = Directory.GetFiles(dynamoRevitRoot, "*DynamoRevitDS.dll").FirstOrDefault();
+            var revitVersion = String.IsNullOrEmpty(revitFilePath) ? null : Version.Parse(FileVersionInfo.GetVersionInfo(revitFilePath).FileVersion);
+            
             var umConfig = UpdateManagerConfiguration.GetSettings(new DynamoRevitLookUp());
+            var RevitUpdateManager = new DynUpdateManager(umConfig);
+            RevitUpdateManager.DynamoRevitVersion = revitVersion;
             Debug.Assert(umConfig.DynamoLookUp != null);
 
             var userDataFolder = Path.Combine(Environment.GetFolderPath(
@@ -399,7 +404,7 @@ namespace Dynamo.Applications
                     StartInTestMode = isAutomationMode,
                     AuthProvider = new RevitOxygenProvider(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher)),
                     ExternalCommandData = commandData,
-                    UpdateManager = new DynUpdateManager(umConfig),
+                    UpdateManager = RevitUpdateManager,
                     ProcessMode = isAutomationMode ? TaskProcessMode.Synchronous : TaskProcessMode.Asynchronous
                 });
         }
@@ -695,5 +700,6 @@ namespace Dynamo.Applications
 
             return paths;
         }
+
     }
 }

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -373,12 +373,14 @@ namespace Dynamo.Applications
             var dynamoRevitExePath = Assembly.GetExecutingAssembly().Location;
             var dynamoRevitRoot = Path.GetDirectoryName(dynamoRevitExePath);// ...\Revit_xxxx\ folder
 
+            // get Dynamo Revit Version
             var revitFilePath = Directory.GetFiles(dynamoRevitRoot, "*DynamoRevitDS.dll").FirstOrDefault();
             var revitVersion = String.IsNullOrEmpty(revitFilePath) ? null : Version.Parse(FileVersionInfo.GetVersionInfo(revitFilePath).FileVersion);
             
             var umConfig = UpdateManagerConfiguration.GetSettings(new DynamoRevitLookUp());
             var RevitUpdateManager = new DynUpdateManager(umConfig);
-            RevitUpdateManager.DynamoRevitVersion = revitVersion;
+            RevitUpdateManager.DynamoRevitVersion = revitVersion; // update RevitUpdateManager with the current DynamoRevit Version
+
             Debug.Assert(umConfig.DynamoLookUp != null);
 
             var userDataFolder = Path.Combine(Environment.GetFolderPath(


### PR DESCRIPTION
### Purpose

This PR address the user story filed in _MAGN-9532_. Previously, in DynamoRevit, whenever users clicked on the 'Help' -> 'About' menu, all they see will be as follows: 

![aboutboxdynamostandalone](https://cloud.githubusercontent.com/assets/16283396/18193768/52414114-7113-11e6-8d9f-d252f9847c87.PNG)

This is the same About Box window which users see in DynamoSandbox. The version number reflected here is essentially the version number of DynamoCore. At times, however, DynamoRevit's version will be different from that of DynamoCore. 

As such, in order to improve the visibility of the different versions to the user, this PR (alongside with the one filed in the main Dynamo repo) allows the user to see both versions at the same time in DynamoRevit. The design was based on the one proposed in the user story:

![aboutboxdynamorevit](https://cloud.githubusercontent.com/assets/16283396/18193820/c04cbf6c-7113-11e6-91a1-81169ce3e046.PNG)

In DynamoSandbox, however, the single version remains:

![aboutboxdynamostandalone](https://cloud.githubusercontent.com/assets/16283396/18193824/d30642ae-7113-11e6-8366-e3384220a6ce.PNG)

Amendments were made in both DynamoRevit.cs as well as in DynamoCore itself. See PR: https://github.com/DynamoDS/Dynamo/pull/7108

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 

### FYIs

@ke-yu 
