### PR TITLE
override to Equals method on Category class that allows to compare category id rather than name (#1455)

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Category.cs
+++ b/src/Libraries/RevitNodes/Elements/Category.cs
@@ -154,5 +154,24 @@ namespace Revit.Elements
         {
             return internalCategory != null ? Name : string.Empty;
         }
+
+        public override bool Equals(object obj)
+        {
+            var item = obj as Category;
+
+            if (item == null)
+            {
+                return false;
+            }
+            else
+            {
+                return this.Id.Equals(item.Id);
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Id.GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Cross-merge #1455 to Revit2018 branch.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### FYIs
@ksobon 
