### PR TITLE
areaPlan wrapper

### DIFF
--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -172,6 +172,8 @@ namespace Revit.Elements
                     return FloorPlanView.FromExisting(view, isRevitOwned);
                 case ViewType.EngineeringPlan:
                     return StructuralPlanView.FromExisting(view, isRevitOwned);
+                case ViewType.AreaPlan:
+                    return AreaPlanView.FromExisting(view, isRevitOwned);
                 default:
                     return UnknownElement.FromExisting(view, true);
             }

--- a/src/Libraries/RevitNodes/Elements/Views/AreaPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/AreaPlanView.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using RevitServices.Persistence;
+using RevitServices.Transactions;
+using DynamoServices;
+
+namespace Revit.Elements.Views
+{
+    /// <summary>
+    /// A Revit Area Plan View
+    /// </summary>
+    [RegisterForTrace]
+    public class AreaPlanView : PlanView
+    {
+
+        #region Private constructors
+
+        /// <summary>
+        /// Private constructor
+        /// </summary>
+        private AreaPlanView(Autodesk.Revit.DB.ViewPlan view)
+        {
+            SafeInit(() => InitAreaPlanView(view));
+        }
+
+        /// <summary>
+        /// Private constructor
+        /// </summary>
+        private AreaPlanView(Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.AreaScheme areaScheme)
+        {
+            SafeInit(() => InitAreaPlanView(level, areaScheme));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        /// <summary>
+        /// Initialize a AreaPlanView element
+        /// </summary>
+        private void InitAreaPlanView(Autodesk.Revit.DB.ViewPlan view)
+        {
+            InternalSetPlanView(view);
+        }
+
+        /// <summary>
+        /// Initialize a AreaPlanView element
+        /// </summary>
+        private void InitAreaPlanView(Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.AreaScheme areaScheme)
+        {
+            TransactionManager.Instance.EnsureInTransaction(Document);
+
+            var vd = CreateAreaPlan(level, areaScheme);
+
+            InternalSetPlanView(vd);
+
+            TransactionManager.Instance.TransactionTaskDone();
+
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElement);
+        }
+
+        #endregion
+
+        #region Public static constructors
+
+        /// <summary>
+        /// Create an Area Plan View at the given Level.
+        /// </summary>
+        /// <param name="level">The Level on which the AreaPlanView is based.</param>
+        /// <param name="areaScheme">Area Scheme to be applied to plan view.</param>
+        /// <returns>An Area Plan View if successful.</returns>
+        public static AreaPlanView ByLevelAndAreaScheme(Level level, Element areaScheme)
+        {
+            if (level == null)
+            {
+                throw new ArgumentNullException(nameof(level));
+            }
+            if (areaScheme == null)
+            {
+                throw new ArgumentNullException(nameof(areaScheme));
+            }
+
+            var scheme = areaScheme.InternalElement as Autodesk.Revit.DB.AreaScheme;
+
+            return new AreaPlanView(level.InternalLevel, scheme);
+        }
+
+        #endregion
+
+        #region Internal methods
+
+        /// <summary>
+        /// Create from existing Element
+        /// </summary>
+        /// <param name="plan">Area Plan View.</param>
+        /// <param name="isRevitOwned">Is Revit Owned?</param>
+        /// <returns></returns>
+        internal static AreaPlanView FromExisting(Autodesk.Revit.DB.ViewPlan plan, bool isRevitOwned)
+        {
+            if (plan == null)
+            {
+                throw new ArgumentNullException(nameof(plan));
+            }
+
+            return new AreaPlanView(plan)
+            {
+                IsRevitOwned = isRevitOwned
+            };
+        }
+
+        #endregion
+
+    }
+}
+

--- a/src/Libraries/RevitNodes/Elements/Views/FloorPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/FloorPlanView.cs
@@ -1,10 +1,5 @@
-﻿
-using System;
-
-using Autodesk.Revit.DB;
-
+﻿using System;
 using DynamoServices;
-
 using RevitServices.Persistence;
 using RevitServices.Transactions;
 
