### PR TITLE
Fix to failing familyInstance.getType node (for Revit 2018)

### DIFF
--- a/src/Libraries/RevitNodes/Elements/AbstractFamilyInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/AbstractFamilyInstance.cs
@@ -1,8 +1,5 @@
 ﻿using Autodesk.DesignScript.Runtime;
-using Autodesk.Revit.DB;
-
 using Revit.GeometryConversion;
-
 using RevitServices.Persistence;
 using RevitServices.Transactions;
 using Point = Autodesk.DesignScript.Geometry.Point;
@@ -70,7 +67,11 @@ namespace Revit.Elements
         {
             get
             {
-                return FamilyType.FromExisting(this.InternalFamilyInstance.Symbol, true);
+                var typeId = InternalFamilyInstance.GetTypeId();
+                return typeId == Autodesk.Revit.DB.ElementId.InvalidElementId
+                    ? null
+                    : FamilyType.FromExisting(
+                        (Autodesk.Revit.DB.FamilySymbol)DocumentManager.Instance.CurrentDBDocument.GetElement(typeId), true);
             }
         }
 
@@ -80,9 +81,9 @@ namespace Revit.Elements
             {
                 TransactionManager.Instance.EnsureInTransaction(DocumentManager.Instance.CurrentDBDocument);
                 DocumentManager.Regenerate();
-                var pos = InternalFamilyInstance.Location as LocationPoint;
+                var pos = InternalFamilyInstance.Location as Autodesk.Revit.DB.LocationPoint;
                 TransactionManager.Instance.TransactionTaskDone();
-                return pos.Point.ToPoint();
+                return pos != null ? pos.Point.ToPoint() : null;
             }
         }
 

--- a/src/Libraries/RevitNodes/Elements/FamilyInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilyInstance.cs
@@ -1,12 +1,7 @@
 ﻿using System;
 using System.Linq;
-
-using Autodesk.Revit.DB;
-
 using DynamoServices;
-
 using Revit.GeometryConversion;
-
 using RevitServices.Persistence;
 using RevitServices.Transactions;
 using DynamoUnits;
@@ -39,7 +34,7 @@ namespace Revit.Elements
         /// <summary>
         /// Internal constructor for a FamilyInstance
         /// </summary>
-        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, XYZ pos,
+        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.XYZ pos,
             Autodesk.Revit.DB.Level level)
         {
             SafeInit(() => InitFamilyInstance(fs, pos, level));
@@ -48,17 +43,17 @@ namespace Revit.Elements
         /// <summary>
         /// Internal constructor for a FamilyInstance
         /// </summary>
-        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, XYZ pos)
+        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.XYZ pos)
         {
             SafeInit(() => InitFamilyInstance(fs, pos));
         }
 
-        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Reference reference, Line pos)
+        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Reference reference, Autodesk.Revit.DB.Line pos)
         {
             SafeInit(() => InitFamilyInstance(fs, reference, pos));
         }
 
-        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Reference reference, XYZ location, XYZ referenceDirection)
+        internal FamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Reference reference, Autodesk.Revit.DB.XYZ location, Autodesk.Revit.DB.XYZ referenceDirection)
         {
             SafeInit(() => InitFamilyInstance(fs, reference, location, referenceDirection));
         }
@@ -78,7 +73,7 @@ namespace Revit.Elements
         /// <summary>
         /// Initialize a FamilyInstance element
         /// </summary>
-        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, XYZ pos,
+        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.XYZ pos,
             Autodesk.Revit.DB.Level level)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
@@ -125,7 +120,7 @@ namespace Revit.Elements
         /// <summary>
         /// Initialize a FamilyInstance element
         /// </summary>
-        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, XYZ pos)
+        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.XYZ pos)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldFam =
@@ -147,18 +142,9 @@ namespace Revit.Elements
             if (!fs.IsActive)
                 fs.Activate();
 
