### PR TITLE
override to Equals method on Category class

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Category.cs
+++ b/src/Libraries/RevitNodes/Elements/Category.cs
@@ -154,5 +154,24 @@ namespace Revit.Elements
         {
             return internalCategory != null ? Name : string.Empty;
         }
+
+        public override bool Equals(object obj)
+        {
+            var item = obj as Category;
+
+            if (item == null)
+            {
+                return false;
+            }
+            else
+            {
+                return this.Id.Equals(item.Id);
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Id.GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
This addresses an issue that user reported here: 
https://github.com/DynamoDS/DynamoRevit/issues/1451

![image](https://cloud.githubusercontent.com/assets/529781/21952222/673e9dd4-d9e4-11e6-9f5c-b12652fa6972.png)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @ikeough @sharadkjaiswal 

### FYIs

None
