### PR TITLE
move Revit version Playlist restriction into DynamoRevitAdditions.dll

### DIFF
--- a/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
+++ b/src/Legacy/DynamoRevitVersionSelector/VersionSelectorApp.cs
@@ -46,8 +46,6 @@ namespace Dynamo.Applications
         //Minimum version requirements needed by Playlist feature for Dynamo and Revit.
         private const int MinDynamoMajorVersionForPlaylist = 1;
         private const int MinDynamoMinorVersionForPlaylist = 2;
-        private const int MinRevitVersionForPlaylist = 2018;
-
 
         internal static string GetDynamoRevitPath(DynamoProduct product, string revitVersion)
         {
@@ -81,10 +79,7 @@ namespace Dynamo.Applications
                 if (p.VersionInfo.Major >= MinDynamoMajorVersionForPlaylist
                     && p.VersionInfo.Minor >= MinDynamoMinorVersionForPlaylist)
                 {
-                    if (Convert.ToInt64(revitVersion) >= MinRevitVersionForPlaylist)
-                    {
-                        PlaylistProducts.Add(p);
-                    }
+                    PlaylistProducts.Add(p);
                 }
             }
 


### PR DESCRIPTION
### Purpose
In order to have more flexibility in the future we are going to impose Revit version restrictions from within DynamoRevitAdditions.dll from now on . 

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@mjkkirschner 

