### PR TITLE
fix failing build

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Views/View.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View.cs
@@ -256,7 +256,12 @@ namespace Revit.Elements.Views
 
             RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
             this.InternalView.SetCategoryOverrides(catId, overrides.InternalOverrideGraphicSettings);
-            this.InternalView.SetCategoryHidden(catId, hide); // Revit 2017 specific method
+            if (hide)
+            {
+                var docCollector = new FilteredElementCollector(Document).OfCategoryId(category.InternalCategory.Id);
+                var elementsToHide = docCollector.ToElementIds();
+                this.InternalView.HideElementsTemporary(elementsToHide);
+            }
             RevitServices.Transactions.TransactionManager.Instance.TransactionTaskDone();
 
             return this;


### PR DESCRIPTION
fix failing 2016 build with workaround to `SetCategoryHidden` method which was added in 2017 API.

