### PR TITLE
Update one preloaded libary file name

### DIFF
--- a/src/DynamoRevit/RevitPathResolver.cs
+++ b/src/DynamoRevit/RevitPathResolver.cs
@@ -46,7 +46,7 @@ namespace Dynamo.Applications
                 "DynamoUnits.dll",
                 "Tessellation.dll",
                 "Analysis.dll",
-                "Display.dll",
+                "GeometryColor.dll",
 
                 revitNodesDll,
                 simpleRaaSDll


### PR DESCRIPTION
### Purpose

As one original module "Display.dll" is renamed to "GeometryColor.dll" (refer https://github.com/DynamoDS/Dynamo/pull/7759), the preloaded library name need to be changed as well.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### FYIs
@sharadkjaiswal @monikaprabhu 
