### PR TITLE
Category selection Dropdown - handle spaces

### DIFF
--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -555,6 +555,23 @@ namespace DSRevitNodesUI
             return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall) };
         }
 
+        protected override bool UpdateValueCore(UpdateValueParams updateValueParams)
+        {
+            string name = updateValueParams.PropertyName;
+            string value = updateValueParams.PropertyValue;
+
+            if (name == "Value" && value != null)
+            {
+                // Un-exception: Find selection by display name, just like the base class does!
+                SelectedIndex = ParseSelectedIndexImpl(value, Items);
+                if (SelectedIndex < 0)
+                    Warning(Dynamo.Properties.Resources.NothingIsSelectedWarning);
+                return true; // UpdateValueCore handled.
+            }
+
+            return base.UpdateValueCore(updateValueParams);
+        }
+
         protected override int ParseSelectedIndex(string index, IList<DynamoDropDownItem> items)
         {
             int selectedIndex = -1;


### PR DESCRIPTION
Un-except the exceptional treatment of Category dropdown combos in
DynamoRevit.

The problem was that the ChoiceList contains user-readable strings for
Category names, while the values obtained and sent to DynamoRevit are
expected to be mangled names. Anything with spaces, dashes, etc in its
name is affected by this discrepancy.

### Purpose

Allow external API calls to properly set the value of a Category drop-down.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @QilongTang @sm6srw 

### FYIs

@BogdanZavu 