### PR TITLE
Show Preview Bubble for Revit UI Nodes

### DIFF
--- a/src/Libraries/RevitNodesUI/Elements.cs
+++ b/src/Libraries/RevitNodesUI/Elements.cs
@@ -40,7 +40,7 @@ namespace DSRevitNodesUI
             var u = RevitServicesUpdater.Instance;
             u.ElementsUpdated += OnElementsUpdated;
 
-            ShouldDisplayPreviewCore = false;
+            ShouldDisplayPreviewCore = true;
         }
 
         void OnElementsUpdated(object sender, ElementUpdateEventArgs e)


### PR DESCRIPTION
### Purpose

As requested by customers, we have turned on the Preview Bubbles for
Revit UI Nodes. This PR will need to be cherry-picked into Revit 2016
and Revit 2018 branches. Additionally, it will need to be cherry-picked
into the 1.3 RC Branches.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 

### FYIs

@ramramps @QilongTang @kronz 
