### PR TITLE
fix to inconsistent element.getCategory naming

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -167,7 +167,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get Element Category
         /// </summary>
-        public Category GetCategory
+        public Category Category
         {
             get { return new Category(this.InternalElement.Category); }
         }


### PR DESCRIPTION
### Purpose

This is super small, but addresses consistency in naming conventions pointed out here: 

https://github.com/DynamoDS/DynamoRevit/issues/1663

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@Racel @kronz @mjkkirschner 

### FYIs