-            Autodesk.Revit.DB.FamilyInstance fi;
-
-            if (Document.IsFamilyDocument)
-            {
-                fi = Document.FamilyCreate.NewFamilyInstance(pos, fs,
-                    Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
-            }
-            else
-            {
-                fi = Document.Create.NewFamilyInstance(
-                    pos, fs, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
-            }
+            var fi = Document.IsFamilyDocument
+                ? Document.FamilyCreate.NewFamilyInstance(pos, fs, Autodesk.Revit.DB.Structure.StructuralType.NonStructural)
+                : Document.Create.NewFamilyInstance(pos, fs, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
 
             InternalSetFamilyInstance(fi);
 
@@ -167,7 +153,7 @@ namespace Revit.Elements
             ElementBinder.SetElementForTrace(InternalElement);
         }
 
-        private void InitFamilyInstance(FamilySymbol fs, Reference reference, Line pos)
+        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Reference reference, Autodesk.Revit.DB.Line pos)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldFam =
@@ -189,16 +175,9 @@ namespace Revit.Elements
             if (!fs.IsActive)
                 fs.Activate();
 
-            Autodesk.Revit.DB.FamilyInstance fi;
-
-            if (Document.IsFamilyDocument)
-            {
-                fi = Document.FamilyCreate.NewFamilyInstance(reference, pos, fs);
-            }
-            else
-            {
-                fi = Document.Create.NewFamilyInstance(reference, pos, fs);
-            }
+            var fi = Document.IsFamilyDocument 
+                ? Document.FamilyCreate.NewFamilyInstance(reference, pos, fs) 
+                : Document.Create.NewFamilyInstance(reference, pos, fs);
 
             InternalSetFamilyInstance(fi);
 
@@ -207,8 +186,8 @@ namespace Revit.Elements
             ElementBinder.SetElementForTrace(InternalElement);
         }
 
-        private void InitFamilyInstance(FamilySymbol fs, Reference reference, XYZ location,
-            XYZ referenceDirection)
+        private void InitFamilyInstance(Autodesk.Revit.DB.FamilySymbol fs, Autodesk.Revit.DB.Reference reference, Autodesk.Revit.DB.XYZ location,
+            Autodesk.Revit.DB.XYZ referenceDirection)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldFam =
@@ -230,16 +209,9 @@ namespace Revit.Elements
             if (!fs.IsActive)
                 fs.Activate();
 
-            Autodesk.Revit.DB.FamilyInstance fi;
-
-            if (Document.IsFamilyDocument)
-            {
-                fi = Document.FamilyCreate.NewFamilyInstance(reference,  location, referenceDirection, fs);
-            }
-            else
-            {
-                fi = Document.Create.NewFamilyInstance(reference, location, referenceDirection, fs);
-            }
+            var fi = Document.IsFamilyDocument 
+                ? Document.FamilyCreate.NewFamilyInstance(reference,  location, referenceDirection, fs) 
+                : Document.Create.NewFamilyInstance(reference, location, referenceDirection, fs);
 
             InternalSetFamilyInstance(fi);
 
@@ -259,26 +231,26 @@ namespace Revit.Elements
             TransactionManager.Instance.EnsureInTransaction(Document);
 
             // http://thebuildingcoder.typepad.com/blog/2011/01/family-instance-missing-level-property.html
-            InternalFamilyInstance.get_Parameter(BuiltInParameter.FAMILY_LEVEL_PARAM).Set(level.Id);
+            InternalFamilyInstance.get_Parameter(Autodesk.Revit.DB.BuiltInParameter.FAMILY_LEVEL_PARAM).Set(level.Id);
 
             TransactionManager.Instance.TransactionTaskDone();
         }
 
-        private void InternalSetPosition(XYZ fi)
+        private void InternalSetPosition(Autodesk.Revit.DB.XYZ fi)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            var lp = InternalFamilyInstance.Location as LocationPoint;
+            var lp = InternalFamilyInstance.Location as Autodesk.Revit.DB.LocationPoint;
             if (lp != null && !lp.Point.IsAlmostEqualTo(fi)) lp.Point = fi;
 
             TransactionManager.Instance.TransactionTaskDone();
         }
 
