### PR TITLE
Rename BuiltIns.ds to BuiltIn.ds to resolve icons correctly

### DIFF
--- a/src/DynamoRevit/RevitPathResolver.cs
+++ b/src/DynamoRevit/RevitPathResolver.cs
@@ -41,7 +41,7 @@ namespace Dynamo.Applications
                 "DSOffice.dll",
                 "DSIronPython.dll",
                 "FunctionObject.ds",
-                "BuiltIns.ds",
+                "BuiltIn.ds",
                 "DynamoConversions.dll",
                 "DynamoUnits.dll",
                 "Tessellation.dll",

--- a/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
+++ b/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
@@ -15,7 +15,7 @@ namespace RevitTestServices
             AddPreloadLibraryPath("DSOffice.dll");
             AddPreloadLibraryPath("DSIronPython.dll");
             AddPreloadLibraryPath("FunctionObject.ds");
-            AddPreloadLibraryPath("BuiltIns.ds");
+            AddPreloadLibraryPath("BuiltIn.ds");
             AddPreloadLibraryPath("DynamoConversions.dll");
             AddPreloadLibraryPath("DynamoUnits.dll");
             AddPreloadLibraryPath("Tessellation.dll");


### PR DESCRIPTION
### Purpose

This PR renames BuiltIns.ds to BuiltIn.ds as a followup of https://github.com/DynamoDS/Dynamo/pull/7880

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.


### FYIs

@Randy-Ma 
@aparajit-pratap 