### PR TITLE
Revit element selection nodes should serialize and deserialize properly in Json

### DIFF
--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -167,8 +167,8 @@ namespace Dynamo.Nodes
 
         [JsonConstructor]
         public RevitSelection(SelectionType selectionType,
-            SelectionObjectType selectionObjectType, string message, string prefix, 
-            List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            SelectionObjectType selectionObjectType, string message, string prefix,
+            IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(selectionType, selectionObjectType, message, prefix, selectionIdentifier, inPorts, outPorts)
         {
             RevitServicesUpdater.Instance.ElementsUpdated += Updater_ElementsUpdated;
@@ -266,8 +266,8 @@ namespace Dynamo.Nodes
 
         [JsonConstructor]
         protected ElementSelection(SelectionType selectionType,
-            SelectionObjectType selectionObjectType, string message, string prefix, 
-            List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            SelectionObjectType selectionObjectType, string message, string prefix,
+            IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(selectionType, selectionObjectType, message, prefix, selectionIdentifier, inPorts, outPorts) { }
 
         
@@ -422,8 +422,8 @@ namespace Dynamo.Nodes
 
         [JsonConstructor]
         public ReferenceSelection(SelectionType selectionType,
-            SelectionObjectType selectionObjectType, string message, string prefix, List<string> selectionIdentifier,
-            IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            SelectionObjectType selectionObjectType, string message, string prefix,
+            IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(selectionType, selectionObjectType, message, prefix, selectionIdentifier, inPorts, outPorts) { }
 
         public override IModelSelectionHelper<Reference> SelectionHelper
@@ -585,7 +585,7 @@ namespace Dynamo.Nodes
                 "Analysis Results") { }
 
         [JsonConstructor]
-        public DSAnalysisResultSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        public DSAnalysisResultSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                   SelectionType.One, 
                   SelectionObjectType.None, 
@@ -608,7 +608,7 @@ namespace Dynamo.Nodes
                 "Element") { }
 
         [JsonConstructor]
-        public DSModelElementSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        public DSModelElementSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.One,
                 SelectionObjectType.None,
@@ -631,7 +631,7 @@ namespace Dynamo.Nodes
                 "Face of Element Id") { }
         
         [JsonConstructor]
-        public DSFaceSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        public DSFaceSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                   SelectionType.One, 
                   SelectionObjectType.Face, 
@@ -654,7 +654,7 @@ namespace Dynamo.Nodes
                 "Edge of Element Id") { }
 
         [JsonConstructor]
-        public DSEdgeSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        public DSEdgeSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.One,
                 SelectionObjectType.Edge,
@@ -677,7 +677,7 @@ namespace Dynamo.Nodes
                 "Point on Element") { }
 
         [JsonConstructor]
-        public DSPointOnElementSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        public DSPointOnElementSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.One,
                 SelectionObjectType.PointOnFace,
@@ -749,7 +749,7 @@ namespace Dynamo.Nodes
                 "UV on Element") { }
 
         [JsonConstructor]
-        public DSUvOnElementSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        public DSUvOnElementSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.One,
                 SelectionObjectType.PointOnFace,
@@ -822,7 +822,7 @@ namespace Dynamo.Nodes
                 "Elements") { }
 
         [JsonConstructor]
-        public DSDividedSurfaceFamiliesSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        public DSDividedSurfaceFamiliesSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.One,
                 SelectionObjectType.None,
@@ -873,7 +873,7 @@ namespace Dynamo.Nodes
                 "Elements") { }
 
         [JsonConstructor]
-        public DSModelElementsSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        public DSModelElementsSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.Many,
                 SelectionObjectType.None,
@@ -897,7 +897,7 @@ namespace Dynamo.Nodes
                 "Faces") { }
 
         [JsonConstructor]
