### PR TITLE
Bump Up Build Number

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -69,6 +69,6 @@ using System.Runtime.InteropServices;
 <#+
 int MajorVersion = 1;
 int MinorVersion = 2;
-int BuildNumber = 0;
+int BuildNumber = 1;
 int RevisionNumber = ((int)(DateTime.UtcNow - new DateTime(2016,1,1)).TotalDays)*10+((int)DateTime.UtcNow.Hour)/3;
 #>


### PR DESCRIPTION
### Purpose

Our DynamoRevit version is currently depending on the DynamoRevitDS.dll version, so bump up the build number so DynamoRevit will show as 1.2.1 in control panel. And our DynamoRevit.exe version is also depending on the same number. 

After the change, build DynamoForRevit repo, RC1.2.1 branch will produce:
![image](https://cloud.githubusercontent.com/assets/3942418/19746016/705d6a24-9ba2-11e6-893a-4cf7a418100e.png)



### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Benglin 

### FYIs
