### PR TITLE
Hide and avoid import one class so that it won't appear in the library view

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitSolid.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitSolid.cs
@@ -243,6 +243,8 @@ namespace Revit.GeometryConversion
     /// <summary>
     /// Family Import Options
     /// </summary>
+    [IsVisibleInDynamoLibrary(false)]
+    [SupressImportIntoVM]
     public class FamilyImportOptions : IFamilyLoadOptions
     {
         public FamilyImportOptions() { }


### PR DESCRIPTION
### Purpose

The class is only meant for internal use but displayed in the library view. This submission is to make the fix.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### FYIs
@kronz 