@@ -54,13 +49,13 @@ namespace Revit.Elements.Views
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            var vd = CreatePlanView(level, ViewFamily.FloorPlan);
+            var vd = CreatePlanView(level, Autodesk.Revit.DB.ViewFamily.FloorPlan);
 
             InternalSetPlanView(vd);
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            ElementBinder.CleanupAndSetElementForTrace(Document, this.InternalElement);
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalElement);
         }
 
         #endregion
@@ -76,7 +71,7 @@ namespace Revit.Elements.Views
         {
             if (level == null)
             {
-                throw new ArgumentNullException("level");
+                throw new ArgumentNullException(nameof(level));
             }
 
             return new FloorPlanView( level.InternalLevel );
@@ -96,7 +91,7 @@ namespace Revit.Elements.Views
         {
             if (plan == null)
             {
-                throw new ArgumentNullException("plan");
+                throw new ArgumentNullException(nameof(plan));
             }
 
             return new FloorPlanView(plan)

--- a/src/Libraries/RevitNodes/Elements/Views/PlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/PlanView.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using Autodesk.Revit.DB;
-using Revit.Elements.Views;
 using RevitServices.Persistence;
 using Autodesk.DesignScript.Runtime;
-using View = Revit.Elements.Views.View;
+using Revit.Elements.Views;
 
 namespace Revit.Elements
 {
@@ -44,29 +39,34 @@ namespace Revit.Elements
         /// <summary>
         /// Set the InternalViewPlan property and the associated element id and unique id
         /// </summary>
-        /// <param name="plan"></param>
+        /// <param name="plan">ViewPlan</param>
         protected void InternalSetPlanView(Autodesk.Revit.DB.ViewPlan plan)
         {
-            this.InternalViewPlan = plan;
-            this.InternalElementId = plan.Id;
-            this.InternalUniqueId = plan.UniqueId;
+            InternalViewPlan = plan;
+            InternalElementId = plan.Id;
+            InternalUniqueId = plan.UniqueId;
         }
 
         #endregion
 
         #region Protected helper methods
 
-        protected static ViewPlan CreatePlanView(Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.ViewFamily planType)
+        protected static Autodesk.Revit.DB.ViewPlan CreatePlanView(Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.ViewFamily planType)
         {
-            var viewFam = DocumentManager.Instance.ElementsOfType<ViewFamilyType>()
+            var viewFam = DocumentManager.Instance.ElementsOfType<Autodesk.Revit.DB.ViewFamilyType>()
                 .FirstOrDefault(x => x.ViewFamily == planType);
 
             if (viewFam == null)
             {
-                throw new Exception("There is no such ViewFamily in the document");
+                throw new Exception(Properties.Resources.ViewPlan_ViewFamilyNotFound);
             }
 
-            return ViewPlan.Create(Document, viewFam.Id, level.Id); ;
+            return Autodesk.Revit.DB.ViewPlan.Create(Document, viewFam.Id, level.Id);
+        }
+
+        protected static Autodesk.Revit.DB.ViewPlan CreateAreaPlan(Autodesk.Revit.DB.Level level, Autodesk.Revit.DB.AreaScheme areaScheme)
+        {
+            return Autodesk.Revit.DB.ViewPlan.CreateAreaPlan(Document, areaScheme.Id, level.Id);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/Views/View.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View.cs
@@ -37,6 +37,7 @@ namespace Revit.Elements.Views
                 case Autodesk.Revit.DB.ViewType.Elevation:
                 case Autodesk.Revit.DB.ViewType.CeilingPlan:
                 case Autodesk.Revit.DB.ViewType.DraftingView:
+                case Autodesk.Revit.DB.ViewType.AreaPlan:
                     return true;
 
                 default: return false;

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -889,6 +889,15 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string ViewPlan_ViewFamilyNotFound {
+            get {
+                return ResourceManager.GetString("ViewPlan_ViewFamilyNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There is no WallType of the given name in the current Document..
         /// </summary>
         internal static string WallTypeNotFound {

--- a/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
@@ -396,4 +396,7 @@
   <data name="RoofTypeNotFound" xml:space="preserve">
     <value>Roof type not found.</value>
   </data>
+  <data name="ViewPlan_ViewFamilyNotFound" xml:space="preserve">
+    <value>There is no such ViewFamily in the document</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -396,4 +396,7 @@
   <data name="RoofTypeNotFound" xml:space="preserve">
     <value>Roof type not found.</value>
   </data>
+  <data name="ViewPlan_ViewFamilyNotFound" xml:space="preserve">
+    <value>There is no such ViewFamily in the document</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/RevitNodes/RevitNodes.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Elements\Room.cs" />
     <Compile Include="Elements\Revision.cs" />
     <Compile Include="Elements\RevisionCloud.cs" />
+    <Compile Include="Elements\Views\AreaPlanView.cs" />
     <Compile Include="PerformanceAdviser\FailureMessage.cs" />
     <Compile Include="PerformanceAdviser\PerformanceAdviserRule.cs" />
     <Compile Include="Elements\SunSettings.cs" />
@@ -238,7 +239,6 @@
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.en-US.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/test/Libraries/RevitNodesTests/Elements/Views/AreaPlanViewTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/Views/AreaPlanViewTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using RTF.Framework;
+using Revit.Elements.Views;
+using RevitServices.Persistence;
+using RevitTestServices;
+using Revit.Elements;
+
+namespace RevitNodesTests.Elements.Views
+{
+    [TestFixture]
+    class AreaPlanViewTests : RevitNodeTestBase
+    {
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByLevelAndAreaScheme_ValidArgs()
+        {
+            const int elevation = 100;
+            var level = Level.ByElevation(elevation);
+            Assert.NotNull(level);
+
+            var areaScheme = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument)
+                .OfClass(typeof(Autodesk.Revit.DB.AreaScheme))
+                .Select(x => x.ToDSType(true))
+                .FirstOrDefault();   
+            Assert.NotNull(areaScheme);
+
+            var view = AreaPlanView.ByLevelAndAreaScheme(level, areaScheme);
+
+            Assert.NotNull(view);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByLevelAndAreaScheme_BadArgs()
+        {
+            const int elevation = 100;
+            var level = Level.ByElevation(elevation);
+            Assert.NotNull(level);
+
+            var areaScheme = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument)
+                .OfClass(typeof(Autodesk.Revit.DB.AreaScheme))
+                .Select(x => x.ToDSType(true))
+                .FirstOrDefault();
+            Assert.NotNull(areaScheme);
+
+            Assert.Throws(typeof(ArgumentNullException), () => AreaPlanView.ByLevelAndAreaScheme(level, null));
+            Assert.Throws(typeof(ArgumentNullException), () => AreaPlanView.ByLevelAndAreaScheme(null, areaScheme));
+        }
+    }
+}

--- a/test/Libraries/RevitNodesTests/RevitNodesTests.csproj
+++ b/test/Libraries/RevitNodesTests/RevitNodesTests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Elements\TagTests.cs" />
     <Compile Include="Elements\TextNoteTests.cs" />
     <Compile Include="Elements\TopographyTests.cs" />
+    <Compile Include="Elements\Views\AreaPlanViewTests.cs" />
     <Compile Include="Elements\Views\AxonometricViewTests.cs" />
     <Compile Include="Elements\Views\CeilingPlanViewTests.cs" />
     <Compile Include="Elements\Views\DraftingViewTests.cs" />


### PR DESCRIPTION
### Purpose

This addresses multiple reports that Area Plans were not being returned properly, either via `Document.ActiveView` nor `ToDSType()` calls. 

![image](https://cloud.githubusercontent.com/assets/529781/26183031/18a86f2a-3b4a-11e7-992b-1ebbb241d400.png)

Specifically this issue: https://github.com/DynamoDS/DynamoRevit/issues/1622

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @jnealb @riteshchandawar @aparajit-pratap 

### FYIs

I cleaned up the `ViewPlan` class a little bit while I was at it. 
