### PR TITLE
fix to failing view.exportAsImage

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Views/View.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View.cs
@@ -121,8 +121,18 @@ namespace Revit.Elements.Views
                 throw new ArgumentException(Properties.Resources.View_ExportAsImage_Path_Invalid, nameof(path));
 
             // rename the file
-            if (File.Exists(destinationFileName)) File.Delete(destinationFileName);
-            File.Move(actualFileName, destinationFileName);
+            if (File.Exists(destinationFileName))
+            {
+                try
+                {
+                    File.Delete(destinationFileName);
+                    File.Move(actualFileName, destinationFileName);
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception(Properties.Resources.ViewExportImageLockedError, ex);
+                }
+            }
             
             Bitmap bmp;
             try

--- a/src/Libraries/RevitNodes/Elements/Views/View.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using Autodesk.Revit.DB;
+using RevitServices.Persistence;
 
 namespace Revit.Elements.Views
 {
@@ -44,8 +45,8 @@ namespace Revit.Elements.Views
         }
 
         /// <summary>
-        ///     Export the view as an image to the given path - defaults to png, but you can override 
-        ///     the file type but supplying a path with the appropriate extension
+        /// Export the view as an image to the given path - defaults to png, but you can override 
+        /// the file type but supplying a path with the appropriate extension
         /// </summary>
         /// <param name="path">A valid path for the image</param>
         /// <returns>The image</returns>
@@ -53,11 +54,11 @@ namespace Revit.Elements.Views
         {
             if (string.IsNullOrEmpty(path))
             {
-                throw new ArgumentException(Properties.Resources.View_ExportAsImage_Path_Invalid, "path");
+                throw new ArgumentException(Properties.Resources.View_ExportAsImage_Path_Invalid, nameof(path));
             }
 
             var fileType = ImageFileType.PNG;
-            string extension = ".png";
+            var extension = ".png";
             if (Path.HasExtension(path))
             {
                 extension = Path.GetExtension(path);
@@ -99,25 +100,34 @@ namespace Revit.Elements.Views
 
             Document.ExportImage(options);
 
-            var pathName = Path.Combine(
-                            Path.GetDirectoryName(path),
-                            Path.GetFileNameWithoutExtension(path));
+            var doc = DocumentManager.Instance.CurrentDBDocument;
+            var revitName = Autodesk.Revit.DB.ImageExportOptions.GetFileName(doc, InternalView.Id);
+            var directoryName = Path.GetDirectoryName(path);
+            var actualFileName = string.Empty;
+            var destinationFileName = string.Empty;
 
-            // Revit outputs file with a bunch of crap in the file name, let's construct that
-            var actualFn = string.Format("{0} - {1} - {2}{3}", pathName, ViewTypeString(InternalView.ViewType),
-                InternalView.ViewName, extension);
+            if (directoryName != null)
+            {
+                actualFileName = Path.Combine(
+                    directoryName,
+                    Path.GetFileNameWithoutExtension(path) + revitName + extension);
 
-            // and the intended destination
-            var destFn = pathName + extension;
+                destinationFileName = Path.Combine(
+                    directoryName,
+                    Path.GetFileNameWithoutExtension(path) + extension);
+            }
+
+            if(string.IsNullOrEmpty(actualFileName) || string.IsNullOrEmpty(destinationFileName))
+                throw new ArgumentException(Properties.Resources.View_ExportAsImage_Path_Invalid, nameof(path));
 
             // rename the file
-            if (File.Exists(destFn)) File.Delete(destFn);
-            File.Move(actualFn, destFn);
+            if (File.Exists(destinationFileName)) File.Delete(destinationFileName);
+            File.Move(actualFileName, destinationFileName);
             
             Bitmap bmp;
             try
             {
-                using (var fs = new FileStream(destFn, FileMode.Open))
+                using (var fs = new FileStream(destinationFileName, FileMode.Open))
                 {
                     bmp = new Bitmap(Image.FromStream(fs));
                 }

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -889,6 +889,15 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string ViewExportImageLockedError {
+            get {
+                return ResourceManager.GetString("ViewExportImageLockedError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There is no WallType of the given name in the current Document..
         /// </summary>
         internal static string WallTypeNotFound {

--- a/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
@@ -396,4 +396,7 @@
   <data name="RoofTypeNotFound" xml:space="preserve">
     <value>Roof type not found.</value>
   </data>
+  <data name="ViewExportImageLockedError" xml:space="preserve">
+    <value>Attempt to override existing image failed due to file lock. Please make sure that image is not currently open in another application.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -396,4 +396,7 @@
   <data name="RoofTypeNotFound" xml:space="preserve">
     <value>Roof type not found.</value>
   </data>
+  <data name="ViewExportImageLockedError" xml:space="preserve">
+    <value>Attempt to override existing image failed due to file lock. Please make sure that image is not currently open in another application.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/RevitNodes/RevitNodes.csproj
@@ -238,7 +238,6 @@
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.en-US.resx">
       <Generator>ResXFileCodeGenerator</Generator>


### PR DESCRIPTION
### Purpose

This addresses this issue: https://github.com/DynamoDS/Dynamo/issues/3262 (possibly but it's an old one) and this issue: https://github.com/DynamoDS/DynamoRevit/issues/1695

Basically the idea is that we use ImageExportOptions.GetFileName instead of manually constructing the predicted filename that Revit will assign to our export. It fails. 

![image](https://cloud.githubusercontent.com/assets/529781/26566247/b35c0f12-44bf-11e7-98d6-1b6516cb90f6.png)

Using their built in static method does not:

![image](https://cloud.githubusercontent.com/assets/529781/26566256/c45b1fa6-44bf-11e7-92b1-74eb64f48985.png)


### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 

### FYIs
