### PR TITLE
Rc1.2.0 revit2017

### DIFF
--- a/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
+++ b/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
@@ -45,7 +45,7 @@ namespace Dynamo.Applications
 
         //Minimum version requirements needed by Playlist feature for Dynamo and Revit.
         private const int MinDynamoMajorVersionForPlaylist = 1;
-        private const int MinDynamoMinorVersionForPlaylist = 1;
+        private const int MinDynamoMinorVersionForPlaylist = 2;
         private const int MinRevitVersionForPlaylist = 2017;
 
 
@@ -79,7 +79,7 @@ namespace Dynamo.Applications
                 Products.Add(p);
 
                 if (p.VersionInfo.Major >= MinDynamoMajorVersionForPlaylist
-                    && p.VersionInfo.Major >= MinDynamoMinorVersionForPlaylist)
+                    && p.VersionInfo.Minor >= MinDynamoMinorVersionForPlaylist)
                 {
                     if (Convert.ToInt64(revitVersion) >= MinRevitVersionForPlaylist)
                     {


### PR DESCRIPTION
### Purpose

When I start Revit I want to see the Playlist button enabled if there is at least one version of Dynamo installed that supports Playlist feature. 
If there are more than 1 version , then I'll see the usual version selector dialog when I press the Playlist button. The dialog will show only Dynamo versions that support Playlist and not all Dynamo versions installed ( as it is the case for Dynamo button ).

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@mjkkirschner 
