### PR TITLE
Symlink fix for directory names that contain spaces (2)

### DIFF
--- a/src/restorepackages.bat
+++ b/src/restorepackages.bat
@@ -27,16 +27,16 @@ set NugetConfig=%ConfigDir%\dynamo-nuget.config
 REM 2. replace "LatestBeta" strings in packages-template.aget with the latest
 REM    pre-release version of DynamoVisualProgramming.Core package,
 REM    and save the replaced file as packages.aget
-set versionQuery=%NugetExe% list DynamoVisualProgramming.Core -prerelease -config "%NugetConfig%"
-for /F "tokens=2 delims= " %%F in ( '%versionQuery%' ) do (set LatestBeta=%%F)
+set versionQueryParams=list DynamoVisualProgramming.Core -prerelease -config "%NugetConfig%"
+for /F "tokens=2 delims= " %%F in ( 'call "%NugetExe%" %versionQueryParams%' ) do (set LatestBeta=%%F)
 echo Latest pre-release version of "DynamoVisualProgramming.Core" package is "%LatestBeta%"
 
 if exist %ConfigDir%\packages.aget del %ConfigDir%\packages.aget
-for /f "tokens=* delims=¶" %%i in ( '"type %ConfigDir%\packages-template.aget"' ) do (
+for /f "tokens=* delims=¶" %%i in ( 'type "%ConfigDir%\packages-template.aget"' ) do (
     set line=%%i
     setlocal EnableDelayedExpansion
     set line=!line:LatestBeta=%LatestBeta%!
-    echo !line!>>%ConfigDir%\packages.aget
+    echo !line!>>"%ConfigDir%\packages.aget"
     endlocal
 )
 


### PR DESCRIPTION
### Purpose

To fix the remaining issue from #1434 *Can't build Revit2017 from source* which was addressed in PR #1438 *Symlink fix for directory names that contain spaces*.

```
> 'C:\Users\ksobon\Google' is not recognized as an internal or external command, operable program
  or batch file.
> Latest pre-release version of "DynamoVisualProgramming.Core" package is ""
> The system cannot find the file specified.
> Error occurred while processing: C:\Users\ksobon\Google.
> The system cannot find the file specified.
```

### Reviewers

@sharadkjaiswal 

### FYIs

@ksobon 