### PR TITLE
Cherry-pick Global Params from Revit2018 to RC1.2.3_Revit2018

### DIFF
--- a/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using Autodesk.DesignScript.Runtime;
+using DynamoServices;
+using System.Collections.Generic;
+using Revit.GeometryConversion;
+using Revit.GeometryReferences;
+using RevitServices.Persistence;
+using RevitServices.Transactions;
+
+namespace Revit.Elements
+{
+    /// <summary>
+    /// Revit Global Parameters
+    /// </summary>
+    [RegisterForTrace]
+    public class GlobalParameter : Element
+    {
+        #region Internal properties
+
+        /// <summary>
+        /// Internal reference to Element
+        /// </summary>
+        internal Autodesk.Revit.DB.GlobalParameter InternalGlobalParameter
+        {
+            get; private set;
+        }
+
+        /// <summary>
+        /// Reference to the Element
+        /// </summary>
+        [SupressImportIntoVM]
+        public override Autodesk.Revit.DB.Element InternalElement
+        {
+            get { return InternalGlobalParameter; }
+        }
+
+        #endregion
+
+        #region Private constructors
+
+        /// <summary>
+        /// Private constructor for wrapping an existing Element
+        /// </summary>
+        /// <param name="grid"></param>
+        private GlobalParameter(Autodesk.Revit.DB.GlobalParameter parameter)
+        {
+            SafeInit(() => InitGlobalParameter(parameter));
+        }
+
+        /// <summary>
+        /// GlobalParameter
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="type"></param>
+        private GlobalParameter(string name, Autodesk.Revit.DB.ParameterType type)
+        {
+            SafeInit(() => InitGlobalParameter(name, type));
+        }
+
+        #endregion
+
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a GlobalParameter element
+        /// </summary>
+        /// <param name="grid"></param>
+        private void InitGlobalParameter(Autodesk.Revit.DB.GlobalParameter g)
+        {
+            InternalSetGlobalParameter(g);
+        }
+
+        /// <summary>
+        /// Initialize a GlobalParameter element
+        /// </summary>
+        /// <param name="line"></param>
+        private void InitGlobalParameter(string name, Autodesk.Revit.DB.ParameterType type)
+        {
+            if (Autodesk.Revit.DB.GlobalParametersManager.IsUniqueName(Document, name))
+            {
+                TransactionManager.Instance.EnsureInTransaction(Document);
+
+                Autodesk.Revit.DB.GlobalParameter g = Autodesk.Revit.DB.GlobalParameter.Create(Document, name, type);
+
+                InternalSetGlobalParameter(g);
+
+                TransactionManager.Instance.TransactionTaskDone();
+
+                ElementBinder.SetElementForTrace(this.InternalElement);
+            }
+            else
+                throw new Exception(Properties.Resources.NameAlreadyInUse);
+        }
+
+
+        #endregion
+
+        #region Private mutators
+
+        /// <summary>
+        /// Set the internal Element, ElementId, and UniqueId
+        /// </summary>
+        /// <param name="grid"></param>
+        private void InternalSetGlobalParameter(Autodesk.Revit.DB.GlobalParameter g)
+        {
+            this.InternalGlobalParameter = g;
+            this.InternalElementId = g.Id;
+            this.InternalUniqueId = g.UniqueId;
+        }
+
+        #endregion
+
+        #region Public properties
+
+        /// <summary>
+        /// Find Global Parameter by Name
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static GlobalParameter FindByName(string name)
+        {
+            if (!Autodesk.Revit.DB.GlobalParametersManager.AreGlobalParametersAllowed(Document))
+            {
+                throw new Exception(Properties.Resources.DocumentDoesNotSupportGlobalParams);
+            }
+
+            var id = Autodesk.Revit.DB.GlobalParametersManager.FindByName(Document, name);
+
+            if (id != null && id != Autodesk.Revit.DB.ElementId.InvalidElementId)
+            {
+                if (Autodesk.Revit.DB.GlobalParametersManager.IsValidGlobalParameter(Document, id))
+                {
+                    var global = Document.GetElement(id) as Autodesk.Revit.DB.GlobalParameter;
+                    return GlobalParameter.FromExisting(global, true);
+                }
+            }
+            
+            return null;
+        }
+
+        /// <summary>
+        /// Get all Global Parameters
+        /// </summary>
+        /// <returns></returns>
+        public static IEnumerable<GlobalParameter> GetAllGlobalParameters()
+        {
+            if (!Autodesk.Revit.DB.GlobalParametersManager.AreGlobalParametersAllowed(Document))
+            {
+                throw new Exception(Properties.Resources.DocumentDoesNotSupportGlobalParams);
+            }
+
+            var ids = Autodesk.Revit.DB.GlobalParametersManager.GetGlobalParametersOrdered(Document);
+
+            List<GlobalParameter> parameters = new List<GlobalParameter>();
+
+            foreach (Autodesk.Revit.DB.ElementId id in ids)
+            {
+                var global = Document.GetElement(id) as Autodesk.Revit.DB.GlobalParameter;
+                parameters.Add(GlobalParameter.FromExisting(global, true));
+            }
+
+            return parameters;
+        }
+
+
+        /// <summary>
+        /// Get Name
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                return this.InternalGlobalParameter.GetDefinition().Name;
+            }
+        }
+
+        /// <summary>
+        /// Get Parameter Group
+        /// </summary>
+        public string ParameterGroup
+        {
+            get
+            {
+                return this.InternalGlobalParameter.GetDefinition().ParameterGroup.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Get Parameter Visibility
+        /// </summary>
+        public bool Visible
+        {
+            get
+            {
+                return this.InternalGlobalParameter.GetDefinition().Visible;
+            }
+        }
+
+        /// <summary>
+        /// Get Parameter Type
+        /// </summary>
+        public string ParameterType
+        {
+            get
+            {
+                return this.InternalGlobalParameter.GetDefinition().ParameterType.ToString();
+            }
+        }
+
+
+        #endregion
+
+        #region Public static constructors
+
+        /// <summary>
+        /// Create a new Global Parameter by Name and Type
+        /// </summary>
+        /// <param name="name">Name fo the parameter</param>
+        /// <param name="parameterType">Parameter type</param>
+        /// <returns></returns>
+        public static GlobalParameter ByName(string name, string parameterType)
+        {
+            Autodesk.Revit.DB.ParameterType ptype = Autodesk.Revit.DB.ParameterType.Text;
+            if (!Enum.TryParse<Autodesk.Revit.DB.ParameterType>(parameterType, out ptype))
+                ptype = Autodesk.Revit.DB.ParameterType.Text;
+
+            if (!Autodesk.Revit.DB.GlobalParametersManager.AreGlobalParametersAllowed(Document))
+            {
+                throw new Exception(Properties.Resources.DocumentDoesNotSupportGlobalParams);
+            }
+
+            return new GlobalParameter(name, ptype);
+        }
+
+        #endregion
+
+        #region Internal static constructor
+
+        /// <summary>
+        /// Wrap an existing Element in the associated DS type
+        /// </summary>
+        /// <param name="grid"></param>
+        /// <param name="isRevitOwned"></param>
+        /// <returns></returns>
+        internal static GlobalParameter FromExisting(Autodesk.Revit.DB.GlobalParameter parameter, bool isRevitOwned)
+        {
+            return new GlobalParameter(parameter)
+            {
+                IsRevitOwned = isRevitOwned
+            };
+        }
+
+        #endregion
+
+    }
+}

