### PR TITLE
new constructors for dimension type

### DIFF
--- a/src/Libraries/RevitNodes/Elements/DimensionType.cs
+++ b/src/Libraries/RevitNodes/Elements/DimensionType.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Linq;
+using Autodesk.DesignScript.Runtime;
+using DynamoServices;
+using RevitServices.Persistence;
+using RevitServices.Transactions;
+
+namespace Revit.Elements
+{
+    /// <summary>
+    /// Dimension Type element.
+    /// </summary>
+    [RegisterForTrace]
+    public class DimensionType : Element
+    {
+        #region Internal Properties
+
+        /// <summary>
+        /// Internal reference to the Revit Element
+        /// </summary>
+        internal Autodesk.Revit.DB.DimensionType InternalRevitElement
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Reference to the Element
+        /// </summary>
+        [SupressImportIntoVM]
+        public override Autodesk.Revit.DB.Element InternalElement
+        {
+            get { return InternalRevitElement; }
+        }
+
+        #endregion
+
+        #region Private mutators
+
+        /// <summary>
+        /// Set the internal Element, ElementId, and UniqueId
+        /// </summary>
+        /// <param name="element"></param>
+        private void InternalSetElement(Autodesk.Revit.DB.DimensionType element)
+        {
+            InternalRevitElement = element;
+            InternalElementId = element.Id;
+            InternalUniqueId = element.UniqueId;
+        }
+
+        #endregion
+
+        #region Private constructors
+
+        /// <summary>
+        /// DimensionType from existing
+        /// </summary>
+        /// <param name="element"></param>
+        private DimensionType(Autodesk.Revit.DB.DimensionType element)
+        {
+            SafeInit(() => InitElement(element));
+        }
+
+        /// <summary>
+        /// DimensionType by duplicating existing.
+        /// </summary>
+        /// <param name="dimType"></param>
+        /// <param name="name"></param>
+        private DimensionType(Autodesk.Revit.DB.DimensionType dimType, string name)
+        {
+            SafeInit(() => Init(dimType, name));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        private void InitElement(Autodesk.Revit.DB.DimensionType element)
+        {
+            InternalSetElement(element);
+        }
+
+        private void Init(Autodesk.Revit.DB.DimensionType dimType, string name)
+        {
+            var document = DocumentManager.Instance.CurrentDBDocument;
+            TransactionManager.Instance.EnsureInTransaction(document);
+
+            // get element from trace
+            var element = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.DimensionType>(document);
+
+            if (element == null)
+            {
+                element = dimType.Duplicate(name) as Autodesk.Revit.DB.DimensionType;
+            }
+
+            InternalSetElement(element);
+            TransactionManager.Instance.TransactionTaskDone();
+            ElementBinder.SetElementForTrace(this.InternalElement);
+        }
+
+        #endregion
+
+        #region Public static constructors
+
+        /// <summary>
+        /// Creates new Dimension Type by duplicating an existing.
+        /// </summary>
+        /// <param name="dimensionType">Dimension Type to duplicate.</param>
+        /// <param name="name">New name that will be assigned to Dimension Type.</param>
+        /// <returns></returns>
+        public static DimensionType FromExisting(Revit.Elements.Element dimensionType, string name)
+        {
+            var dimType = dimensionType.InternalElement as Autodesk.Revit.DB.DimensionType;
+            return new DimensionType(dimType, name);
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns Dimension Style for a givent type.
+        /// </summary>
+        public string StyleType
+        {
+            get
+            {
+                return this.InternalRevitElement.StyleType.ToString();
+            }
+        }
+
+        #endregion
+
+        #region Internal static constructors
+
+        /// <summary>
+        /// From existing element
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="isRevitOwned"></param>
+        /// <returns></returns>
+        internal static DimensionType FromExisting(Autodesk.Revit.DB.DimensionType instance, bool isRevitOwned)
+        {
+            return new DimensionType(instance)
+            {
+                IsRevitOwned = isRevitOwned
+            };
+        }
+
+        #endregion
+    }
+}
+

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -222,6 +222,11 @@ namespace Revit.Elements
             return Dimension.FromExisting(ele, isRevitOwned);
         }
 
+        public static DimensionType Wrap(Autodesk.Revit.DB.DimensionType ele, bool isRevitOwned)
+        {
+            return DimensionType.FromExisting(ele, isRevitOwned);
+        }
+
         public static FilledRegionType Wrap(Autodesk.Revit.DB.FilledRegionType ele, bool isRevitOwned)
         {
             return FilledRegionType.FromExisting(ele, isRevitOwned);

--- a/src/Libraries/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/RevitNodes/RevitNodes.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Elements\CurtainPanel.cs" />
     <Compile Include="Elements\Dimension.cs" />
     <Compile Include="Elements\DetailCurve.cs" />
+    <Compile Include="Elements\DimensionType.cs" />
     <Compile Include="Elements\DirectShape.cs" />
     <Compile Include="Elements\Element.cs" />
     <Compile Include="Elements\AbstractFamilyInstance.cs" />


### PR DESCRIPTION
### Purpose

This adds new wrappers around `DimensionType` object. It creates a constructor for creating new Dimension Types as well as retrieving its style. It was requested here: 

https://forum.dynamobim.com/t/change-dimension-style/8680/10?u=konrad_k_sobon

![image](https://cloud.githubusercontent.com/assets/529781/21906574/d32d69d2-d8d9-11e6-9c5a-38b6c6bb612e.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @ikeough

### FYIs
