### PR TITLE
Preload conflict dll between Dynamo4Revit and Revit Host

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -371,7 +371,7 @@ namespace Dynamo.Applications
 
             foreach (var assembly in assemblyList)
             {
-                var assemblyPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory + "", assembly);
+                var assemblyPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assembly);
                 if(File.Exists(assemblyPath))
                     Assembly.LoadFrom(assemblyPath);
             }


### PR DESCRIPTION
### Purpose

[MAGN-10678](https://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-10678) GOT REPRO : Blank and un-editable Code Block nodes with D4R upgrade to 1.2

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @sm6srw 

### FYIs

@ramramps @jnealb 