-        public SelectFaces(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        public SelectFaces(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.Many,
                 SelectionObjectType.Face,
@@ -921,7 +921,7 @@ namespace Dynamo.Nodes
                 DSRevitNodesUI.Properties.Resources.SelectEdgesPrefix) { }
 
         [JsonConstructor]
-        public SelectEdges(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+        public SelectEdges(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.Many,
                 SelectionObjectType.Edge,

--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -37,6 +37,8 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
 using RevitServices.Transactions;
 
+using Newtonsoft.Json;
+
 namespace Dynamo.Nodes
 {
 
@@ -158,6 +160,16 @@ namespace Dynamo.Nodes
         protected RevitSelection(SelectionType selectionType,
             SelectionObjectType selectionObjectType, string message, string prefix)
             : base(selectionType, selectionObjectType, message, prefix)
+        {
+            RevitServicesUpdater.Instance.ElementsUpdated += Updater_ElementsUpdated;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened += Controller_RevitDocumentChanged;
+        }
+
+        [JsonConstructor]
+        public RevitSelection(SelectionType selectionType,
+            SelectionObjectType selectionObjectType, string message, string prefix, List<string> selectionIdentifier,
+            IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(selectionType, selectionObjectType, message, prefix, selectionIdentifier, inPorts, outPorts)
         {
             RevitServicesUpdater.Instance.ElementsUpdated += Updater_ElementsUpdated;
             DynamoRevitApp.EventHandlerProxy.DocumentOpened += Controller_RevitDocumentChanged;
@@ -400,6 +412,12 @@ namespace Dynamo.Nodes
             SelectionObjectType selectionObjectType, string message, string prefix)
             : base(selectionType, selectionObjectType, message, prefix) { }
 
+        [JsonConstructor]
+        public ReferenceSelection(SelectionType selectionType,
+            SelectionObjectType selectionObjectType, string message, string prefix, List<string> selectionIdentifier,
+            IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(selectionType, selectionObjectType, message, prefix, selectionIdentifier, inPorts, outPorts) { }
+
         public override IModelSelectionHelper<Reference> SelectionHelper
         {
             get { return RevitReferenceSelectionHelper.Instance; }
@@ -581,6 +599,13 @@ namespace Dynamo.Nodes
                 SelectionObjectType.Face,
                 "Select a face.",
                 "Face of Element Id") { }
+        
+        [JsonConstructor]
+        public DSFaceSelection(SelectionType selectionType,
+            SelectionObjectType selectionObjectType, string message, string prefix, List<string> selectionIdentifier,
+            IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(selectionType, selectionObjectType, message, prefix, selectionIdentifier, inPorts, outPorts) {}
+            
     }
 
     [NodeName("Select Edge"), NodeCategory(Revit.Elements.BuiltinNodeCategories.REVIT_SELECTION),

--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -167,8 +167,8 @@ namespace Dynamo.Nodes
 
         [JsonConstructor]
         public RevitSelection(SelectionType selectionType,
-            SelectionObjectType selectionObjectType, string message, string prefix, List<string> selectionIdentifier,
-            IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            SelectionObjectType selectionObjectType, string message, string prefix, 
+            List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(selectionType, selectionObjectType, message, prefix, selectionIdentifier, inPorts, outPorts)
         {
             RevitServicesUpdater.Instance.ElementsUpdated += Updater_ElementsUpdated;
@@ -263,6 +263,14 @@ namespace Dynamo.Nodes
         protected ElementSelection(SelectionType selectionType,
             SelectionObjectType selectionObjectType, string message, string prefix)
             : base(selectionType, selectionObjectType, message, prefix) { }
+
+        [JsonConstructor]
+        protected ElementSelection(SelectionType selectionType,
+            SelectionObjectType selectionObjectType, string message, string prefix, 
+            List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(selectionType, selectionObjectType, message, prefix, selectionIdentifier, inPorts, outPorts) { }
+
+        
 
         public override IModelSelectionHelper<TSelection> SelectionHelper
         {
@@ -575,6 +583,17 @@ namespace Dynamo.Nodes
                 SelectionObjectType.None,
                 "Select an analysis result.",
                 "Analysis Results") { }
+
+        [JsonConstructor]
+        public DSAnalysisResultSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(
+                  SelectionType.One, 
+                  SelectionObjectType.None, 
+                  "Select an analysis result.", 
+                  "Analysis Results", 
+                  selectionIdentifier, 
+                  inPorts, 
+                  outPorts) { }
     }
 
     [NodeName("Select Model Element"), NodeCategory(Revit.Elements.BuiltinNodeCategories.REVIT_SELECTION),
@@ -587,6 +606,17 @@ namespace Dynamo.Nodes
                 SelectionObjectType.None,
                 "Select Model Element",
                 "Element") { }
+
+        [JsonConstructor]
+        public DSModelElementSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(
+                SelectionType.One,
+                SelectionObjectType.None,
+                "Select Model Element",
+                "Element",
+                selectionIdentifier,
+                inPorts,
+                outPorts) { }
     }
 
     [NodeName("Select Face"), NodeCategory(Revit.Elements.BuiltinNodeCategories.REVIT_SELECTION),
@@ -601,11 +631,15 @@ namespace Dynamo.Nodes
                 "Face of Element Id") { }
         
         [JsonConstructor]
-        public DSFaceSelection(SelectionType selectionType,
-            SelectionObjectType selectionObjectType, string message, string prefix, List<string> selectionIdentifier,
-            IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
-            : base(selectionType, selectionObjectType, message, prefix, selectionIdentifier, inPorts, outPorts) {}
-            
+        public DSFaceSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(
+                  SelectionType.One, 
+                  SelectionObjectType.Face, 
+                  "Select a face.", 
+                  "Face of Element Id", 
+                  selectionIdentifier, 
+                  inPorts, 
+                  outPorts) {}
     }
 
     [NodeName("Select Edge"), NodeCategory(Revit.Elements.BuiltinNodeCategories.REVIT_SELECTION),
@@ -618,6 +652,17 @@ namespace Dynamo.Nodes
                 SelectionObjectType.Edge,
                 "Select an edge.",
                 "Edge of Element Id") { }
+
+        [JsonConstructor]
+        public DSEdgeSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(
+                SelectionType.One,
+                SelectionObjectType.Edge,
+                "Select an edge.",
+                "Edge of Element Id",
+                selectionIdentifier,
+                inPorts,
+                outPorts) { }
     }
 
     [NodeName("Select Point on Face"), NodeCategory(Revit.Elements.BuiltinNodeCategories.REVIT_SELECTION),
@@ -630,6 +675,17 @@ namespace Dynamo.Nodes
                 SelectionObjectType.PointOnFace,
                 "Select a point on a face.",
                 "Point on Element") { }
+
+        [JsonConstructor]
+        public DSPointOnElementSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(
+                SelectionType.One,
+                SelectionObjectType.PointOnFace,
+                "Select a point on a face.",
+                "Point on Element",
+                selectionIdentifier,
+                inPorts,
+                outPorts) { }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(
             List<AssociativeNode> inputAstNodes)
@@ -691,6 +747,17 @@ namespace Dynamo.Nodes
                 SelectionObjectType.PointOnFace,
                 "Select a point on a face.",
                 "UV on Element") { }
+
+        [JsonConstructor]
+        public DSUvOnElementSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(
+                SelectionType.One,
+                SelectionObjectType.PointOnFace,
+                "Select a point on a face.",
+                "UV on Element",
+                selectionIdentifier,
+                inPorts,
+                outPorts) { }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(
             List<AssociativeNode> inputAstNodes)
@@ -754,6 +821,17 @@ namespace Dynamo.Nodes
                 "Select a divided surface.",
                 "Elements") { }
 
+        [JsonConstructor]
+        public DSDividedSurfaceFamiliesSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(
+                SelectionType.One,
+                SelectionObjectType.None,
+                "Select a divided surface.",
+                "Elements",
+                selectionIdentifier,
+                inPorts,
+                outPorts) { }
+
         // Set an update method. When the target object is modified in
         // Revit, this will cause the sub-elements to be modified.
         protected override IEnumerable<Element> ExtractSelectionResults(DividedSurface selection)
@@ -793,6 +871,18 @@ namespace Dynamo.Nodes
                 SelectionObjectType.None,
                 "Select elements.",
                 "Elements") { }
+
+        [JsonConstructor]
+        public DSModelElementsSelection(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(
+                SelectionType.Many,
+                SelectionObjectType.None,
+                "Select elements.",
+                "Elements",
+                selectionIdentifier,
+                inPorts,
+                outPorts)
+        { }
     }
 
     [NodeName("Select Faces"), NodeCategory(Revit.Elements.BuiltinNodeCategories.REVIT_SELECTION),
@@ -805,6 +895,18 @@ namespace Dynamo.Nodes
                 SelectionObjectType.Face,
                 "Select faces.",
                 "Faces") { }
+
+        [JsonConstructor]
+        public SelectFaces(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(
+                SelectionType.Many,
+                SelectionObjectType.Face,
+                "Select faces.",
+                "Faces",
+                selectionIdentifier,
+                inPorts,
+                outPorts)
+        { }
     }
 
     [NodeName("Select Edges"), NodeCategory(Revit.Elements.BuiltinNodeCategories.REVIT_SELECTION),
@@ -817,6 +919,17 @@ namespace Dynamo.Nodes
                 SelectionObjectType.Edge,
                 DSRevitNodesUI.Properties.Resources.SelectEdgesDescription,
                 DSRevitNodesUI.Properties.Resources.SelectEdgesPrefix) { }
+
+        [JsonConstructor]
+        public SelectEdges(List<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(
+                SelectionType.Many,
+                SelectionObjectType.Edge,
+                DSRevitNodesUI.Properties.Resources.SelectEdgesDescription,
+                DSRevitNodesUI.Properties.Resources.SelectEdgesPrefix,
+                selectionIdentifier,
+                inPorts,
+                outPorts) { }
     }
 
 }

--- a/test/Libraries/RevitIntegrationTests/SelectionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/SelectionTests.cs
@@ -377,6 +377,56 @@ namespace RevitSystemTests
             Assert.AreEqual(0, list.Count);
         }
 
+        [Test]
+        [Category("SmokeTests")]
+        [TestModel(@".\Selection\Selection.rfa")]
+        public void SelectionVerifyElementID()
+        {
+            // Open Xml graph
+            OpenAndAssertNoDummyNodes(Path.Combine(workingDirectory, @".\Selection\SelectModelElement.dyn"));
+            RunCurrentModel();
+
+            // Expected identification values
+            const string expectedSelectionId = "d854cdd2-7ea0-4cc0-bd7b-18891f94b3ee-000082e3";
+            const string expectedUUID = "bce7e393-aba2-4136-80ad-5aa136e5c5bf";
+
+            // Select model element node
+            var modelElementNode = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSModelElementSelection>();
+            var elementSelectionId = modelElementNode.SelectionIdentifier.First();
+            var elementUUID = modelElementNode.GUID.ToString();
+
+            // Assert node exists and returns expected identifiers
+            Assert.NotNull(modelElementNode);
+            Assert.AreEqual(expectedSelectionId, elementSelectionId);
+            Assert.AreEqual(expectedUUID, elementUUID);
+    
+            // Save model in temp location
+            ViewModel.CurrentSpace.Save(Path.Combine(workingDirectory, @".\Selection\SelectModelElement_temp.dyn"));
+
+            // Close workspace
+            Assert.IsTrue(ViewModel.CloseHomeWorkspaceCommand.CanExecute(null));
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            // Open Json temp file
+            OpenAndAssertNoDummyNodes(Path.Combine(workingDirectory, @".\Selection\SelectModelElement_temp.dyn"));
+            RunCurrentModel();
+
+            // Repeat verifications
+            modelElementNode = ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<DSModelElementSelection>();
+            elementSelectionId = modelElementNode.SelectionIdentifier.First();
+            elementUUID = modelElementNode.GUID.ToString();
+            Assert.NotNull(modelElementNode);
+            Assert.AreEqual(expectedSelectionId, elementSelectionId);
+            Assert.AreEqual(expectedUUID, elementUUID);
+
+            // Close workspace
+            Assert.IsTrue(ViewModel.CloseHomeWorkspaceCommand.CanExecute(null));
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            // Delete temp file
+            File.Delete(Path.Combine(workingDirectory, @".\Selection\SelectionElementId_temp.dyn"));
+        }
+
         [Test, Category("SmokeTests"), TestModel(@".\Selection\SelectionSync.rvt")]
         public void SelectionInSyncWithDocumentOperations_Elements()
         {


### PR DESCRIPTION
### Purpose

[QNTM-1284](https://jira.autodesk.com/browse/QNTM-1284)

The purpose of this PR is to enable the serialization and deserialization of Revit element selection nodes in Json.  Previously Revit/Dynamo would freeze when attempting save a graph containing Revit selection nodes and the Json file is never written.  The selection node should also maintain the Revit element id that is referenced so it will automatically be recognized when reopening a graph.

Supplemental to [Dynamo PR #8131](https://github.com/DynamoDS/Dynamo/pull/8131)

![giphy](https://user-images.githubusercontent.com/13341935/29972605-aa48e9a6-8efa-11e7-8db0-e2b844948d1b.gif)

All RTF selection tests are passing including new tests:
![rtf_tests_upload](https://user-images.githubusercontent.com/13341935/30068475-e9b98a94-922b-11e7-829a-022cb4f472f2.jpg)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

