### PR TITLE
Fix one failed test case

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Floor.cs
+++ b/src/Libraries/RevitNodes/Elements/Floor.cs
@@ -127,7 +127,9 @@ namespace Revit.Elements
                 throw new ArgumentNullException("outlineCurves");
             }
 
-            return ByOutlineTypeAndLevel(PolyCurve.ByJoinedCurves(outlineCurves), floorType, level);
+            var floor = ByOutlineTypeAndLevel(PolyCurve.ByJoinedCurves(outlineCurves), floorType, level);
+            DocumentManager.Regenerate();
+            return floor;
         }
 
         /// <summary>
@@ -162,7 +164,9 @@ namespace Revit.Elements
             var ca = new CurveArray();
             outline.Curves().ForEach(x => ca.Append(x.ToRevitType())); 
 
-            return new Floor(ca, floorType.InternalFloorType, level.InternalLevel );
+            var floor = new Floor(ca, floorType.InternalFloorType, level.InternalLevel);
+            DocumentManager.Regenerate();
+            return floor;
         }
 
 

--- a/src/Libraries/RevitNodes/Elements/Roof.cs
+++ b/src/Libraries/RevitNodes/Elements/Roof.cs
@@ -162,7 +162,9 @@ namespace Revit.Elements
             var ca = new CurveArray();
             polycurve.Curves().ForEach(x => ca.Append(x.ToRevitType()));
 
-            return new Roof(ca, level.InternalLevel,roofType.InternalRoofType);
+            var roof = new Roof(ca, level.InternalLevel,roofType.InternalRoofType);
+            DocumentManager.Regenerate();
+            return roof;
         }
 
         /// <summary>
@@ -186,7 +188,9 @@ namespace Revit.Elements
             var ca = new CurveArray();
             outline.Curves().ForEach(x => ca.Append(x.ToRevitType()));
 
-            return new Roof(ca, plane.InternalReferencePlane, level.InternalLevel, roofType.InternalRoofType, extrusionStart, extrusionEnd);
+            var roof = new Roof(ca, plane.InternalReferencePlane, level.InternalLevel, roofType.InternalRoofType, extrusionStart, extrusionEnd);
+            DocumentManager.Regenerate();
+            return roof;
         }
 
 


### PR DESCRIPTION
### Purpose

This is to fix the failed test case: FloorSlabShapePoints_Edit. The cause of the failure is that upon creation, the internal SlabShapeEditor is not initiated yet and is still null. This is to fix the issue by regenerating the document so that SlabShapeEditor is set.

