### PR TITLE
Mark detail views as annotative

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Views/View.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View.cs
@@ -37,6 +37,7 @@ namespace Revit.Elements.Views
                 case Autodesk.Revit.DB.ViewType.Section:
                 case Autodesk.Revit.DB.ViewType.Elevation:
                 case Autodesk.Revit.DB.ViewType.CeilingPlan:
+                case Autodesk.Revit.DB.ViewType.DraftingView:
                     return true;
 
                 default: return false;


### PR DESCRIPTION
### Purpose

Drafting views can host annotative elements like filled regions and detail curves too.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)

### Reviewers

@moethu