### PR TITLE
Correct Categories

### DIFF
--- a/src/Libraries/RevitNodes/NodeCategories.cs
+++ b/src/Libraries/RevitNodes/NodeCategories.cs
@@ -13,7 +13,7 @@
         public const string REVIT_BAKE = "Revit.Bake";
         public const string REVIT_API = "Revit.API";
         public const string REVIT_ELEMENTS_DIVIDEDPATH_ACTION = "Revit.Elements.DividedPath.Actions";
-
+        public const string REVIT_ELEMENTS_PERFORMANCEADVISER = "Revit.Elements.PerformanceAdviserRule";
         public const string ANALYZE = "Analyze";
     }
 }

--- a/src/Libraries/RevitNodes/PerformanceAdviser/FailureMessage.cs
+++ b/src/Libraries/RevitNodes/PerformanceAdviser/FailureMessage.cs
@@ -1,10 +1,9 @@
-﻿using Autodesk.Revit.DB;
+﻿using System.Collections.Generic;
 using Autodesk.DesignScript.Runtime;
+using Autodesk.Revit.DB;
 using RevitServices.Persistence;
-using System.Collections.Generic;
-using Revit.Elements;
 
-namespace Revit.PerformanceAdviser
+namespace Revit.Elements
 {
     /// <summary>
     /// Performance Adviser Failure Message
@@ -37,12 +36,12 @@ namespace Revit.PerformanceAdviser
         /// <summary>
         /// The Failing Elements of the message.
         /// </summary>
-        public ICollection<Revit.Elements.Element> FailingElements
+        public ICollection<Element> FailingElements
         {
             get
             {
                 var failingIds = InternalElement.GetFailingElements();
-                var failingElements = new List<Revit.Elements.Element>();
+                var failingElements = new List<Element>();
 
                 foreach (var failingId in failingIds)
                 {

--- a/src/Libraries/RevitNodes/PerformanceAdviser/PerformanceAdviserRule.cs
+++ b/src/Libraries/RevitNodes/PerformanceAdviser/PerformanceAdviserRule.cs
@@ -4,22 +4,21 @@ using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
-using Revit.Elements;
 
-namespace Revit.PerformanceAdviser
+namespace Revit.Elements
 {
     /// <summary>
     /// Performance Adviser Rule
     /// </summary>
     public class PerformanceAdviserRule
     {
-        internal Autodesk.Revit.DB.PerformanceAdviserRuleId InternalId
+        internal PerformanceAdviserRuleId InternalId
         { 
             get; set;
         }
 
         [SupressImportIntoVM]
-        public PerformanceAdviserRule(Autodesk.Revit.DB.PerformanceAdviserRuleId id)
+        public PerformanceAdviserRule(PerformanceAdviserRuleId id)
         {
             this.InternalId = id;
         }
@@ -31,7 +30,7 @@ namespace Revit.PerformanceAdviser
         {
             get
             {
-                Autodesk.Revit.DB.PerformanceAdviser adviser = Autodesk.Revit.DB.PerformanceAdviser.GetPerformanceAdviser();
+                PerformanceAdviser adviser = PerformanceAdviser.GetPerformanceAdviser();
                 return adviser.GetRuleName(this.InternalId);
             }
         }
@@ -43,7 +42,7 @@ namespace Revit.PerformanceAdviser
         {
             get
             {
-                Autodesk.Revit.DB.PerformanceAdviser adviser = Autodesk.Revit.DB.PerformanceAdviser.GetPerformanceAdviser();
+                PerformanceAdviser adviser = PerformanceAdviser.GetPerformanceAdviser();
                 return adviser.GetRuleDescription(this.InternalId);
             }
         }
@@ -55,7 +54,7 @@ namespace Revit.PerformanceAdviser
         {
             get
             {
-                Autodesk.Revit.DB.PerformanceAdviser adviser = Autodesk.Revit.DB.PerformanceAdviser.GetPerformanceAdviser();
+                PerformanceAdviser adviser = PerformanceAdviser.GetPerformanceAdviser();
                 // Check if the rule is activated
                 return adviser.IsRuleEnabled(this.InternalId);
             }
@@ -68,7 +67,7 @@ namespace Revit.PerformanceAdviser
         {
             set
             {
-                Autodesk.Revit.DB.PerformanceAdviser adviser = Autodesk.Revit.DB.PerformanceAdviser.GetPerformanceAdviser();
+                PerformanceAdviser adviser = PerformanceAdviser.GetPerformanceAdviser();
                 // Activate or deactivate the rule
                 adviser.SetRuleEnabled(this.InternalId, value);
             }
@@ -96,7 +95,7 @@ namespace Revit.PerformanceAdviser
             var document = DocumentManager.Instance.CurrentDBDocument;
             TransactionManager.Instance.EnsureInTransaction(document);
 
-            Autodesk.Revit.DB.PerformanceAdviser adviser = Autodesk.Revit.DB.PerformanceAdviser.GetPerformanceAdviser();
+            PerformanceAdviser adviser = PerformanceAdviser.GetPerformanceAdviser();
             IList<PerformanceAdviserRuleId> rulesIdsToExecute = new List<PerformanceAdviserRuleId>();
 
             foreach (var rule in rules) rulesIdsToExecute.Add(new PerformanceAdviserRuleId(rule.RuleId));
@@ -131,7 +130,7 @@ namespace Revit.PerformanceAdviser
         [SupressImportIntoVM]
         public override string ToString()
         {
-            Autodesk.Revit.DB.PerformanceAdviser adviser = Autodesk.Revit.DB.PerformanceAdviser.GetPerformanceAdviser();
+            PerformanceAdviser adviser = PerformanceAdviser.GetPerformanceAdviser();
             return string.Format("{0} : {1}", adviser.GetRuleName(this.InternalId), adviser.GetRuleDescription(this.InternalId));
         }
         

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -438,13 +438,11 @@ namespace DSRevitNodesUI
     }
 
     [NodeName("Performance Adviser Rules")]
-    [NodeCategory(BuiltinNodeCategories.REVIT)]
+    [NodeCategory(BuiltinNodeCategories.REVIT_ELEMENTS_PERFORMANCEADVISER)]
     [NodeDescription("PerformanceAdviserDescription", typeof(Properties.Resources))]
     [IsDesignScriptCompatible]
     public class PerformanceAdviserRules : RevitDropDownBase
     {
-
-
         public PerformanceAdviserRules() : base("Performance Adviser Rules") { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
@@ -455,10 +453,10 @@ namespace DSRevitNodesUI
             IList<PerformanceAdviserRuleId> ruleIds = adviser.GetAllRuleIds();
             string ruleInfo = string.Empty;
 
-            List<Revit.PerformanceAdviser.PerformanceAdviserRule> elements = new List<Revit.PerformanceAdviser.PerformanceAdviserRule>();
+            List<Revit.Elements.PerformanceAdviserRule> elements = new List<Revit.Elements.PerformanceAdviserRule>();
             foreach (PerformanceAdviserRuleId ruleId in ruleIds)
             {
-                elements.Add(new Revit.PerformanceAdviser.PerformanceAdviserRule(ruleId));
+                elements.Add(new Revit.Elements.PerformanceAdviserRule(ruleId));
             }
 
             if (!elements.Any())
@@ -483,7 +481,7 @@ namespace DSRevitNodesUI
 
             var args = new List<AssociativeNode>
             {
-                AstFactory.BuildStringNode(((Revit.PerformanceAdviser.PerformanceAdviserRule) Items[SelectedIndex].Item).RuleId.ToString())
+                AstFactory.BuildStringNode(((Revit.Elements.PerformanceAdviserRule) Items[SelectedIndex].Item).RuleId.ToString())
             };
             var functionCall = AstFactory.BuildFunctionCall("Revit.Elements.PerformanceAdviserRule",
                                                             "ById",

--- a/test/Libraries/RevitIntegrationTests/PerformanceAdviserTests.cs
+++ b/test/Libraries/RevitIntegrationTests/PerformanceAdviserTests.cs
@@ -30,8 +30,8 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             object rule = GetPreviewValue("4afe4fdd-4663-4bc1-923c-48210fff043f");
-            Assert.IsTrue(typeof(Revit.PerformanceAdviser.PerformanceAdviserRule) == rule.GetType());
-            Revit.PerformanceAdviser.PerformanceAdviserRule prule = rule as Revit.PerformanceAdviser.PerformanceAdviserRule;
+            Assert.IsTrue(typeof(Revit.Elements.PerformanceAdviserRule) == rule.GetType());
+            Revit.Elements.PerformanceAdviserRule prule = rule as Revit.Elements.PerformanceAdviserRule;
 
             object name = GetPreviewValue("0d24a270-9640-4cda-b6fe-8850be7ba0d8");
             Assert.AreEqual(name, prule.Name);

--- a/test/Libraries/RevitNodesTests/Elements/PerformanceAdvTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/PerformanceAdvTests.cs
@@ -15,14 +15,14 @@ namespace RevitNodesTests.Elements
         {
             PerformanceAdviser adviser = PerformanceAdviser.GetPerformanceAdviser();
             IList<PerformanceAdviserRuleId> ruleIds = adviser.GetAllRuleIds();
-            var perf = Revit.PerformanceAdviser.PerformanceAdviserRule.ById(ruleIds[0].Guid.ToString());
+            var perf = Revit.Elements.PerformanceAdviserRule.ById(ruleIds[0].Guid.ToString());
             Assert.NotNull(perf);
 
             Assert.NotNull(perf.Description);
 
             Assert.NotNull(perf.Name);
 
-            Assert.AreEqual(perf.GetType(), typeof(Revit.PerformanceAdviser.PerformanceAdviserRule));
+            Assert.AreEqual(perf.GetType(), typeof(Revit.Elements.PerformanceAdviserRule));
         }
 
         [Test]
@@ -31,14 +31,14 @@ namespace RevitNodesTests.Elements
         {
             PerformanceAdviser adviser = PerformanceAdviser.GetPerformanceAdviser();
             IList<PerformanceAdviserRuleId> ruleIds = adviser.GetAllRuleIds();
-            var perf = Revit.PerformanceAdviser.PerformanceAdviserRule.ById(ruleIds[0].Guid.ToString());
-            List<Revit.PerformanceAdviser.PerformanceAdviserRule> rules = new List<Revit.PerformanceAdviser.PerformanceAdviserRule>(){perf};
+            var perf = Revit.Elements.PerformanceAdviserRule.ById(ruleIds[0].Guid.ToString());
+            List<Revit.Elements.PerformanceAdviserRule> rules = new List<Revit.Elements.PerformanceAdviserRule>(){perf};
 
-            var messages = Revit.PerformanceAdviser.PerformanceAdviserRule.Execute(rules);
+            var messages = Revit.Elements.PerformanceAdviserRule.Execute(rules);
 
             foreach (var msg in messages)
             {
-                Assert.IsTrue(msg.GetType() == typeof(Revit.PerformanceAdviser.FailureMessage));
+                Assert.IsTrue(msg.GetType() == typeof(Revit.Elements.FailureMessage));
                 Assert.IsNotNull(msg.Description);
                 Assert.IsNotNull(msg.Severity);
             }


### PR DESCRIPTION
### Purpose

This is to put the **PerformanceAdviserRules** Node and the performance adviser nodes back into **Revit->elements->PerformanceAdviserRule** category. They were put into the wrong category before.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

The result looks like this: 
![image](https://cloud.githubusercontent.com/assets/3942418/22456104/588b9378-e75e-11e6-8e69-2c9787da3dd4.png)

### Reviewers



### FYIs

@moethu @kronz 
