### PR TITLE
fix to ElementClassFilter handling in All Elements of Type node

### DIFF
--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementQueries.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementQueries.cs
@@ -10,29 +10,29 @@ namespace Revit.Elements.InternalUtilities
     [IsVisibleInDynamoLibrary(false)]
     public static class ElementQueries
     {
-        private static readonly Dictionary<Type, string> ClassFilterExceptions = new Dictionary<Type, string>
+        private static readonly HashSet<Type> ClassFilterExceptions = new HashSet<Type>
         {
-            { typeof(Autodesk.Revit.DB.Material), "Material"},
-            { typeof(Autodesk.Revit.DB.CurveElement), "CurveElement"},
-            { typeof(Autodesk.Revit.DB.ConnectorElement), "ConnectorElement"},
-            { typeof(Autodesk.Revit.DB.HostedSweep), "HostedSweep"},
-            { typeof(Autodesk.Revit.DB.Architecture.Room), "Room"},
-            { typeof(Autodesk.Revit.DB.Mechanical.Space), "Space"},
-            { typeof(Autodesk.Revit.DB.Area), "Area"},
-            { typeof(Autodesk.Revit.DB.Architecture.RoomTag), "RoomTag"},
-            { typeof(Autodesk.Revit.DB.Mechanical.SpaceTag), "SpaceTag"},
-            { typeof(Autodesk.Revit.DB.AreaTag), "AreaTag"},
-            { typeof(Autodesk.Revit.DB.CombinableElement), "CombinableElement"},
-            { typeof(Autodesk.Revit.DB.Mullion), "Mullion"},
-            { typeof(Autodesk.Revit.DB.Panel), "Panel"},
-            { typeof(Autodesk.Revit.DB.AnnotationSymbol), "AnnotationSymbol"},
-            { typeof(Autodesk.Revit.DB.Structure.AreaReinforcementType), "AreaReinforecementType"},
-            { typeof(Autodesk.Revit.DB.Structure.PathReinforcementType), "PathReinforecementType"},
-            { typeof(Autodesk.Revit.DB.AnnotationSymbolType), "AnnotationSymbolType"},
-            { typeof(Autodesk.Revit.DB.Architecture.RoomTagType), "RoomTagType"},
-            { typeof(Autodesk.Revit.DB.Mechanical.SpaceTagType), "SpaceTagType"},
-            { typeof(Autodesk.Revit.DB.AreaTagType), "AreaTagType"},
-            { typeof(Autodesk.Revit.DB.Structure.TrussType), "TrussType"}
+            typeof(Autodesk.Revit.DB.Material),
+            typeof(Autodesk.Revit.DB.CurveElement),
+            typeof(Autodesk.Revit.DB.ConnectorElement),
+            typeof(Autodesk.Revit.DB.HostedSweep),
+            typeof(Autodesk.Revit.DB.Architecture.Room),
+            typeof(Autodesk.Revit.DB.Mechanical.Space),
+            typeof(Autodesk.Revit.DB.Area),
+            typeof(Autodesk.Revit.DB.Architecture.RoomTag),
+            typeof(Autodesk.Revit.DB.Mechanical.SpaceTag),
+            typeof(Autodesk.Revit.DB.AreaTag),
+            typeof(Autodesk.Revit.DB.CombinableElement),
+            typeof(Autodesk.Revit.DB.Mullion),
+            typeof(Autodesk.Revit.DB.Panel),
+            typeof(Autodesk.Revit.DB.AnnotationSymbol),
+            typeof(Autodesk.Revit.DB.Structure.AreaReinforcementType),
+            typeof(Autodesk.Revit.DB.Structure.PathReinforcementType),
+            typeof(Autodesk.Revit.DB.AnnotationSymbolType),
+            typeof(Autodesk.Revit.DB.Architecture.RoomTagType),
+            typeof(Autodesk.Revit.DB.Mechanical.SpaceTagType),
+            typeof(Autodesk.Revit.DB.AreaTagType),
+            typeof(Autodesk.Revit.DB.Structure.TrussType)
         };
 
         public static IList<Element> OfFamilyType(FamilyType familyType)
@@ -66,7 +66,7 @@ namespace Revit.Elements.InternalUtilities
             filtering to get our intended element set.
             */
 
-            if (ClassFilterExceptions.ContainsKey(elementType))
+            if (ClassFilterExceptions.Contains(elementType))
             {
                 return new FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument)
                     .OfClass(elementType.BaseType)


### PR DESCRIPTION
### Purpose

It addresses an issue listed here: 

https://github.com/DynamoDS/DynamoRevit/issues/1674

Here's the fixed example: 

![image](https://cloud.githubusercontent.com/assets/529781/26041695/f1347758-38fc-11e7-9fa0-dc1060fa259b.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @jnealb @riteshchandawar @kronz @Racel 

### FYIs

I also made a small change to the way that previous collector was called. There was no need to call `ToElements()` and then `x.Id.IntegerValue` when we can call `ToElementIds()` directly. I believe that's a little faster as well. 