--- a/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
@@ -143,29 +143,6 @@ namespace Revit.Elements
             return null;
         }
 
-        /// <summary>
-        /// Get all Global Parameters
-        /// </summary>
-        /// <returns></returns>
-        public static IEnumerable<GlobalParameter> GetAllGlobalParameters()
-        {
-            if (!Autodesk.Revit.DB.GlobalParametersManager.AreGlobalParametersAllowed(Document))
-            {
-                throw new Exception(Properties.Resources.DocumentDoesNotSupportGlobalParams);
-            }
-
-            var ids = Autodesk.Revit.DB.GlobalParametersManager.GetGlobalParametersOrdered(Document);
-
-            List<GlobalParameter> parameters = new List<GlobalParameter>();
-
-            foreach (Autodesk.Revit.DB.ElementId id in ids)
-            {
-                var global = Document.GetElement(id) as Autodesk.Revit.DB.GlobalParameter;
-                parameters.Add(GlobalParameter.FromExisting(global, true));
-            }
-
-            return parameters;
-        }
 
 
         /// <summary>

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -273,6 +273,12 @@ namespace Revit.Elements
             return FaceWall.FromExisting(ele, isRevitOwned);
         }
 
+        public static GlobalParameter Wrap(Autodesk.Revit.DB.GlobalParameter ele, bool isRevitOwned)
+        {
+            return GlobalParameter.FromExisting(ele, isRevitOwned);
+
+        }
+
         public static CurtainSystem Wrap(Autodesk.Revit.DB.CurtainSystem ele, bool isRevitOwned)
         {
             return CurtainSystem.FromExisting(ele, isRevitOwned);

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -601,15 +601,6 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Name already in use..
-        /// </summary>
-        internal static string NameAlreadyInUse {
-            get {
-                return ResourceManager.GetString("NameAlreadyInUse", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to No shared parameter file found..
         /// </summary>
         internal static string NoSharedParameterFileFound {

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -259,6 +259,15 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Document does not support global parameters..
+        /// </summary>
+        internal static string DocumentDoesNotSupportGlobalParams {
+            get {
+                return ResourceManager.GetString("DocumentDoesNotSupportGlobalParams", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Dynamo Data.
         /// </summary>
         internal static string Dynamo_AVF_Data_Name {
@@ -588,6 +597,15 @@ namespace Revit.Properties {
         internal static string NameArgumentException {
             get {
                 return ResourceManager.GetString("NameArgumentException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name already in use..
+        /// </summary>
+        internal static string NameAlreadyInUse {
+            get {
+                return ResourceManager.GetString("NameAlreadyInUse", resourceCulture);
             }
         }
         

--- a/src/Libraries/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/RevitNodes/RevitNodes.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Elements\Roof.cs" />
     <Compile Include="Elements\CurtainSystemType.cs" />
     <Compile Include="Elements\CurtainSystem.cs" />
+    <Compile Include="Elements\GlobalParameter.cs" />
     <Compile Include="Elements\InternalUtilities\ElementQueries.cs" />
     <Compile Include="Elements\InternalUtilities\ElementUtils.cs" />
     <Compile Include="Elements\InternalUtilities\TransformUtils.cs" />

--- a/test/Libraries/RevitIntegrationTests/GlobalParameterTests.cs
+++ b/test/Libraries/RevitIntegrationTests/GlobalParameterTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Dynamo.Nodes;
+using Autodesk.DesignScript.Geometry;
+using CoreNodeModels.Input;
+using NUnit.Framework;
+using RevitServices.Persistence;
+using RevitTestServices;
+using RTF.Framework;
+
+
+namespace RevitSystemTests
+{
+    [TestFixture]
+    class GlobalParameterTests : RevitSystemTestBase
+    {
+        [Test]
+        [TestModel(@".\empty-2017.rvt")]
+        public void CreateGlobalParameterAndTestProperties()
+        {
+            var model = ViewModel.Model;
+
+            string samplePath = Path.Combine(workingDirectory, @".\Parameter\GlobalParameter.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+
+            RunCurrentModel();
+
+            Assert.AreEqual(GetPreviewValue("97d5b4ba-76e4-40e9-b1b2-8ce98e642a40"), "MyGlobalParameter");
+            Assert.AreEqual(GetPreviewValue("04ccd2fc-45bb-4953-9306-b7eb21d991a0"), "Text");
+            Assert.AreEqual(GetPreviewValue("bb83a545-0c80-4f34-b987-da1d3d0dc2b7"), true);
+        }
+
+
+
+
+    }
+}

--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="WallTests.cs" />
     <Compile Include="CurtainSystemTests.cs" />
 	<Compile Include="PerformanceAdviserTests.cs" />
+    <Compile Include="GlobalParameterTests.cs" />
     <Compile Include="RoomTests.cs" />
     <Compile Include="RevisionTests.cs" />
     <Compile Include="LocationTests.cs" />

--- a/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq;
+
+using Autodesk.DesignScript.Geometry;
+using Autodesk.Revit.Creation;
+using Autodesk.Revit.DB;
+
+using NUnit.Framework;
+
+using Revit.Elements;
+using Revit.GeometryConversion;
+using Revit.GeometryReferences;
+
+using RevitServices.Persistence;
+
+using RevitTestServices;
+
+using RTF.Framework;
+
+using Element = Revit.Elements.Element;
+using FamilyType = Revit.Elements.FamilyType;
+
+namespace RevitNodesTests.Elements
+{
+    [TestFixture]
+    class GlobalParametersTests : RevitNodeTestBase
+    {
+        [Test]
+        [TestModel(@".\empty-2017.rvt")]
+        public void SetAndGetGlobalParameterByName()
+        {
+            
+            var gp = Revit.Elements.GlobalParameter.ByName("MyGlobal", "Text");
+            Assert.IsNotNull(gp);
+            Assert.IsTrue(typeof(Revit.Elements.GlobalParameter) == gp.GetType());
+            Assert.IsTrue("MyGlobal" == gp.Name);
+            Assert.IsTrue("Text" == gp.ParameterType);
+            Assert.IsTrue(true == gp.Visible);
+
+            var param = Revit.Elements.GlobalParameter.FindByName("MyGlobal");
+            Assert.NotNull(param);
+        }
+
+        [Test]
+        [TestModel(@".\empty-2017.rvt")]
+        public void GetAllGlobalParameters()
+        {
+            var gp1 = Revit.Elements.GlobalParameter.ByName("MyGlobal1", "Text");
+            Assert.IsNotNull(gp1);
+
+            var gps = Revit.Elements.GlobalParameter.GetAllGlobalParameters();
+            Assert.IsNotNull(gps);
+
+            bool found = false;
+
+            foreach (var gp in gps)
+            {
+                if (gp.Name == "MyGlobal1") found = true;
+            }
+
+            Assert.IsTrue(found);
+        }
+
+
+    }
+}

--- a/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
@@ -65,25 +65,6 @@ namespace RevitNodesTests.Elements
             Assert.NotNull(param);
         }
 
-        [Test]
-        [TestModel(@".\empty.rvt")]
-        public void GetAllGlobalParameters()
-        {
-            var gp1 = Revit.Elements.GlobalParameter.ByName("MyGlobal1", "Text");
-            Assert.IsNotNull(gp1);
-
-            var gps = Revit.Elements.GlobalParameter.GetAllGlobalParameters();
-            Assert.IsNotNull(gps);
-
-            bool found = false;
-
-            foreach (var gp in gps)
-            {
-                if (gp.Name == "MyGlobal1") found = true;
-            }
-
-            Assert.IsTrue(found);
-        }
 
 
     }

--- a/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
@@ -26,7 +26,7 @@ namespace RevitNodesTests.Elements
     class GlobalParametersTests : RevitNodeTestBase
     {
         [Test]
-        [TestModel(@".\empty-2017.rvt")]
+        [TestModel(@".\empty.rvt")]
         public void SetAndGetGlobalParameterByName()
         {
             
@@ -42,7 +42,7 @@ namespace RevitNodesTests.Elements
         }
 
         [Test]
-        [TestModel(@".\empty-2017.rvt")]
+        [TestModel(@".\empty.rvt")]
         public void GetAllGlobalParameters()
         {
             var gp1 = Revit.Elements.GlobalParameter.ByName("MyGlobal1", "Text");

--- a/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
@@ -29,7 +29,29 @@ namespace RevitNodesTests.Elements
         [TestModel(@".\empty.rvt")]
         public void SetAndGetGlobalParameterByName()
         {
-            
+
+            var gpString = Revit.Elements.GlobalParameter.ByName("MyGlobal", Autodesk.Revit.DB.ParameterType.Text.ToString());
+            Assert.IsNotNull(gpString.InternalGlobalParameter);
+            Revit.Elements.GlobalParameter.SetValue(gpString, "4711");
+            Assert.AreEqual("4711", gpString.Value);
+
+            var gpInt = Revit.Elements.GlobalParameter.ByName("MyGlobalInt", Autodesk.Revit.DB.ParameterType.Integer.ToString());
+            Assert.IsNotNull(gpInt.InternalGlobalParameter);
+            Revit.Elements.GlobalParameter.SetValue(gpInt, 4711);
+            Assert.AreEqual(4711, gpInt.Value);
+
+            var gpLen = Revit.Elements.GlobalParameter.ByName("MyGlobalDouble", Autodesk.Revit.DB.ParameterType.Length.ToString());
+            Assert.IsNotNull(gpLen.InternalGlobalParameter);
+            Revit.Elements.GlobalParameter.SetValue(gpLen, 47.11);
+            double val = (double)gpLen.Value;
+            val.ShouldBeApproximately(47.11);
+        }
+
+        [Test]
+        [TestModel(@".\empty.rvt")]
+        public void SetAndGetGlobalParameterValue()
+        {
+
             var gp = Revit.Elements.GlobalParameter.ByName("MyGlobal", "Text");
             Assert.IsNotNull(gp);
             Assert.IsTrue(typeof(Revit.Elements.GlobalParameter) == gp.GetType());
@@ -38,6 +60,8 @@ namespace RevitNodesTests.Elements
             Assert.IsTrue(true == gp.Visible);
 
             var param = Revit.Elements.GlobalParameter.FindByName("MyGlobal");
+
+
             Assert.NotNull(param);
         }
 

--- a/test/Libraries/RevitNodesTests/RevitNodesTests.csproj
+++ b/test/Libraries/RevitNodesTests/RevitNodesTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Elements\FloorTests.cs" />
     <Compile Include="Elements\CoordinatesTests.cs" />
     <Compile Include="Elements\FloorTypeTests.cs" />
+    <Compile Include="Elements\GlobalParametersTests.cs" />
     <Compile Include="Elements\GridTests.cs" />
     <Compile Include="Elements\ImportInstanceTests.cs" />
     <Compile Include="Elements\LevelTests.cs" />

--- a/test/System/Parameter/GlobalParameter.dyn
+++ b/test/System/Parameter/GlobalParameter.dyn
@@ -1,0 +1,33 @@
+<Workspace Version="1.2.1.2802" X="15.9109978299614" Y="64.5931612167346" zoom="0.612283078543345" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
+  <NamespaceResolutionMap />
+  <Elements>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="GlobalParameter.ByName" x="348.5" y="167.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="RevitNodes.dll" function="Revit.Elements.GlobalParameter.ByName@string,string">
+      <PortInfo index="0" default="False" />
+      <PortInfo index="1" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="2686aa52-2a95-4d9d-b637-9bbc63e40f98" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="91" y="87" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="&quot;MyGlobalParameter&quot;;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="89205379-97aa-4d39-bbf1-390e9342f7d3" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="204" y="253" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="&quot;Text&quot;;" ShouldFocus="false" />
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="bb83a545-0c80-4f34-b987-da1d3d0dc2b7" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="GlobalParameter.Visible" x="702.248458777932" y="16.8103369451022" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="RevitNodes.dll" function="Revit.Elements.GlobalParameter.Visible">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="97d5b4ba-76e4-40e9-b1b2-8ce98e642a40" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="GlobalParameter.Name" x="697.348764330819" y="315.691698218987" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="RevitNodes.dll" function="Revit.Elements.GlobalParameter.Name">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="04ccd2fc-45bb-4953-9306-b7eb21d991a0" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="GlobalParameter.ParameterType" x="690.815838401335" y="167.06763332323" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="RevitNodes.dll" function="Revit.Elements.GlobalParameter.ParameterType">
+      <PortInfo index="0" default="False" />
+    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
+  </Elements>
+  <Connectors>
+    <Dynamo.Graph.Connectors.ConnectorModel start="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" start_index="0" end="bb83a545-0c80-4f34-b987-da1d3d0dc2b7" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" start_index="0" end="04ccd2fc-45bb-4953-9306-b7eb21d991a0" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" start_index="0" end="97d5b4ba-76e4-40e9-b1b2-8ce98e642a40" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="2686aa52-2a95-4d9d-b637-9bbc63e40f98" start_index="0" end="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" end_index="0" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="89205379-97aa-4d39-bbf1-390e9342f7d3" start_index="0" end="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" end_index="1" portType="0" />
+  </Connectors>
+  <Notes />
+  <Annotations />
+  <Presets />
+  <Cameras>
+    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+  </Cameras>
+</Workspace>


### PR DESCRIPTION
### Purpose
Cherry-pick Global Params from Revit2018 to RC1.2.3_Revit2018

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@sm6srw

### FYIs

