### PR TITLE
put schedule helper classes in scheduleViews

### DIFF
--- a/src/Libraries/RevitNodes/RevitNodes_DynamoCustomization.xml
+++ b/src/Libraries/RevitNodes/RevitNodes_DynamoCustomization.xml
@@ -20,7 +20,7 @@
       <category>Revit.Filter</category>
     </namespace>
     <namespace name="Revit.Schedules">
-      <category>Revit.Schedules</category>
+      <category>Revit.Views.ScheduleView</category>
     </namespace>
     <namespace name="Revit.Geometry">
       <category>Revit.Geometry</category>


### PR DESCRIPTION
### Purpose

move schedule helper classes under the schedule view ...

![screen shot 2016-12-13 at 3 45 28 pm](https://cloud.githubusercontent.com/assets/508936/21158800/b5d4078c-c14c-11e6-8598-84fc850a645e.png)

There seems to be a small bug in the tree view for this particular case of nested categories under a type, not displaying the correct indentation - should be fixed as a separate task.