-        private void InternalSetPosition(Curve pos)
+        private void InternalSetPosition(Autodesk.Revit.DB.Curve pos)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
-            var lp = InternalFamilyInstance.Location as LocationCurve;
+            var lp = InternalFamilyInstance.Location as Autodesk.Revit.DB.LocationCurve;
 
             if (lp != null && lp.Curve != pos) lp.Curve = pos;
 
@@ -294,6 +266,7 @@ namespace Revit.Elements
         /// <search>
         /// symbol
         /// </search>
+        [Obsolete("Use Element.ElementType instead.")]
         public new FamilyType Type
         {
             // NOTE: Because AbstractFamilyInstance is not visible in the library
@@ -329,8 +302,8 @@ namespace Revit.Elements
         /// <summary>
         /// Place a Revit FamilyInstance given the FamilyType (also known as the FamilySymbol in the Revit API) and its coordinates in world space
         /// </summary>
-        /// <param name="familyType"></param>
-        /// <param name="point"></param>
+        /// <param name="familyType">Family Type. Also called Family Symbol.</param>
+        /// <param name="point">Point in meters.</param>
         /// <returns></returns>
         public static FamilyInstance ByPoint(FamilyType familyType, Point point)
         {
@@ -353,7 +326,7 @@ namespace Revit.Elements
         /// 
         /// Note: The FamilyPlacementType must be CurveBased and the input surface must be created from a Revit Face 
         /// </summary>
-        /// <param name="familyType"></param>
+        /// <param name="familyType">Family Type. Also called Family Symbol.</param>
         /// <param name="face">Surface geometry derived from a Revit face as reference element</param>
         /// <param name="line">A line on the face defining where the symbol is to be placed</param>
         /// <returns>FamilyInstance</returns>
@@ -373,7 +346,7 @@ namespace Revit.Elements
             }
             var reference = ElementFaceReference.TryGetFaceReference(face);
 
-            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference, (Line) line.ToRevitType());
+            return new FamilyInstance(familyType.InternalFamilySymbol, reference.InternalReference, (Autodesk.Revit.DB.Line) line.ToRevitType());
         }
 
         /// <summary>
@@ -382,7 +355,7 @@ namespace Revit.Elements
         /// 
         /// Note: The FamilyType should be workplane based and the input surface must be created from a Revit Face. The reference direction defines the rotation of the instance on the reference, and thus cannot be perpendicular to the face.
         /// </summary>
-        /// <param name="familyType"></param>
+        /// <param name="familyType">Family Type. Also called Family Symbol.</param>
         /// <param name="face">Surface geometry derived from a Revit face as reference element</param>
         /// <param name="location">Point on the face where the instance is to be placed</param>
         /// <param name="referenceDirection">A vector that defines the direction of placement of the family instance</param>
@@ -415,7 +388,7 @@ namespace Revit.Elements
         /// <summary>
         /// Place a Revit FamilyInstance given the FamilyType (also known as the FamilySymbol in the Revit API) and its coordinates in world space
         /// </summary>
-        /// <param name="familyType"></param>
+        /// <param name="familyType">Family Type. Also called Family Symbol.</param>
         /// <param name="x">X coordinate in meters</param>
         /// <param name="y">Y coordinate in meters</param>
         /// <param name="z">Z coordinate in meters</param>
@@ -435,9 +408,9 @@ namespace Revit.Elements
         /// <summary>
         /// Place a Revit FamilyInstance given the FamilyType (also known as the FamilySymbol in the Revit API), it's coordinates in world space, and the Level
         /// </summary>
