### PR TITLE
Ignore two test cases which are caused merely by missing files

### DIFF
--- a/test/Libraries/RevitIntegrationTests/FamilyTests.cs
+++ b/test/Libraries/RevitIntegrationTests/FamilyTests.cs
@@ -305,7 +305,7 @@ namespace RevitSystemTests
         }
 
 
-        [Test]
+        [Ignore]
         [TestModel(@".\empty.rvt")]
         public void CreateFamilyTypeByGeometry()
         {

--- a/test/Libraries/RevitNodesTests/Elements/FamilySymbolTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/FamilySymbolTests.cs
@@ -52,7 +52,7 @@ namespace RevitNodesTests.Elements
             Assert.Throws(typeof(System.ArgumentNullException), () => FamilyType.ByFamilyAndName(null, "Turtle"));
         }
 
-        [Test]
+        [Ignore]
         [TestModel(@".\empty.rvt")]
         public void ByGeometry_GoodArgs()
         {


### PR DESCRIPTION
### Purpose

This is to ignore two test cases which are failing simply because the relevant template files are not there. They have been ignored before but have been added back again recently.

I have also made some changes to the test framework(Refer https://github.com/DynamoDS/RevitTestFramework/pull/67) so that in the future purely adding a "Ignore" attribute will work as well.

### FYIs
@mjkkirschner 