### PR TITLE
DYN-488 Revit 2018

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -343,7 +343,7 @@ namespace Revit.Elements
             //
             var allParams =
             InternalElement.Parameters.Cast<Autodesk.Revit.DB.Parameter>()
-                .Where(x => x.Definition.Name == parameterName)
+                .Where(x => string.CompareOrdinal(x.Definition.Name, parameterName) == 0)
                 .OrderBy(x => x.Id.IntegerValue);
 
             var param = allParams.FirstOrDefault(x => x.IsReadOnly == false) ?? allParams.FirstOrDefault();

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -311,6 +311,11 @@ namespace Revit.Elements
         }
 
 
+        /// <summary>
+        /// Get a parameter by name of an element
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter.</param>
+        /// <returns></returns>
         private Autodesk.Revit.DB.Parameter GetParameterByName(string parameterName)
         {
             var allParams =

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -310,6 +310,19 @@ namespace Revit.Elements
             // or transactions and which must necessarily be threaded in a specific way.
         }
 
+
+        private Autodesk.Revit.DB.Parameter GetParameterByName(string parameterName)
+        {
+            var allParams =
+            InternalElement.Parameters.Cast<Autodesk.Revit.DB.Parameter>()
+                .Where(x => x.Definition.Name == parameterName)
+                .OrderBy(x => x.Id.IntegerValue);
+
+            var param = allParams.FirstOrDefault(x => x.IsReadOnly == false) ?? allParams.FirstOrDefault();
+
+            return param;
+        }
+
         /// <summary>
         /// Get the value of one of the element's parameters.
         /// </summary>
@@ -318,14 +331,15 @@ namespace Revit.Elements
         public object GetParameterValueByName(string parameterName)
         {
 
-            var param =
+//            var param =
                 // We don't use Element.GetOrderedParameters(), it only returns ordered parameters
                 // as show in the UI
-                InternalElement.Parameters.Cast<Autodesk.Revit.DB.Parameter>()
+//                InternalElement.Parameters.Cast<Autodesk.Revit.DB.Parameter>()
                     // Element.Parameters returns a differently ordered list on every invocation.
                     // We must sort it to get sensible results.
-                    .OrderBy(x => x.Id.IntegerValue) 
-                    .FirstOrDefault(x => x.Definition.Name == parameterName);         
+//                    .OrderBy(x => x.Id.IntegerValue) 
+//                    .FirstOrDefault(x => x.Definition.Name == parameterName);         
+            var param = GetParameterByName(parameterName);
             
             if (param == null || !param.HasValue)
                 return string.Empty;
@@ -382,7 +396,8 @@ namespace Revit.Elements
         /// <param name="value">The value.</param>
         public Element SetParameterByName(string parameterName, object value)
         {
-            var param = InternalElement.Parameters.Cast<Autodesk.Revit.DB.Parameter>().FirstOrDefault(x => x.Definition.Name == parameterName);
+//            var param = InternalElement.Parameters.Cast<Autodesk.Revit.DB.Parameter>().FirstOrDefault(x => x.Definition.Name == parameterName);
+            var param = GetParameterByName(parameterName);
 
             if (param == null)
                 throw new Exception(Properties.Resources.ParameterNotFound);


### PR DESCRIPTION
### Purpose
Parameter names are not unique on a given element. There are several valid cases where 
duplicated parameter names can be found in the Parameter Set.

The most common ones are:
 * Multiple built-in parameters with the same name
This is a common implementation pattern when a different parameter behavior is wanted
for different scopes. For example, lets say that you want a parameter to be writable
in the property palette but read-only in a schedule view. The easiest way to accomplish
this would be to add two parameters. One that is read-write and one that is read-only. 
These parameters will both have the same name and they will share the same getter. 
* Built-in parameters and User parameters with the same name
This happens when a loadable family defines a user parameter with the same name
as a built-in parameter.

Proposed solution:
1. Get all parameters for the given name
2. Sort parameters by ElementId - This will give us built-in parameters first (ID's for built-ins are always < -1)
3. If it exist: Use the first writable parameter 
4. Otherwise: Use the first read-only parameter

This should solve the first case and address the most common scenario for the second case. A possible future enhancement, if the need arises, would be to add a way for the user to ignore built-ins. 

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 



### FYIs