-        /// <param name="familyType"></param>
-        /// <param name="point">Point in meters</param>
-        /// <param name="level"></param>
+        /// <param name="familyType">Family Type. Also called Family Symbol.</param>
+        /// <param name="point">Point in meters.</param>
+        /// <param name="level">Level to host Family Instance.</param>
         /// <returns></returns>
         public static FamilyInstance ByPointAndLevel(FamilyType familyType, Point point, Level level)
         {
@@ -452,7 +425,7 @@ namespace Revit.Elements
         /// <summary>
         /// Obtain a collection of FamilyInstances from the Revit Document and use them in the Dynamo graph
         /// </summary>
-        /// <param name="familyType"></param>
+        /// <param name="familyType">Family Type. Also called Family Symbol.</param>
         /// <returns></returns>
         /// <search>
         /// byfamilysymbol,ByFamilySymbol
@@ -512,8 +485,8 @@ namespace Revit.Elements
                     // TODO: This might need to change since its not clear if the Host element is revit owned or not.
                     // Currently there is no way of figuring this out, therefore the assumption is true (Revit owned)
                     return ElementWrapper.Wrap(this.InternalFamilyInstance.Host, true);
-                else
-                    throw new Exception(Properties.Resources.InvalidHost);
+
+                throw new Exception(Properties.Resources.InvalidHost);
             }
         }
 
@@ -531,12 +504,12 @@ namespace Revit.Elements
         /// <summary>
         /// Gets the family type of this family instance
         /// </summary>
