### PR TITLE
Display Dynamo Revit Version alongside with Dynamo Core Version in DynamoRevit

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -373,7 +373,14 @@ namespace Dynamo.Applications
             var dynamoRevitExePath = Assembly.GetExecutingAssembly().Location;
             var dynamoRevitRoot = Path.GetDirectoryName(dynamoRevitExePath);// ...\Revit_xxxx\ folder
 
+            // get Dynamo Revit Version
+            var revitFilePath = Directory.GetFiles(dynamoRevitRoot, "*DynamoRevitDS.dll").FirstOrDefault();
+            var revitVersion = String.IsNullOrEmpty(revitFilePath) ? null : Version.Parse(FileVersionInfo.GetVersionInfo(revitFilePath).FileVersion);
+            
             var umConfig = UpdateManagerConfiguration.GetSettings(new DynamoRevitLookUp());
+            var RevitUpdateManager = new DynUpdateManager(umConfig);
+            RevitUpdateManager.DynamoRevitVersion = revitVersion; // update RevitUpdateManager with the current DynamoRevit Version
+
             Debug.Assert(umConfig.DynamoLookUp != null);
 
             var userDataFolder = Path.Combine(Environment.GetFolderPath(

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -374,9 +374,8 @@ namespace Dynamo.Applications
             var dynamoRevitRoot = Path.GetDirectoryName(dynamoRevitExePath);// ...\Revit_xxxx\ folder
 
             // get Dynamo Revit Version
-            var revitFilePath = Directory.GetFiles(dynamoRevitRoot, "*DynamoRevitDS.dll").FirstOrDefault();
-            var revitVersion = String.IsNullOrEmpty(revitFilePath) ? null : Version.Parse(FileVersionInfo.GetVersionInfo(revitFilePath).FileVersion);
-            
+            var revitVersion = Assembly.GetExecutingAssembly().GetName().Version;
+
             var umConfig = UpdateManagerConfiguration.GetSettings(new DynamoRevitLookUp());
             var revitUpdateManager = new DynUpdateManager(umConfig);
             revitUpdateManager.HostVersion = revitVersion; // update RevitUpdateManager with the current DynamoRevit Version

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -379,7 +379,8 @@ namespace Dynamo.Applications
             
             var umConfig = UpdateManagerConfiguration.GetSettings(new DynamoRevitLookUp());
             var RevitUpdateManager = new DynUpdateManager(umConfig);
-            RevitUpdateManager.DynamoRevitVersion = revitVersion; // update RevitUpdateManager with the current DynamoRevit Version
+            RevitUpdateManager.HostVersion = revitVersion; // update RevitUpdateManager with the current DynamoRevit Version
+            RevitUpdateManager.HostName = "Dynamo Revit";
 
             Debug.Assert(umConfig.DynamoLookUp != null);
 

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -407,7 +407,7 @@ namespace Dynamo.Applications
                     StartInTestMode = isAutomationMode,
                     AuthProvider = new RevitOxygenProvider(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher)),
                     ExternalCommandData = commandData,
-                    UpdateManager = new DynUpdateManager(umConfig),
+                    UpdateManager = RevitUpdateManager,
                     ProcessMode = isAutomationMode ? TaskProcessMode.Synchronous : TaskProcessMode.Asynchronous
                 });
         }

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -378,9 +378,9 @@ namespace Dynamo.Applications
             var revitVersion = String.IsNullOrEmpty(revitFilePath) ? null : Version.Parse(FileVersionInfo.GetVersionInfo(revitFilePath).FileVersion);
             
             var umConfig = UpdateManagerConfiguration.GetSettings(new DynamoRevitLookUp());
-            var RevitUpdateManager = new DynUpdateManager(umConfig);
-            RevitUpdateManager.HostVersion = revitVersion; // update RevitUpdateManager with the current DynamoRevit Version
-            RevitUpdateManager.HostName = "Dynamo Revit";
+            var revitUpdateManager = new DynUpdateManager(umConfig);
+            revitUpdateManager.HostVersion = revitVersion; // update RevitUpdateManager with the current DynamoRevit Version
+            revitUpdateManager.HostName = "Dynamo Revit";
 
             Debug.Assert(umConfig.DynamoLookUp != null);
 
@@ -407,7 +407,7 @@ namespace Dynamo.Applications
                     StartInTestMode = isAutomationMode,
                     AuthProvider = new RevitOxygenProvider(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher)),
                     ExternalCommandData = commandData,
-                    UpdateManager = RevitUpdateManager,
+                    UpdateManager = revitUpdateManager,
                     ProcessMode = isAutomationMode ? TaskProcessMode.Synchronous : TaskProcessMode.Asynchronous
                 });
         }


### PR DESCRIPTION
### Purpose

This PR address the user story filed in _MAGN-9532_. Previously, in DynamoRevit, whenever users clicked on the 'Help' -> 'About' menu, all they see will be as follows: 

![aboutboxdynamostandalone](https://cloud.githubusercontent.com/assets/16283396/18334519/c9001ba4-75aa-11e6-80da-2d3f70391c51.PNG)

This is the same About Box window which users see in DynamoSandbox. The version number reflected here is essentially the version number of DynamoCore. At times, however, DynamoRevit's version will be different from that of DynamoCore. 

As such, in order to improve the visibility of the different versions to the user, this PR (alongside with the one filed in the main Dynamo repo) allows the user to see both versions at the same time in DynamoRevit. The design was based on the one proposed in the user story:

![aboutboxdynamorevit](https://cloud.githubusercontent.com/assets/16283396/18334520/cbfeacda-75aa-11e6-9927-f05b2507add3.PNG)

In DynamoSandbox/Core, however, the single version remains:

![aboutboxdynamostandalone](https://cloud.githubusercontent.com/assets/16283396/18334529/d4902a9a-75aa-11e6-9926-35bc287f5c3e.PNG)

Amendments were made in both DynamoRevit.cs as well as in DynamoCore itself. See PR: https://github.com/DynamoDS/Dynamo/pull/7108

EDIT: Updated to a more generic implementation for the Core - Client relationship. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sharadkjaiswal 

### FYIs

@ke-yu 
