### PR TITLE
Add journal keys for node values to be pushed into revit dynamo model

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -27,6 +27,7 @@ using Dynamo.ViewModels;
 using DynamoInstallDetective;
 using Greg.AuthProviders;
 using Microsoft.Win32;
+using Newtonsoft.Json;
 using RevitServices.Persistence;
 using RevitServices.Threading;
 using DynUpdateManager = Dynamo.Updates.UpdateManager;
@@ -149,6 +150,21 @@ namespace Dynamo.Applications
         /// needs to be shutdown before performing any action.
         /// </summary>
         public const string ModelShutDownKey = "dynModelShutDown";
+
+        /// <summary>
+        /// The journal file can specify the values of Dynamo nodes.
+        /// </summary>
+        public const string ModelNodesInfo = "dynModelNodesInfo";
+    }
+
+    /// <summary>
+    /// Defines parameters for Dynamo nodes
+    /// </summary>
+    public class JournalNodeKeys
+    {
+        public const string Id = "Id";
+        public const string Name = "Name";
+        public const string Value = "Value";
     }
 
 
@@ -544,6 +560,27 @@ namespace Dynamo.Applications
                 {
                     dynamoViewModel.OpenIfSavedCommand.Execute(new Dynamo.Models.DynamoModel.OpenFileCommand(commandData.JournalData[JournalKeys.DynPathKey], forceManualRun));
                     dynamoViewModel.ShowStartPage = false;
+                }
+
+                //If we have information about the nodes and their values we want to push those values after the file is opened.
+                if (commandData.JournalData.ContainsKey(JournalKeys.ModelNodesInfo))
+                {
+                    try
+                    {
+                        var allNodesInfo = JsonConvert.DeserializeObject<List<Dictionary<string, string>>>(commandData.JournalData[JournalKeys.ModelNodesInfo]);
+                        if (allNodesInfo != null)
+                        {
+                            foreach (var nodeInfo in allNodesInfo)
+                            {
+                                if (nodeInfo.ContainsKey(JournalNodeKeys.Id) && nodeInfo.ContainsKey(JournalNodeKeys.Name) && nodeInfo.ContainsKey(JournalNodeKeys.Value))
+                                {
+                                    DynamoModel.UpdateModelValueCommand modelCommand = new DynamoModel.UpdateModelValueCommand(nodeInfo[JournalNodeKeys.Id], nodeInfo[JournalNodeKeys.Name], nodeInfo[JournalNodeKeys.Value]);
+                                    modelCommand.Execute(revitDynamoModel);
+                                }
+                            }
+                        }
+                    }
+                    catch { }
                 }
 
                 //If we are in automation mode the model will run anyway (on the main thread 

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -158,7 +158,8 @@ namespace Dynamo.Applications
     }
 
     /// <summary>
-    /// Defines parameters for Dynamo nodes
+    /// Defines parameters for Dynamo nodes needed in order to update nodes
+    /// values through UpdateModelValueCommand.
     /// </summary>
     public class JournalNodeKeys
     {
@@ -572,15 +573,22 @@ namespace Dynamo.Applications
                         {
                             foreach (var nodeInfo in allNodesInfo)
                             {
-                                if (nodeInfo.ContainsKey(JournalNodeKeys.Id) && nodeInfo.ContainsKey(JournalNodeKeys.Name) && nodeInfo.ContainsKey(JournalNodeKeys.Value))
+                                if (nodeInfo.ContainsKey(JournalNodeKeys.Id) && 
+                                    nodeInfo.ContainsKey(JournalNodeKeys.Name) && 
+                                    nodeInfo.ContainsKey(JournalNodeKeys.Value))
                                 {
-                                    DynamoModel.UpdateModelValueCommand modelCommand = new DynamoModel.UpdateModelValueCommand(nodeInfo[JournalNodeKeys.Id], nodeInfo[JournalNodeKeys.Name], nodeInfo[JournalNodeKeys.Value]);
+                                    var modelCommand = new DynamoModel.UpdateModelValueCommand(nodeInfo[JournalNodeKeys.Id], 
+                                                                                               nodeInfo[JournalNodeKeys.Name], 
+                                                                                               nodeInfo[JournalNodeKeys.Value]);
                                     modelCommand.Execute(revitDynamoModel);
                                 }
                             }
                         }
                     }
-                    catch { }
+                    catch
+                    {
+                        Console.WriteLine("Exception while trying to update nodes with new values");
+                    }
                 }
 
                 //If we are in automation mode the model will run anyway (on the main thread 


### PR DESCRIPTION
### Purpose
We want to be able to push nodes values when we execute a DynamoRevit command. We receive these values from a third party ( like Dynamo Player ) as a command parameter and we push them into nodes using UpdateModelValueCommand


### Reviewers
@mjkkirschner
