### PR TITLE
Rename BuiltIns.ds to BuiltIn.ds to resolve icons correctly

### DIFF
--- a/src/DynamoRevit/RevitPathResolver.cs
+++ b/src/DynamoRevit/RevitPathResolver.cs
@@ -41,7 +41,7 @@ namespace Dynamo.Applications
                 "DSOffice.dll",
                 "DSIronPython.dll",
                 "FunctionObject.ds",
-                "BuiltIns.ds",
+                "BuiltIn.ds",
                 "DynamoConversions.dll",
                 "DynamoUnits.dll",
                 "Tessellation.dll",

--- a/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
+++ b/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
@@ -15,7 +15,7 @@ namespace RevitTestServices
             AddPreloadLibraryPath("DSOffice.dll");
             AddPreloadLibraryPath("DSIronPython.dll");
             AddPreloadLibraryPath("FunctionObject.ds");
-            AddPreloadLibraryPath("BuiltIns.ds");
+            AddPreloadLibraryPath("BuiltIn.ds");
             AddPreloadLibraryPath("DynamoConversions.dll");
             AddPreloadLibraryPath("DynamoUnits.dll");
             AddPreloadLibraryPath("Tessellation.dll");


### PR DESCRIPTION
### Purpose

Cross-merge #1681 to Revit2016 branch.