-        public FamilyType GetType
-        { 
-            get
-            { 
-                return FamilyType.FromExisting(this.InternalFamilyInstance.Symbol, true);
-            }
+        [Obsolete("Use Element.ElementType instead.")]
+        public new FamilyType GetType
+        {
+            // NOTE: Because AbstractFamilyInstance is not visible in the library
+            //       we redefine this method on FamilyInstance
+            get { return base.Type; }
         }
 
         
@@ -550,19 +523,19 @@ namespace Revit.Elements
         {
             if (this == null)
             {
-                throw new ArgumentNullException("familyInstance");
+                throw new ArgumentNullException("degree");
             }
 
             var oldTransform = InternalGetTransform();
             double[] oldRotationAngles;
             TransformUtils.ExtractEularAnglesFromTransform(oldTransform, out oldRotationAngles);
-            double newRotationAngle = degree * Math.PI / 180;
+            var newRotationAngle = degree * Math.PI / 180;
 
             if (!oldRotationAngles[0].AlmostEquals(newRotationAngle, 1.0e-6))
             {
-                double rotateAngle = newRotationAngle - oldRotationAngles[0];
-                var axis = Line.CreateUnbound(oldTransform.Origin, oldTransform.BasisZ);
-                ElementTransformUtils.RotateElement(Document, new ElementId(Id), axis, -rotateAngle);
+                var rotateAngle = newRotationAngle - oldRotationAngles[0];
+                var axis = Autodesk.Revit.DB.Line.CreateUnbound(oldTransform.Origin, oldTransform.BasisZ);
+                Autodesk.Revit.DB.ElementTransformUtils.RotateElement(Document, new Autodesk.Revit.DB.ElementId(Id), axis, -rotateAngle);
             }
 
             TransactionManager.Instance.TransactionTaskDone();
@@ -578,7 +551,7 @@ namespace Revit.Elements
         /// Get the transform of the internal family instance
         /// </summary>
         /// <returns>The internal transform</returns>
-        private Transform InternalGetTransform()
+        private Autodesk.Revit.DB.Transform InternalGetTransform()
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 

--- a/src/Libraries/RevitNodes/Elements/StucturalFraming.cs
+++ b/src/Libraries/RevitNodes/Elements/StucturalFraming.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.Creation;
-using Autodesk.Revit.DB;
-
 using DynamoServices;
-
 using Revit.GeometryConversion;
-
 using RevitServices.Persistence;
 using RevitServices.Transactions;
 
@@ -191,21 +187,21 @@ namespace Revit.Elements
             //we do this by finding the angle between the z axis
             //and vector between the start of the beam and the target point
             //both projected onto the start plane of the beam.
-            var zAxis = new XYZ(0, 0, 1);
-            var yAxis = new XYZ(0, 1, 0);
+            var zAxis = new Autodesk.Revit.DB.XYZ(0, 0, 1);
+            var yAxis = new Autodesk.Revit.DB.XYZ(0, 1, 0);
 
             //flatten the beam line onto the XZ plane
             //using the start's z coordinate
             var start = curve.GetEndPoint(0);
             var end = curve.GetEndPoint(1);
-            var newEnd = new XYZ(end.X, end.Y, start.Z); //drop end point to plane
+            var newEnd = new Autodesk.Revit.DB.XYZ(end.X, end.Y, start.Z); //drop end point to plane
 
             //catch the case where the end is directly above
             //the start, creating a normal with zero length
             //in that case, use the Z axis
-            XYZ planeNormal = newEnd.IsAlmostEqualTo(start) ? zAxis : (newEnd - start).Normalize();
+            var planeNormal = newEnd.IsAlmostEqualTo(start) ? zAxis : (newEnd - start).Normalize();
 
-            double gamma = upVector.AngleOnPlaneTo(zAxis.IsAlmostEqualTo(planeNormal) ? yAxis : zAxis, planeNormal);
+            var gamma = upVector.AngleOnPlaneTo(zAxis.IsAlmostEqualTo(planeNormal) ? yAxis : zAxis, planeNormal);
 
             return new FamilyInstanceCreationData(curve, symbol, level, structuralType)
             {
@@ -232,8 +228,8 @@ namespace Revit.Elements
             // infinite loop. Check the framing's curve for similarity to the 
             // provided curve and update only if the two are different.
 
-            var locCurve = InternalFamilyInstance.Location as LocationCurve;
-            if (!CurveUtils.CurvesAreSimilar(locCurve.Curve, crv))
+            var locCurve = InternalFamilyInstance.Location as Autodesk.Revit.DB.LocationCurve;
+            if (locCurve != null && !CurveUtils.CurvesAreSimilar(locCurve.Curve, crv))
             {
                 locCurve.Curve = crv;
             }
@@ -247,12 +243,12 @@ namespace Revit.Elements
         /// <summary>
         /// Gets curve geometry from location of the specified structural element
         /// </summary>
-        new public Autodesk.DesignScript.Geometry.Curve Location
+        public new Autodesk.DesignScript.Geometry.Curve Location
         {
             get
             {
                 var location = this.InternalFamilyInstance.Location;
-                var crv = location as LocationCurve;
+                var crv = location as Autodesk.Revit.DB.LocationCurve;
                 if (null != crv && null != crv.Curve)
                     return crv.Curve.ToProtoType();
                 throw new Exception(Properties.Resources.InvalidElementLocation);
@@ -264,8 +260,21 @@ namespace Revit.Elements
         /// <search>
         /// symbol
         /// </search>
+        [Obsolete("Use Element.ElementType instead.")]
         public new FamilyType Type
         {    
+            // NOTE: Because AbstractFamilyInstance is not visible in the library
+            //       we redefine this method on FamilyInstance
+            get { return base.Type; }
+        }
+
+        // (Konrad) We had to add this call here because if we feed Structural Framing to
+        // FamilyInstance.GetType it tries to call StructuralFraming.GetType and that throws 
+        // an exception. These methods should not exist on either class, but rather on base Element.
+        [Obsolete("Use Element.ElementType instead.")]
+        [IsVisibleInDynamoLibrary(false)]
+        public new FamilyType GetType
+        {
             // NOTE: Because AbstractFamilyInstance is not visible in the library
             //       we redefine this method on FamilyInstance
             get { return base.Type; }
@@ -290,22 +299,22 @@ namespace Revit.Elements
         {
             if (curve == null)
             {
-                throw new System.ArgumentNullException("curve");
+                throw new ArgumentNullException("curve");
             }
 
             if (level == null)
             {
-                throw new System.ArgumentNullException("level");
+                throw new ArgumentNullException("level");
             }
 
             if (upVector == null)
             {
-                throw new System.ArgumentNullException("upVector");
+                throw new ArgumentNullException("upVector");
             }
 
             if (structuralFramingType == null)
             {
-                throw new System.ArgumentNullException("structuralFramingType");
+                throw new ArgumentNullException("structuralFramingType");
             }            
 
             return new StructuralFraming(curve.ToRevitType(), upVector.ToXyz(), level.InternalLevel,
@@ -319,21 +328,21 @@ namespace Revit.Elements
         /// <param name="level">The level with which you'd like the beam to be associated.</param>
         /// <param name="structuralFramingType">The structural framing type representing the beam.</param>
         /// <returns></returns>
-        public static StructuralFraming BeamByCurve(Autodesk.DesignScript.Geometry.Curve curve, Revit.Elements.Level level, Revit.Elements.FamilyType structuralFramingType)
+        public static StructuralFraming BeamByCurve(Autodesk.DesignScript.Geometry.Curve curve, Level level, FamilyType structuralFramingType)
         {
             if (curve == null)
             {
-                throw new System.ArgumentNullException("curve");
+                throw new ArgumentNullException("curve");
             }
 
             if (level == null)
             {
-                throw new System.ArgumentNullException("level");
+                throw new ArgumentNullException("level");
             }
 
             if (structuralFramingType == null)
             {
-                throw new System.ArgumentNullException("structuralFramingType");
+                throw new ArgumentNullException("structuralFramingType");
             }
 
             return new StructuralFraming(curve.ToRevitType(), level.InternalLevel, Autodesk.Revit.DB.Structure.StructuralType.Beam, structuralFramingType.InternalFamilySymbol);
@@ -346,21 +355,21 @@ namespace Revit.Elements
         /// <param name="level">The level with which you'd like the brace to be associated.</param>
         /// <param name="structuralFramingType">The structural framing type representing the brace.</param>
         /// <returns></returns>
-        public static StructuralFraming BraceByCurve(Autodesk.DesignScript.Geometry.Curve curve, Revit.Elements.Level level, Revit.Elements.FamilyType structuralFramingType)
+        public static StructuralFraming BraceByCurve(Autodesk.DesignScript.Geometry.Curve curve, Level level, FamilyType structuralFramingType)
         {
             if (curve == null)
             {
-                throw new System.ArgumentNullException("curve");
+                throw new ArgumentNullException("curve");
             }
 
             if (level == null)
             {
-                throw new System.ArgumentNullException("level");
+                throw new ArgumentNullException("level");
             }
 
             if (structuralFramingType == null)
             {
-                throw new System.ArgumentNullException("structuralFramingType");
+                throw new ArgumentNullException("structuralFramingType");
             }
 
             return new StructuralFraming(curve.ToRevitType(), level.InternalLevel, Autodesk.Revit.DB.Structure.StructuralType.Brace, structuralFramingType.InternalFamilySymbol);
@@ -374,21 +383,21 @@ namespace Revit.Elements
         /// <param name="structuralColumnType">The structural column type representing the column.</param>
         /// <returns></returns>
         public static StructuralFraming ColumnByCurve(
-            Autodesk.DesignScript.Geometry.Curve curve, Revit.Elements.Level level, Revit.Elements.FamilyType structuralColumnType)
+            Autodesk.DesignScript.Geometry.Curve curve, Level level, FamilyType structuralColumnType)
         {
             if (curve == null)
             {
-                throw new System.ArgumentNullException("curve");
+                throw new ArgumentNullException("curve");
             }
 
             if (level == null)
             {
-                throw new System.ArgumentNullException("level");
+                throw new ArgumentNullException("level");
             }
 
             if (structuralColumnType == null)
             {
-                throw new System.ArgumentNullException("structuralColumnType");
+                throw new ArgumentNullException("structuralColumnType");
             }
 
             var start = curve.PointAtParameter(0);


### PR DESCRIPTION
### Purpose
Cherry-picking #1780 for Revit 2018

### Reviewers
@sm6srw
