### PR TITLE
Temporarily marking two tests under Ignore category

### DIFF
--- a/test/Libraries/RevitIntegrationTests/FamilyTests.cs
+++ b/test/Libraries/RevitIntegrationTests/FamilyTests.cs
@@ -304,8 +304,8 @@ namespace RevitSystemTests
             Assert.AreEqual(initialNumber, finalNumber);
         }
 
-
-        [Test]
+        //TODO: Turn this test on once template files are installed on CI machines
+        [Ignore]
         [TestModel(@".\empty.rvt")]
         public void CreateFamilyTypeByGeometry()
         {

--- a/test/Libraries/RevitNodesTests/Elements/FamilySymbolTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/FamilySymbolTests.cs
@@ -52,7 +52,8 @@ namespace RevitNodesTests.Elements
             Assert.Throws(typeof(System.ArgumentNullException), () => FamilyType.ByFamilyAndName(null, "Turtle"));
         }
 
-        [Test]
+        //TODO: Turn this test on once template files are installed on CI machines
+        [Ignore]
         [TestModel(@".\empty.rvt")]
         public void ByGeometry_GoodArgs()
         {


### PR DESCRIPTION
### Purpose

Revit Template files are missing from the CI test machines because of which these tests are failing. Temporarily marking this tests under "Ignore" category. They will need to be turned back on once the required files are installed as will those in #1541 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.


### FYIs

@Randy-Ma 
