### PR TITLE
Fix the issue - Dynamo crashing while creating a Family Type using Geometry

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitSolid.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/ProtoToRevitSolid.cs
@@ -142,7 +142,7 @@ namespace Revit.GeometryConversion
             string tempFamilyFile = System.IO.Path.Combine(tempDir, name + ".rfa");
 
             // scale the incoming geometry
-            UnitConverter.ConvertToHostUnits<Autodesk.DesignScript.Geometry.Solid>(ref solidGeometry);
+            solidGeometry = solidGeometry.InHostUnits();
 
             // get a displacement vector
             Vector vector = Vector.ByTwoPoints(Autodesk.DesignScript.Geometry.BoundingBox.ByGeometry(solidGeometry).MinPoint, Autodesk.DesignScript.Geometry.Point.Origin());


### PR DESCRIPTION
### Purpose

This is to fix one crash as titled. The crash is happening is because the geometry is disposed while it will later be used to create geometry previews. The fix here is to avoid disposing the geometry.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### FYIs
@kronz @riteshchandawar 

