### PR TITLE
Symlink fix for directory names that contain spaces

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblyInfoGenerator.csproj
+++ b/src/AssemblySharedInfoGenerator/AssemblyInfoGenerator.csproj
@@ -75,6 +75,6 @@
   </Target>
   -->
   <Target Name="BeforeBuild">
-    <Exec Command="$(SolutionDir)restorepackages.bat" ContinueOnError="true" /> 
+    <Exec Command="&quot;$(SolutionDir)restorepackages.bat&quot;" ContinueOnError="true" /> 
   </Target>
 </Project>

--- a/src/restorepackages.bat
+++ b/src/restorepackages.bat
@@ -48,7 +48,7 @@ REM 3. download 3rdParty packages by Aget.exe
     echo If any package is not found in the NuGet Gallery, redirect to look up in the Artifactory server...
 
     :: Symlinks are generated here
-    %PythonAget% -agettable "%ConfigDir%\packages.aget" -refsDir %SymLinksDir%
+    %PythonAget% -agettable "%ConfigDir%\packages.aget" -refsDir "%SymLinksDir%"
     if ERRORLEVEL 1 (
         echo ERROR: Failed to update Dynamo 3rdParty nuget packages in packages.aget
         exit /b 1


### PR DESCRIPTION
### Purpose

To fix issue #1434 *Can't build Revit2017 from source.*

```
> 'C:\Users\ksobon\Google' is not recognized as an internal or external command, operable program
  or batch file.
> C:\Users\ksobon\Google Drive\Work\DynamoRevit\src\AssemblySharedInfoGenerator\AssemblyInfoGener
  ator.csproj(78,5): warning MSB3073: The command "C:\Users\ksobon\Google Drive\Work\DynamoRevit\
  src\restorepackages.bat" exited with code 9009.
```

### Reviewers

@sharadkjaiswal 

### FYIs

@ksobon 