### PR TITLE
Add the option to reuse the existing workspace model if the file we want to work with is already loaded

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -153,8 +153,9 @@ namespace Dynamo.Applications
 
         /// <summary>
         /// The journal file can specify if a check should be performed to see if the
-        /// existing model already points to the Dynamo file we want to run or perform
-        /// other tasks. If that's the case, we want to use the existing model.
+        /// current workspaceModel already points to the Dynamo file we want to 
+        /// run (or perform other tasks). If that's the case, we want to use the
+        /// current workspaceModel.
         /// </summary>
         public const string DynPathCheckExisting = "dynPathCheckExisting";
 
@@ -571,7 +572,7 @@ namespace Dynamo.Applications
                     }
                 }
 
-                if (!useExistingWorkspace)
+                if (!useExistingWorkspace) //if use existing is false, open the specified workspace
                 {
                     if (ModelState == RevitDynamoModelState.StartedUIless)
                     {

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -152,6 +152,13 @@ namespace Dynamo.Applications
         public const string ModelShutDownKey = "dynModelShutDown";
 
         /// <summary>
+        /// The journal file can specify if a check should be performed to see if the
+        /// existing model already points to the Dynamo file we want to run or perform
+        /// other tasks. If that's the case, we want to use the existing model.
+        /// </summary>
+        public const string DynPathCheckExisting = "dynPathCheckExisting";
+
+        /// <summary>
         /// The journal file can specify the values of Dynamo nodes.
         /// </summary>
         public const string ModelNodesInfo = "dynModelNodesInfo";
@@ -551,16 +558,30 @@ namespace Dynamo.Applications
             if (commandData.JournalData.ContainsKey(JournalKeys.DynPathKey))
             {
                 bool isAutomationMode = CheckJournalForKey(commandData, JournalKeys.AutomationModeKey);
-                bool forceManualRun = CheckJournalForKey(commandData, JournalKeys.ForceManualRunKey);                
+                bool forceManualRun = CheckJournalForKey(commandData, JournalKeys.ForceManualRunKey);
 
-                if (ModelState == RevitDynamoModelState.StartedUIless)
+                bool useExistingWorkspace = false;
+                if (CheckJournalForKey(commandData, JournalKeys.DynPathCheckExisting))
                 {
-                    revitDynamoModel.OpenFileFromPath(commandData.JournalData[JournalKeys.DynPathKey], forceManualRun);
+                    WorkspaceModel currentWorkspace = revitDynamoModel.CurrentWorkspace;
+                    if (currentWorkspace.FileName.Equals(commandData.JournalData[JournalKeys.DynPathKey], 
+                        StringComparison.OrdinalIgnoreCase))
+                    {
+                        useExistingWorkspace = true;
+                    }
                 }
-                else
+
+                if (!useExistingWorkspace)
                 {
-                    dynamoViewModel.OpenIfSavedCommand.Execute(new Dynamo.Models.DynamoModel.OpenFileCommand(commandData.JournalData[JournalKeys.DynPathKey], forceManualRun));
-                    dynamoViewModel.ShowStartPage = false;
+                    if (ModelState == RevitDynamoModelState.StartedUIless)
+                    {
+                        revitDynamoModel.OpenFileFromPath(commandData.JournalData[JournalKeys.DynPathKey], forceManualRun);
+                    }
+                    else
+                    {
+                        dynamoViewModel.OpenIfSavedCommand.Execute(new Dynamo.Models.DynamoModel.OpenFileCommand(commandData.JournalData[JournalKeys.DynPathKey], forceManualRun));
+                        dynamoViewModel.ShowStartPage = false;
+                    }
                 }
 
                 //If we have information about the nodes and their values we want to push those values after the file is opened.


### PR DESCRIPTION
### Purpose
Sometimes we want to reuse the existing workspace : performance related or other reasons.
In our case when we want to run a script , we want to perform a model check first and only if certain conditions are met we allow a script to run. But it's app to the third party app to decide on those conditions and that's why they can choose to open and then check the model on their end and after that post a run request (and they will probably choose to reuse existing workspace in this case).

### Declarations

Check these if you believe they are true

- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate

### Reviewers

@mjkkirschner 