### PR TITLE
As a D4R dev, I want D4R UI nodes to deserialize w/o adding duplicate ports (Cherry Picked)

### DIFF
--- a/src/DynamoRevit/Models/RevitNodeModel.cs
+++ b/src/DynamoRevit/Models/RevitNodeModel.cs
@@ -1,8 +1,14 @@
-﻿using Dynamo.Graph.Nodes;
+﻿using System.Collections.Generic;
+using Dynamo.Graph.Nodes;
+using Newtonsoft.Json;
 
 namespace Dynamo.Applications.Models
 {
     public abstract class RevitNodeModel : NodeModel
     {
+        public RevitNodeModel() { }
+
+        [JsonConstructor]
+        public RevitNodeModel(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
     }
 }

--- a/src/Libraries/RevitNodesUI/Elements.cs
+++ b/src/Libraries/RevitNodesUI/Elements.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Newtonsoft.Json;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
 using Autodesk.Revit.DB.Electrical;
@@ -36,6 +37,15 @@ namespace DSRevitNodesUI
     public abstract class ElementsQueryBase : RevitNodeModel
     {
         protected ElementsQueryBase()
+        {
+            var u = RevitServicesUpdater.Instance;
+            u.ElementsUpdated += OnElementsUpdated;
+
+            ShouldDisplayPreviewCore = true;
+        }
+
+        [JsonConstructor]
+        public ElementsQueryBase(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
             var u = RevitServicesUpdater.Instance;
             u.ElementsUpdated += OnElementsUpdated;
@@ -87,6 +97,11 @@ namespace DSRevitNodesUI
             RegisterAllPorts();
         }
 
+        [JsonConstructor]
+        public ElementsOfFamilyType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+        }
+
         public override IEnumerable<AssociativeNode> BuildOutputAst(
             List<AssociativeNode> inputAstNodes)
         {
@@ -109,6 +124,11 @@ namespace DSRevitNodesUI
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("element type", Properties.Resources.PortDataElementTypeToolTip)));
             OutPorts.Add(new PortModel(PortType.Output, this, new PortData("elements", Properties.Resources.PortDataAllElementsInDocumentToolTip)));
             RegisterAllPorts();
+        }
+
+        [JsonConstructor]
+        public ElementsOfType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(
@@ -135,6 +155,11 @@ namespace DSRevitNodesUI
             RegisterAllPorts();
         }
 
+        [JsonConstructor]
+        public ElementsOfCategory(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+        }
+
         public override IEnumerable<AssociativeNode> BuildOutputAst(
             List<AssociativeNode> inputAstNodes)
         {
@@ -157,6 +182,11 @@ namespace DSRevitNodesUI
             OutPorts.Add(new PortModel(PortType.Output, this, new PortData("Elements", Properties.Resources.PortDataElementAtLevelToolTip)));
 
             RegisterAllPorts();
+        }
+
+        [JsonConstructor]
+        public ElementsAtLevel(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
         }
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(
@@ -183,6 +213,16 @@ namespace DSRevitNodesUI
             OutPorts.Add(new PortModel(PortType.Output, this, new PortData("elements", Properties.Resources.PortDataAllVisibleElementsToolTip)));
             RegisterAllPorts();
 
+            DynamoRevitApp.EventHandlerProxy.ViewActivated += RevitDynamoModel_RevitDocumentChanged;
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened += RevitDynamoModel_RevitDocumentChanged;
+
+            RevitServicesUpdater.Instance.ElementsUpdated += RevitServicesUpdaterOnElementsUpdated;
+            RevitDynamoModel_RevitDocumentChanged(null, null);
+        }
+
+        [JsonConstructor]
+        public ElementsInView(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
             DynamoRevitApp.EventHandlerProxy.ViewActivated += RevitDynamoModel_RevitDocumentChanged;
             DynamoRevitApp.EventHandlerProxy.DocumentOpened += RevitDynamoModel_RevitDocumentChanged;
 

--- a/src/Libraries/RevitNodesUI/GenericClasses.cs
+++ b/src/Libraries/RevitNodesUI/GenericClasses.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 using Autodesk.DesignScript.Geometry;
 using Autodesk.DesignScript.Runtime;
 using DSRevitNodesUI;
@@ -11,6 +12,7 @@ using RevitServices.Transactions;
 
 using Dynamo.Utilities;
 using Dynamo.Models;
+using Dynamo.Graph.Nodes;
 using ProtoCore.AST.AssociativeAST;
 
 namespace DSRevitNodesUI
@@ -29,6 +31,13 @@ namespace DSRevitNodesUI
         /// <param name="name">Name of the Node</param>
         /// <param name="elementType">Type of Revit Element to display</param>
         public CustomRevitElementDropDown(string name, Type elementType) : base(name) { this.ElementType = elementType; PopulateDropDownItems(); }
+
+        [JsonConstructor]
+        public CustomRevitElementDropDown(string name, Type elementType, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base(name, inPorts, outPorts)
+        {
+            this.ElementType = elementType; PopulateDropDownItems();
+        }
 
         /// <summary>
         /// Type of Element
@@ -121,6 +130,13 @@ namespace DSRevitNodesUI
         /// <param name="name">Node Name</param>
         /// <param name="enumerationType">Type of Enumeration to Display</param>
         public CustomGenericEnumerationDropDown(string name, Type enumerationType) : base(name) { this.EnumerationType = enumerationType; PopulateDropDownItems(); }
+
+        [JsonConstructor]
+        public CustomGenericEnumerationDropDown(string name, Type enumerationType, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base(name, inPorts, outPorts)
+        {
+            this.EnumerationType = enumerationType; PopulateDropDownItems();
+        }
 
         /// <summary>
         /// Type of Enumeration

--- a/src/Libraries/RevitNodesUI/GenericClasses.cs
+++ b/src/Libraries/RevitNodesUI/GenericClasses.cs
@@ -30,13 +30,18 @@ namespace DSRevitNodesUI
         /// </summary>
         /// <param name="name">Name of the Node</param>
         /// <param name="elementType">Type of Revit Element to display</param>
-        public CustomRevitElementDropDown(string name, Type elementType) : base(name) { this.ElementType = elementType; PopulateDropDownItems(); }
+        public CustomRevitElementDropDown(string name, Type elementType) : base(name)
+        {
+            this.ElementType = elementType;
+            PopulateDropDownItems();
+        }
 
         [JsonConstructor]
         public CustomRevitElementDropDown(string name, Type elementType, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
             : base(name, inPorts, outPorts)
         {
-            this.ElementType = elementType; PopulateDropDownItems();
+            this.ElementType = elementType;
+            PopulateDropDownItems();
         }
 
         /// <summary>
@@ -129,13 +134,18 @@ namespace DSRevitNodesUI
         /// </summary>
         /// <param name="name">Node Name</param>
         /// <param name="enumerationType">Type of Enumeration to Display</param>
-        public CustomGenericEnumerationDropDown(string name, Type enumerationType) : base(name) { this.EnumerationType = enumerationType; PopulateDropDownItems(); }
+        public CustomGenericEnumerationDropDown(string name, Type enumerationType) : base(name)
+        {
+            this.EnumerationType = enumerationType;
+            PopulateDropDownItems();
+        }
 
         [JsonConstructor]
         public CustomGenericEnumerationDropDown(string name, Type enumerationType, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
             : base(name, inPorts, outPorts)
         {
-            this.EnumerationType = enumerationType; PopulateDropDownItems();
+            this.EnumerationType = enumerationType;
+            PopulateDropDownItems();
         }
 
         /// <summary>

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -71,11 +71,12 @@ namespace DSRevitNodesUI
     public class FamilyTypes : RevitDropDownBase
     {
         private const string NO_FAMILY_TYPES = "No family types available.";
+        private const string outputName = "Family Type";
 
-        public FamilyTypes() : base("Family Type") { }
+        public FamilyTypes() : base(outputName) { }
 
         [JsonConstructor]
-        public FamilyTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Family Type", inPorts, outPorts)
+        public FamilyTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(outputName, inPorts, outPorts)
         {
         }
 
@@ -138,19 +139,20 @@ namespace DSRevitNodesUI
     public class FamilyInstanceParameters : RevitDropDownBase 
     {
         private const string noFamilyParameters = "No family parameters available.";
+        private const string outputName = "Parameter";
         private Element element;
         private ElementId storedId = null;
         internal EngineController EngineController { get; set; }
 
         public FamilyInstanceParameters()
-            : base("Parameter") 
+            : base(outputName) 
         {
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("f", Properties.Resources.PortDataFamilySymbolToolTip)));
             PropertyChanged += OnPropertyChanged;
         }
 
         [JsonConstructor]
-        public FamilyInstanceParameters(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Parameter", inPorts, outPorts)
+        public FamilyInstanceParameters(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(outputName, inPorts, outPorts)
         {
             PropertyChanged += OnPropertyChanged;
         }
@@ -361,10 +363,12 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class FloorTypes : RevitDropDownBase
     {
-        public FloorTypes() : base("Floor Type") { }
+        private const string outputName = "Floor Type";
+
+        public FloorTypes() : base(outputName) { }
 
         [JsonConstructor]
-        public FloorTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Floor Type", inPorts, outPorts) { }
+        public FloorTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(outputName, inPorts, outPorts) { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {
@@ -412,10 +416,12 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class WallTypes : RevitDropDownBase
     {
-        public WallTypes() : base("Wall Type") { }
+        private const string outputName = "Wall Type";
+
+        public WallTypes() : base(outputName) { }
 
         [JsonConstructor]
-        public WallTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Wall Type", inPorts, outPorts) { }
+        public WallTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(outputName, inPorts, outPorts) { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {
@@ -463,10 +469,12 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class PerformanceAdviserRules : RevitDropDownBase
     {
-        public PerformanceAdviserRules() : base("Performance Adviser Rules") { }
+        private const string outputName = "Performance Adviser Rules";
+
+        public PerformanceAdviserRules() : base(outputName) { }
 
         [JsonConstructor]
-        public PerformanceAdviserRules(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Performance Adviser Rules", inPorts, outPorts) { }
+        public PerformanceAdviserRules(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(outputName, inPorts, outPorts) { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {
@@ -668,11 +676,12 @@ namespace DSRevitNodesUI
     public class Levels : RevitDropDownBase
     {
         private const string noLevels = "No levels available.";
+        private const string outputName = "Levels";
 
-        public Levels() : base("Levels") { }
+        public Levels() : base(outputName) { }
 
         [JsonConstructor]
-        public Levels(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Levels", inPorts, outPorts) { }
+        public Levels(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(outputName, inPorts, outPorts) { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {
@@ -786,12 +795,14 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class StructuralFramingTypes : AllElementsInBuiltInCategory
     {
+        private const string outputName = "Framing Types";
+
         public StructuralFramingTypes()
-            : base(BuiltInCategory.OST_StructuralFraming, "Framing Types", Properties.Resources.DropDownNoFramingType){}
+            : base(BuiltInCategory.OST_StructuralFraming, outputName, Properties.Resources.DropDownNoFramingType){}
 
         [JsonConstructor]
         public StructuralFramingTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base(BuiltInCategory.OST_StructuralFraming, "Framing Types", Properties.Resources.DropDownNoFramingType, inPorts, outPorts) { }
+            : base(BuiltInCategory.OST_StructuralFraming, outputName, Properties.Resources.DropDownNoFramingType, inPorts, outPorts) { }
     }
 
     [NodeName("Structural Column Types")]
@@ -800,12 +811,14 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class StructuralColumnTypes : AllElementsInBuiltInCategory
     {
+        private const string outputName = "Column Types";
+
         public StructuralColumnTypes()
-            : base(BuiltInCategory.OST_StructuralColumns, "Column Types", Properties.Resources.DropDownNoColumnType){}
+            : base(BuiltInCategory.OST_StructuralColumns, outputName, Properties.Resources.DropDownNoColumnType){}
 
         [JsonConstructor]
         public StructuralColumnTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base(BuiltInCategory.OST_StructuralColumns, "Column Types", Properties.Resources.DropDownNoColumnType, inPorts, outPorts) { }
+            : base(BuiltInCategory.OST_StructuralColumns, outputName, Properties.Resources.DropDownNoColumnType, inPorts, outPorts) { }
     }
 
     [NodeName("Spacing Rule Layout")]
@@ -858,10 +871,12 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class Views : RevitDropDownBase
     {
-        public Views() : base("Views") { }
+        private const string outputName = "Views";
+
+        public Views() : base(outputName) { }
 
         [JsonConstructor]
-        public Views(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Views", inPorts, outPorts) { }
+        public Views(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(outputName, inPorts, outPorts) { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Xml;
+using Newtonsoft.Json;
 using Autodesk.Revit.DB;
 using CoreNodeModels;
 using DSCore;
@@ -45,6 +46,12 @@ namespace DSRevitNodesUI
             DynamoRevitApp.EventHandlerProxy.DocumentOpened += Controller_RevitDocumentChanged;
         }
 
+        [JsonConstructor]
+        public RevitDropDownBase(string value, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(value, inPorts, outPorts)
+        {
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened += Controller_RevitDocumentChanged;
+        }
+
         void Controller_RevitDocumentChanged(object sender, EventArgs e)
         {
             PopulateItems();
@@ -66,6 +73,11 @@ namespace DSRevitNodesUI
         private const string NO_FAMILY_TYPES = "No family types available.";
 
         public FamilyTypes() : base("Family Type") { }
+
+        [JsonConstructor]
+        public FamilyTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Family Type", inPorts, outPorts)
+        {
+        }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {
@@ -134,6 +146,12 @@ namespace DSRevitNodesUI
             : base("Parameter") 
         {
             InPorts.Add(new PortModel(PortType.Input, this, new PortData("f", Properties.Resources.PortDataFamilySymbolToolTip)));
+            PropertyChanged += OnPropertyChanged;
+        }
+
+        [JsonConstructor]
+        public FamilyInstanceParameters(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Parameter", inPorts, outPorts)
+        {
             PropertyChanged += OnPropertyChanged;
         }
 
@@ -343,9 +361,10 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class FloorTypes : RevitDropDownBase
     {
-        
-
         public FloorTypes() : base("Floor Type") { }
+
+        [JsonConstructor]
+        public FloorTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Floor Type", inPorts, outPorts) { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {
@@ -393,9 +412,10 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class WallTypes : RevitDropDownBase
     {
- 
-
         public WallTypes() : base("Wall Type") { }
+
+        [JsonConstructor]
+        public WallTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Wall Type", inPorts, outPorts) { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {
@@ -444,6 +464,9 @@ namespace DSRevitNodesUI
     public class PerformanceAdviserRules : RevitDropDownBase
     {
         public PerformanceAdviserRules() : base("Performance Adviser Rules") { }
+
+        [JsonConstructor]
+        public PerformanceAdviserRules(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Performance Adviser Rules", inPorts, outPorts) { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {
@@ -504,6 +527,12 @@ namespace DSRevitNodesUI
             OutPorts[0] = new PortModel(PortType.Output, this, 
                 new PortData("Category", Properties.Resources.PortDataCategoriesToolTip, existing.DefaultValue));
             OutPorts[0].GUID = existing.GUID;
+        }
+
+        [JsonConstructor]
+        public Categories(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+            // Verify additional information for output ports is not required here!
         }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
@@ -642,6 +671,9 @@ namespace DSRevitNodesUI
 
         public Levels() : base("Levels") { }
 
+        [JsonConstructor]
+        public Levels(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Levels", inPorts, outPorts) { }
+
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {
             Items.Clear();
@@ -689,6 +721,17 @@ namespace DSRevitNodesUI
 
         internal AllElementsInBuiltInCategory(
             BuiltInCategory category, string outputMessage, string noTypesMessage) : base(outputMessage)
+        {
+            this.category = category;
+            this.noTypesMessage = noTypesMessage;
+            PopulateItems();
+        }
+
+        [JsonConstructor]
+        internal AllElementsInBuiltInCategory(
+            BuiltInCategory category, string outputMessage, string noTypesMessage,
+            IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base(outputMessage, inPorts, outPorts)
         {
             this.category = category;
             this.noTypesMessage = noTypesMessage;
@@ -745,6 +788,10 @@ namespace DSRevitNodesUI
     {
         public StructuralFramingTypes()
             : base(BuiltInCategory.OST_StructuralFraming, "Framing Types", Properties.Resources.DropDownNoFramingType){}
+
+        [JsonConstructor]
+        public StructuralFramingTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base(BuiltInCategory.OST_StructuralFraming, "Framing Types", Properties.Resources.DropDownNoFramingType, inPorts, outPorts) { }
     }
 
     [NodeName("Structural Column Types")]
@@ -755,13 +802,22 @@ namespace DSRevitNodesUI
     {
         public StructuralColumnTypes()
             : base(BuiltInCategory.OST_StructuralColumns, "Column Types", Properties.Resources.DropDownNoColumnType){}
+
+        [JsonConstructor]
+        public StructuralColumnTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base(BuiltInCategory.OST_StructuralColumns, "Column Types", Properties.Resources.DropDownNoColumnType, inPorts, outPorts) { }
     }
 
     [NodeName("Spacing Rule Layout")]
     [NodeCategory(BuiltinNodeCategories.REVIT_ELEMENTS_DIVIDEDPATH_ACTION)]
     [NodeDescription("SpacingRuleLayoutDescription", typeof(Properties.Resources))]
     [IsDesignScriptCompatible]
-    public class SpacingRuleLayouts : EnumAsInt<SpacingRuleLayout> {
+    public class SpacingRuleLayouts : EnumAsInt<SpacingRuleLayout>
+    {
+        public SpacingRuleLayouts() { }
+
+        [JsonConstructor]
+        public SpacingRuleLayouts(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
     }
 
     [NodeName("Element Types")]
@@ -770,6 +826,11 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class ElementTypes : AllChildrenOfType<Element>
     {
+        public ElementTypes() { }
+
+        [JsonConstructor]
+        public ElementTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts) { }
+
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             AssociativeNode node;
@@ -798,6 +859,9 @@ namespace DSRevitNodesUI
     public class Views : RevitDropDownBase
     {
         public Views() : base("Views") { }
+
+        [JsonConstructor]
+        public Views(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base("Views", inPorts, outPorts) { }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)
         {

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -532,7 +532,7 @@ namespace DSRevitNodesUI
         [JsonConstructor]
         public Categories(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
         {
-            // Verify additional information for output ports is not required here!
+            // TODO verify additional information for output ports is not required here!
         }
 
         protected override SelectionState PopulateItemsCore(string currentSelection)

--- a/src/Libraries/RevitNodesUI/RevitTypes.cs
+++ b/src/Libraries/RevitNodesUI/RevitTypes.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 using Autodesk.DesignScript.Geometry;
 using Autodesk.DesignScript.Runtime;
 using DSRevitNodesUI;
@@ -26,6 +27,10 @@ namespace DSRevitNodesUI
     public class RevitPhases : CustomRevitElementDropDown
     {
         public RevitPhases() : base("Phase", typeof(Autodesk.Revit.DB.Phase)) { }
+
+        [JsonConstructor]
+        public RevitPhases(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Phase", typeof(Autodesk.Revit.DB.Phase), inPorts, outPorts) { }
     }
 
     [NodeName("Select Revision")]
@@ -35,6 +40,10 @@ namespace DSRevitNodesUI
     public class RevitRevisions : CustomRevitElementDropDown
     {
         public RevitRevisions() : base("Revision", typeof(Autodesk.Revit.DB.Revision)) { }
+
+        [JsonConstructor]
+        public RevitRevisions(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Revision", typeof(Autodesk.Revit.DB.Revision), inPorts, outPorts) { }
     }
 
     [NodeName("Select Filled Region Type")]
@@ -44,6 +53,10 @@ namespace DSRevitNodesUI
     public class FilledRegionTypes : CustomRevitElementDropDown
     {
         public FilledRegionTypes() : base("FilledRegionType", typeof(Autodesk.Revit.DB.FilledRegionType)) { }
+
+        [JsonConstructor]
+        public FilledRegionTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("FilledRegionType", typeof(Autodesk.Revit.DB.FilledRegionType), inPorts, outPorts) { }
     }
 
     [NodeName("Select Rule Type")]
@@ -53,6 +66,10 @@ namespace DSRevitNodesUI
     public class RuleTypes : CustomGenericEnumerationDropDown
     {
         public RuleTypes() : base("RuleType", typeof(Revit.Filter.FilterRule.RuleType)) { }
+
+        [JsonConstructor]
+        public RuleTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("RuleType", typeof(Revit.Filter.FilterRule.RuleType), inPorts, outPorts) { }
     }
 
     [NodeName("Select Revision Numbering")]
@@ -62,6 +79,10 @@ namespace DSRevitNodesUI
     public class RevisionNumbering : CustomGenericEnumerationDropDown
     {
         public RevisionNumbering() : base("Revision Numbering", typeof(Autodesk.Revit.DB.RevisionNumbering)) { }
+
+        [JsonConstructor]
+        public RevisionNumbering(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Revision Numbering", typeof(Autodesk.Revit.DB.RevisionNumbering), inPorts, outPorts) { }
     }
 
     [NodeName("Select Revision Number Type")]
@@ -71,6 +92,10 @@ namespace DSRevitNodesUI
     public class RevisionNumberType : CustomGenericEnumerationDropDown
     {
         public RevisionNumberType() : base("Revision Number Type", typeof(Autodesk.Revit.DB.RevisionNumberType)) { }
+
+        [JsonConstructor]
+        public RevisionNumberType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Revision Number Type", typeof(Autodesk.Revit.DB.RevisionNumberType), inPorts, outPorts) { }
     }
 
 
@@ -81,6 +106,10 @@ namespace DSRevitNodesUI
     public class ParameterType : CustomGenericEnumerationDropDown
     {
         public ParameterType() : base("Parameter Type", typeof(Autodesk.Revit.DB.ParameterType)) { }
+
+        [JsonConstructor]
+        public ParameterType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Parameter Type", typeof(Autodesk.Revit.DB.ParameterType), inPorts, outPorts) { }
     }
 
     [NodeName("Select BuiltIn Parameter Group")]
@@ -90,6 +119,10 @@ namespace DSRevitNodesUI
     public class BuiltInParameterGroup : CustomGenericEnumerationDropDown
     {
         public BuiltInParameterGroup() : base("BuiltIn Parameter Group", typeof(Autodesk.Revit.DB.BuiltInParameterGroup)) { }
+
+        [JsonConstructor]
+        public BuiltInParameterGroup(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("BuiltIn Parameter Group", typeof(Autodesk.Revit.DB.BuiltInParameterGroup), inPorts, outPorts) { }
     }
 
     [NodeName("Select Revision Visibility")]
@@ -99,6 +132,10 @@ namespace DSRevitNodesUI
     public class RevisionVisibility : CustomGenericEnumerationDropDown
     {
         public RevisionVisibility() : base("Revision Visibility", typeof(Autodesk.Revit.DB.RevisionVisibility)) { }
+
+        [JsonConstructor]
+        public RevisionVisibility(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Revision Visibility", typeof(Autodesk.Revit.DB.RevisionVisibility), inPorts, outPorts) { }
     }
 
     [NodeName("Select Direct Shape Room Bounding Option")]
@@ -108,6 +145,10 @@ namespace DSRevitNodesUI
     public class DirectShapeRoomBoundingOption : CustomGenericEnumerationDropDown
     {
         public DirectShapeRoomBoundingOption() : base("Direct Shape Room Bounding Option", typeof(Autodesk.Revit.DB.DirectShapeRoomBoundingOption)) { }
+
+        [JsonConstructor]
+        public DirectShapeRoomBoundingOption(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Direct Shape Room Bounding Option", typeof(Autodesk.Revit.DB.DirectShapeRoomBoundingOption), inPorts, outPorts) { }
     }
 
     [NodeName("Detail Level")]
@@ -117,6 +158,10 @@ namespace DSRevitNodesUI
     public class DetailLevel : CustomGenericEnumerationDropDown
     {
         public DetailLevel() : base("Detail Level", typeof(Autodesk.Revit.DB.ViewDetailLevel)) { }
+
+        [JsonConstructor]
+        public DetailLevel(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Detail Level", typeof(Autodesk.Revit.DB.ViewDetailLevel), inPorts, outPorts) { }
     }
 
     [NodeName("Select Horizontal Text Alignment")]
@@ -126,6 +171,10 @@ namespace DSRevitNodesUI
     public class HorizontalAlignment : CustomGenericEnumerationDropDown
     {
         public HorizontalAlignment() : base("Horizontal Alignment", typeof(Autodesk.Revit.DB.HorizontalAlignmentStyle)) { }
+
+        [JsonConstructor]
+        public HorizontalAlignment(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Horizontal Alignment", typeof(Autodesk.Revit.DB.HorizontalAlignmentStyle), inPorts, outPorts) { }
     }
 
     [NodeName("Select Vertical Text Alignment")]
@@ -135,6 +184,10 @@ namespace DSRevitNodesUI
     public class VerticalAlignment : CustomGenericEnumerationDropDown
     {
         public VerticalAlignment() : base("Vertical Alignment", typeof(Autodesk.Revit.DB.VerticalAlignmentStyle)) { }
+
+        [JsonConstructor]
+        public VerticalAlignment(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Vertical Alignment", typeof(Autodesk.Revit.DB.VerticalAlignmentStyle), inPorts, outPorts) { }
     }
     
     [NodeName("Wall Location")]
@@ -144,6 +197,10 @@ namespace DSRevitNodesUI
     public class WallLocation : CustomGenericEnumerationDropDown
     {
         public WallLocation() : base("Wall Location", typeof(Autodesk.Revit.DB.WallLocationLine)) { }
+
+        [JsonConstructor]
+        public WallLocation(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("Wall Location", typeof(Autodesk.Revit.DB.WallLocationLine), inPorts, outPorts) { }
     }
 
 
@@ -154,6 +211,10 @@ namespace DSRevitNodesUI
     public class ScheduleTypes : CustomGenericEnumerationDropDown
     {
         public ScheduleTypes() : base("ScheduleType", typeof(Revit.Elements.Views.ScheduleView.ScheduleType)) { }
+
+        [JsonConstructor]
+        public ScheduleTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("ScheduleType", typeof(Revit.Elements.Views.ScheduleView.ScheduleType), inPorts, outPorts) { }
     }
 
     [NodeName("Export Column Headers")]
@@ -163,6 +224,10 @@ namespace DSRevitNodesUI
     public class ExportColumnHeaders : CustomGenericEnumerationDropDown
     {
         public ExportColumnHeaders() : base("ColumnHeaders", typeof(Revit.Schedules.ScheduleExportOptions.ExportColumnHeaders)) { }
+
+        [JsonConstructor]
+        public ExportColumnHeaders(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("ColumnHeaders", typeof(Revit.Schedules.ScheduleExportOptions.ExportColumnHeaders), inPorts, outPorts) { }
     }
 
     [NodeName("Export Text Qualifier")]
@@ -172,6 +237,10 @@ namespace DSRevitNodesUI
     public class ExportTextQualifier : CustomGenericEnumerationDropDown
     {
         public ExportTextQualifier() : base("TextQualifier", typeof(Revit.Schedules.ScheduleExportOptions.ExportTextQualifier)) { }
+
+        [JsonConstructor]
+        public ExportTextQualifier(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("TextQualifier", typeof(Revit.Schedules.ScheduleExportOptions.ExportTextQualifier), inPorts, outPorts) { }
     }
 
     [NodeName("Fill Patterns")]
@@ -181,6 +250,10 @@ namespace DSRevitNodesUI
     public class FillPatterns : CustomRevitElementDropDown
     {
         public FillPatterns() : base("FillPattern", typeof(Autodesk.Revit.DB.FillPatternElement)) { }
+
+        [JsonConstructor]
+        public FillPatterns(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("FillPattern", typeof(Autodesk.Revit.DB.FillPatternElement), inPorts, outPorts) { }
     }
 
     [NodeName("Fill Pattern Targets")]
@@ -190,6 +263,10 @@ namespace DSRevitNodesUI
     public class FillPatternTargets : CustomGenericEnumerationDropDown
     {
         public FillPatternTargets() : base("FillPatternTarget", typeof(Autodesk.Revit.DB.FillPatternTarget)) { }
+
+        [JsonConstructor]
+        public FillPatternTargets(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("FillPatternTarget", typeof(Autodesk.Revit.DB.FillPatternTarget), inPorts, outPorts) { }
     }
 
     [NodeName("Line Patterns")]
@@ -199,6 +276,10 @@ namespace DSRevitNodesUI
     public class LinePatterns : CustomRevitElementDropDown
     {
         public LinePatterns() : base("LinePattern", typeof(Autodesk.Revit.DB.LinePatternElement)) { }
+
+        [JsonConstructor]
+        public LinePatterns(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("LinePattern", typeof(Autodesk.Revit.DB.LinePatternElement), inPorts, outPorts) { }
     }
 
     [NodeName("Schedule Filter Type")]
@@ -208,5 +289,9 @@ namespace DSRevitNodesUI
     public class ScheduleFilterType : CustomGenericEnumerationDropDown
     {
         public ScheduleFilterType() : base("FilterType", typeof(Autodesk.Revit.DB.ScheduleFilterType)) { }
+
+        [JsonConstructor]
+        public ScheduleFilterType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
+            : base("FilterType", typeof(Autodesk.Revit.DB.ScheduleFilterType), inPorts, outPorts) { }
     }
 }

--- a/src/Libraries/RevitNodesUI/RevitTypes.cs
+++ b/src/Libraries/RevitNodesUI/RevitTypes.cs
@@ -26,11 +26,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class RevitPhases : CustomRevitElementDropDown
     {
-        public RevitPhases() : base("Phase", typeof(Autodesk.Revit.DB.Phase)) { }
+        private const string outputName = "Phase";
+
+        public RevitPhases() : base(outputName, typeof(Autodesk.Revit.DB.Phase)) { }
 
         [JsonConstructor]
         public RevitPhases(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Phase", typeof(Autodesk.Revit.DB.Phase), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.Phase), inPorts, outPorts) { }
     }
 
     [NodeName("Select Revision")]
@@ -39,11 +41,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class RevitRevisions : CustomRevitElementDropDown
     {
-        public RevitRevisions() : base("Revision", typeof(Autodesk.Revit.DB.Revision)) { }
+        private const string outputName = "Revision";
+
+        public RevitRevisions() : base(outputName, typeof(Autodesk.Revit.DB.Revision)) { }
 
         [JsonConstructor]
         public RevitRevisions(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Revision", typeof(Autodesk.Revit.DB.Revision), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.Revision), inPorts, outPorts) { }
     }
 
     [NodeName("Select Filled Region Type")]
@@ -52,11 +56,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class FilledRegionTypes : CustomRevitElementDropDown
     {
-        public FilledRegionTypes() : base("FilledRegionType", typeof(Autodesk.Revit.DB.FilledRegionType)) { }
+        private const string outputName = "FilledRegionType";
+
+        public FilledRegionTypes() : base(outputName, typeof(Autodesk.Revit.DB.FilledRegionType)) { }
 
         [JsonConstructor]
         public FilledRegionTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("FilledRegionType", typeof(Autodesk.Revit.DB.FilledRegionType), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.FilledRegionType), inPorts, outPorts) { }
     }
 
     [NodeName("Select Rule Type")]
@@ -65,11 +71,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class RuleTypes : CustomGenericEnumerationDropDown
     {
-        public RuleTypes() : base("RuleType", typeof(Revit.Filter.FilterRule.RuleType)) { }
+        private const string outputName = "RuleType";
+
+        public RuleTypes() : base(outputName, typeof(Revit.Filter.FilterRule.RuleType)) { }
 
         [JsonConstructor]
         public RuleTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("RuleType", typeof(Revit.Filter.FilterRule.RuleType), inPorts, outPorts) { }
+            : base(outputName, typeof(Revit.Filter.FilterRule.RuleType), inPorts, outPorts) { }
     }
 
     [NodeName("Select Revision Numbering")]
@@ -78,11 +86,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class RevisionNumbering : CustomGenericEnumerationDropDown
     {
-        public RevisionNumbering() : base("Revision Numbering", typeof(Autodesk.Revit.DB.RevisionNumbering)) { }
+        private const string outputName = "Revision Numbering";
+
+        public RevisionNumbering() : base(outputName, typeof(Autodesk.Revit.DB.RevisionNumbering)) { }
 
         [JsonConstructor]
         public RevisionNumbering(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Revision Numbering", typeof(Autodesk.Revit.DB.RevisionNumbering), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.RevisionNumbering), inPorts, outPorts) { }
     }
 
     [NodeName("Select Revision Number Type")]
@@ -91,11 +101,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class RevisionNumberType : CustomGenericEnumerationDropDown
     {
-        public RevisionNumberType() : base("Revision Number Type", typeof(Autodesk.Revit.DB.RevisionNumberType)) { }
+        private const string outputName = "Revision Number Type";
+
+        public RevisionNumberType() : base(outputName, typeof(Autodesk.Revit.DB.RevisionNumberType)) { }
 
         [JsonConstructor]
         public RevisionNumberType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Revision Number Type", typeof(Autodesk.Revit.DB.RevisionNumberType), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.RevisionNumberType), inPorts, outPorts) { }
     }
 
 
@@ -105,11 +117,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class ParameterType : CustomGenericEnumerationDropDown
     {
-        public ParameterType() : base("Parameter Type", typeof(Autodesk.Revit.DB.ParameterType)) { }
+        private const string outputName = "Parameter Type";
+
+        public ParameterType() : base(outputName, typeof(Autodesk.Revit.DB.ParameterType)) { }
 
         [JsonConstructor]
         public ParameterType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Parameter Type", typeof(Autodesk.Revit.DB.ParameterType), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.ParameterType), inPorts, outPorts) { }
     }
 
     [NodeName("Select BuiltIn Parameter Group")]
@@ -118,11 +132,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class BuiltInParameterGroup : CustomGenericEnumerationDropDown
     {
-        public BuiltInParameterGroup() : base("BuiltIn Parameter Group", typeof(Autodesk.Revit.DB.BuiltInParameterGroup)) { }
+        private const string outputName = "BuiltIn Parameter Group";
+
+        public BuiltInParameterGroup() : base(outputName, typeof(Autodesk.Revit.DB.BuiltInParameterGroup)) { }
 
         [JsonConstructor]
         public BuiltInParameterGroup(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("BuiltIn Parameter Group", typeof(Autodesk.Revit.DB.BuiltInParameterGroup), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.BuiltInParameterGroup), inPorts, outPorts) { }
     }
 
     [NodeName("Select Revision Visibility")]
@@ -131,11 +147,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class RevisionVisibility : CustomGenericEnumerationDropDown
     {
-        public RevisionVisibility() : base("Revision Visibility", typeof(Autodesk.Revit.DB.RevisionVisibility)) { }
+        private const string outputName = "Revision Visibility";
+
+        public RevisionVisibility() : base(outputName, typeof(Autodesk.Revit.DB.RevisionVisibility)) { }
 
         [JsonConstructor]
         public RevisionVisibility(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Revision Visibility", typeof(Autodesk.Revit.DB.RevisionVisibility), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.RevisionVisibility), inPorts, outPorts) { }
     }
 
     [NodeName("Select Direct Shape Room Bounding Option")]
@@ -144,11 +162,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class DirectShapeRoomBoundingOption : CustomGenericEnumerationDropDown
     {
-        public DirectShapeRoomBoundingOption() : base("Direct Shape Room Bounding Option", typeof(Autodesk.Revit.DB.DirectShapeRoomBoundingOption)) { }
+        private const string outputName = "Direct Shape Room Bounding Option";
+
+        public DirectShapeRoomBoundingOption() : base(outputName, typeof(Autodesk.Revit.DB.DirectShapeRoomBoundingOption)) { }
 
         [JsonConstructor]
         public DirectShapeRoomBoundingOption(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Direct Shape Room Bounding Option", typeof(Autodesk.Revit.DB.DirectShapeRoomBoundingOption), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.DirectShapeRoomBoundingOption), inPorts, outPorts) { }
     }
 
     [NodeName("Detail Level")]
@@ -157,11 +177,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class DetailLevel : CustomGenericEnumerationDropDown
     {
-        public DetailLevel() : base("Detail Level", typeof(Autodesk.Revit.DB.ViewDetailLevel)) { }
+        private const string outputName = "Detail Level";
+
+        public DetailLevel() : base(outputName, typeof(Autodesk.Revit.DB.ViewDetailLevel)) { }
 
         [JsonConstructor]
         public DetailLevel(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Detail Level", typeof(Autodesk.Revit.DB.ViewDetailLevel), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.ViewDetailLevel), inPorts, outPorts) { }
     }
 
     [NodeName("Select Horizontal Text Alignment")]
@@ -170,11 +192,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class HorizontalAlignment : CustomGenericEnumerationDropDown
     {
-        public HorizontalAlignment() : base("Horizontal Alignment", typeof(Autodesk.Revit.DB.HorizontalAlignmentStyle)) { }
+        private const string outputName = "Horizontal Alignment";
+
+        public HorizontalAlignment() : base(outputName, typeof(Autodesk.Revit.DB.HorizontalAlignmentStyle)) { }
 
         [JsonConstructor]
         public HorizontalAlignment(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Horizontal Alignment", typeof(Autodesk.Revit.DB.HorizontalAlignmentStyle), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.HorizontalAlignmentStyle), inPorts, outPorts) { }
     }
 
     [NodeName("Select Vertical Text Alignment")]
@@ -183,11 +207,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class VerticalAlignment : CustomGenericEnumerationDropDown
     {
-        public VerticalAlignment() : base("Vertical Alignment", typeof(Autodesk.Revit.DB.VerticalAlignmentStyle)) { }
+        private const string outputName = "Vertical Alignment";
+
+        public VerticalAlignment() : base(outputName, typeof(Autodesk.Revit.DB.VerticalAlignmentStyle)) { }
 
         [JsonConstructor]
         public VerticalAlignment(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Vertical Alignment", typeof(Autodesk.Revit.DB.VerticalAlignmentStyle), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.VerticalAlignmentStyle), inPorts, outPorts) { }
     }
     
     [NodeName("Wall Location")]
@@ -196,11 +222,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class WallLocation : CustomGenericEnumerationDropDown
     {
-        public WallLocation() : base("Wall Location", typeof(Autodesk.Revit.DB.WallLocationLine)) { }
+        private const string outputName = "Wall Location";
+
+        public WallLocation() : base(outputName, typeof(Autodesk.Revit.DB.WallLocationLine)) { }
 
         [JsonConstructor]
         public WallLocation(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("Wall Location", typeof(Autodesk.Revit.DB.WallLocationLine), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.WallLocationLine), inPorts, outPorts) { }
     }
 
 
@@ -210,11 +238,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class ScheduleTypes : CustomGenericEnumerationDropDown
     {
-        public ScheduleTypes() : base("ScheduleType", typeof(Revit.Elements.Views.ScheduleView.ScheduleType)) { }
+        private const string outputName = "ScheduleType";
+
+        public ScheduleTypes() : base(outputName, typeof(Revit.Elements.Views.ScheduleView.ScheduleType)) { }
 
         [JsonConstructor]
         public ScheduleTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("ScheduleType", typeof(Revit.Elements.Views.ScheduleView.ScheduleType), inPorts, outPorts) { }
+            : base(outputName, typeof(Revit.Elements.Views.ScheduleView.ScheduleType), inPorts, outPorts) { }
     }
 
     [NodeName("Export Column Headers")]
@@ -223,11 +253,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class ExportColumnHeaders : CustomGenericEnumerationDropDown
     {
-        public ExportColumnHeaders() : base("ColumnHeaders", typeof(Revit.Schedules.ScheduleExportOptions.ExportColumnHeaders)) { }
+        private const string outputName = "ColumnHeaders";
+
+        public ExportColumnHeaders() : base(outputName, typeof(Revit.Schedules.ScheduleExportOptions.ExportColumnHeaders)) { }
 
         [JsonConstructor]
         public ExportColumnHeaders(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("ColumnHeaders", typeof(Revit.Schedules.ScheduleExportOptions.ExportColumnHeaders), inPorts, outPorts) { }
+            : base(outputName, typeof(Revit.Schedules.ScheduleExportOptions.ExportColumnHeaders), inPorts, outPorts) { }
     }
 
     [NodeName("Export Text Qualifier")]
@@ -236,11 +268,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class ExportTextQualifier : CustomGenericEnumerationDropDown
     {
-        public ExportTextQualifier() : base("TextQualifier", typeof(Revit.Schedules.ScheduleExportOptions.ExportTextQualifier)) { }
+        private const string outputName = "TextQualifier";
+
+        public ExportTextQualifier() : base(outputName, typeof(Revit.Schedules.ScheduleExportOptions.ExportTextQualifier)) { }
 
         [JsonConstructor]
         public ExportTextQualifier(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("TextQualifier", typeof(Revit.Schedules.ScheduleExportOptions.ExportTextQualifier), inPorts, outPorts) { }
+            : base(outputName, typeof(Revit.Schedules.ScheduleExportOptions.ExportTextQualifier), inPorts, outPorts) { }
     }
 
     [NodeName("Fill Patterns")]
@@ -249,11 +283,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class FillPatterns : CustomRevitElementDropDown
     {
-        public FillPatterns() : base("FillPattern", typeof(Autodesk.Revit.DB.FillPatternElement)) { }
+        private const string outputName = "FillPattern";
+
+        public FillPatterns() : base(outputName, typeof(Autodesk.Revit.DB.FillPatternElement)) { }
 
         [JsonConstructor]
         public FillPatterns(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("FillPattern", typeof(Autodesk.Revit.DB.FillPatternElement), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.FillPatternElement), inPorts, outPorts) { }
     }
 
     [NodeName("Fill Pattern Targets")]
@@ -262,11 +298,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class FillPatternTargets : CustomGenericEnumerationDropDown
     {
-        public FillPatternTargets() : base("FillPatternTarget", typeof(Autodesk.Revit.DB.FillPatternTarget)) { }
+        private const string outputName = "FillPatternTarget";
+
+        public FillPatternTargets() : base(outputName, typeof(Autodesk.Revit.DB.FillPatternTarget)) { }
 
         [JsonConstructor]
         public FillPatternTargets(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("FillPatternTarget", typeof(Autodesk.Revit.DB.FillPatternTarget), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.FillPatternTarget), inPorts, outPorts) { }
     }
 
     [NodeName("Line Patterns")]
@@ -275,11 +313,13 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class LinePatterns : CustomRevitElementDropDown
     {
-        public LinePatterns() : base("LinePattern", typeof(Autodesk.Revit.DB.LinePatternElement)) { }
+        private const string outputName = "LinePattern";
+
+        public LinePatterns() : base(outputName, typeof(Autodesk.Revit.DB.LinePatternElement)) { }
 
         [JsonConstructor]
         public LinePatterns(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("LinePattern", typeof(Autodesk.Revit.DB.LinePatternElement), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.LinePatternElement), inPorts, outPorts) { }
     }
 
     [NodeName("Schedule Filter Type")]
@@ -288,10 +328,12 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     public class ScheduleFilterType : CustomGenericEnumerationDropDown
     {
-        public ScheduleFilterType() : base("FilterType", typeof(Autodesk.Revit.DB.ScheduleFilterType)) { }
+        private const string outputName = "FilterType";
+
+        public ScheduleFilterType() : base(outputName, typeof(Autodesk.Revit.DB.ScheduleFilterType)) { }
 
         [JsonConstructor]
         public ScheduleFilterType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base("FilterType", typeof(Autodesk.Revit.DB.ScheduleFilterType), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.ScheduleFilterType), inPorts, outPorts) { }
     }
 }

--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -577,20 +577,23 @@ namespace Dynamo.Nodes
      IsVisibleInDynamoLibrary(false)]
     public class DSAnalysisResultSelection : ElementSelection<Element>
     {
+        private const string message = "Select an analysis result.";
+        private const string prefix = "Analysis Results";
+
         public DSAnalysisResultSelection()
             : base(
                 SelectionType.One,
                 SelectionObjectType.None,
-                "Select an analysis result.",
-                "Analysis Results") { }
+                message,
+                prefix) { }
 
         [JsonConstructor]
         public DSAnalysisResultSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                   SelectionType.One, 
-                  SelectionObjectType.None, 
-                  "Select an analysis result.", 
-                  "Analysis Results", 
+                  SelectionObjectType.None,
+                  message,
+                  prefix, 
                   selectionIdentifier, 
                   inPorts, 
                   outPorts) { }
@@ -600,20 +603,23 @@ namespace Dynamo.Nodes
      NodeDescription("SelectModelElementDescription", typeof(DSRevitNodesUI.Properties.Resources)), IsDesignScriptCompatible]
     public class DSModelElementSelection : ElementSelection<Element>
     {
+        private const string message = "Select Model Element";
+        private const string prefix = "Element";
+
         public DSModelElementSelection()
             : base(
                 SelectionType.One,
                 SelectionObjectType.None,
-                "Select Model Element",
-                "Element") { }
+                message,
+                prefix) { }
 
         [JsonConstructor]
         public DSModelElementSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.One,
                 SelectionObjectType.None,
-                "Select Model Element",
-                "Element",
+                message,
+                prefix,
                 selectionIdentifier,
                 inPorts,
                 outPorts) { }
@@ -623,20 +629,23 @@ namespace Dynamo.Nodes
      NodeDescription("SelectFaceDescription", typeof(DSRevitNodesUI.Properties.Resources)), IsDesignScriptCompatible]
     public class DSFaceSelection : ReferenceSelection
     {
+        private const string message = "Select a face.";
+        private const string prefix = "Face of Element Id";
+
         public DSFaceSelection()
             : base(
                 SelectionType.One,
                 SelectionObjectType.Face,
-                "Select a face.",
-                "Face of Element Id") { }
+                message,
+                prefix) { }
         
         [JsonConstructor]
         public DSFaceSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                   SelectionType.One, 
-                  SelectionObjectType.Face, 
-                  "Select a face.", 
-                  "Face of Element Id", 
+                  SelectionObjectType.Face,
+                  message,
+                  prefix, 
                   selectionIdentifier, 
                   inPorts, 
                   outPorts) {}
@@ -646,20 +655,23 @@ namespace Dynamo.Nodes
      NodeDescription("SelectEdgeDescription", typeof(DSRevitNodesUI.Properties.Resources)), IsDesignScriptCompatible]
     public class DSEdgeSelection : ReferenceSelection
     {
+        private const string message = "Select an edge.";
+        private const string prefix = "Edge of Element Id";
+
         public DSEdgeSelection()
             : base(
                 SelectionType.One,
                 SelectionObjectType.Edge,
-                "Select an edge.",
-                "Edge of Element Id") { }
+                message,
+                prefix) { }
 
         [JsonConstructor]
         public DSEdgeSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.One,
                 SelectionObjectType.Edge,
-                "Select an edge.",
-                "Edge of Element Id",
+               message,
+                prefix,
                 selectionIdentifier,
                 inPorts,
                 outPorts) { }
@@ -669,20 +681,23 @@ namespace Dynamo.Nodes
      NodeDescription("SelectPointonFaceDescription", typeof(DSRevitNodesUI.Properties.Resources)), IsDesignScriptCompatible]
     public class DSPointOnElementSelection : ReferenceSelection
     {
+        private const string message = "Select a point on a face.";
+        private const string prefix = "Point on Element";
+
         public DSPointOnElementSelection()
             : base(
                 SelectionType.One,
                 SelectionObjectType.PointOnFace,
-                "Select a point on a face.",
-                "Point on Element") { }
+                message,
+                prefix) { }
 
         [JsonConstructor]
         public DSPointOnElementSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.One,
                 SelectionObjectType.PointOnFace,
-                "Select a point on a face.",
-                "Point on Element",
+                message,
+                prefix,
                 selectionIdentifier,
                 inPorts,
                 outPorts) { }
@@ -741,20 +756,23 @@ namespace Dynamo.Nodes
      NodeDescription("SelectUVonFaceDescription", typeof(DSRevitNodesUI.Properties.Resources)), IsDesignScriptCompatible]
     public class DSUvOnElementSelection : ReferenceSelection
     {
+        private const string message = "Select a point on a face.";
+        private const string prefix = "UV on Element";
+
         public DSUvOnElementSelection()
             : base(
                 SelectionType.One,
                 SelectionObjectType.PointOnFace,
-                "Select a point on a face.",
-                "UV on Element") { }
+                message,
+                prefix) { }
 
         [JsonConstructor]
         public DSUvOnElementSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.One,
                 SelectionObjectType.PointOnFace,
-                "Select a point on a face.",
-                "UV on Element",
+                message,
+                prefix,
                 selectionIdentifier,
                 inPorts,
                 outPorts) { }
@@ -814,20 +832,23 @@ namespace Dynamo.Nodes
      IsDesignScriptCompatible]
     public class DSDividedSurfaceFamiliesSelection : ElementSelection<DividedSurface>
     {
+        private const string message = "Select a divided surface.";
+        private const string prefix = "Elements";
+
         public DSDividedSurfaceFamiliesSelection()
             : base(
                 SelectionType.One,
                 SelectionObjectType.None,
-                "Select a divided surface.",
-                "Elements") { }
+                message,
+                prefix) { }
 
         [JsonConstructor]
         public DSDividedSurfaceFamiliesSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.One,
                 SelectionObjectType.None,
-                "Select a divided surface.",
-                "Elements",
+                message,
+                prefix,
                 selectionIdentifier,
                 inPorts,
                 outPorts) { }
@@ -865,20 +886,23 @@ namespace Dynamo.Nodes
      NodeDescription("SelectModelElementsDescription", typeof(DSRevitNodesUI.Properties.Resources)), IsDesignScriptCompatible]
     public class DSModelElementsSelection : ElementSelection<Element>
     {
+        private const string message = "Select elements.";
+        private const string prefix = "Elements";
+
         public DSModelElementsSelection()
             : base(
                 SelectionType.Many,
                 SelectionObjectType.None,
-                "Select elements.",
-                "Elements") { }
+                message,
+                prefix) { }
 
         [JsonConstructor]
         public DSModelElementsSelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.Many,
                 SelectionObjectType.None,
-                "Select elements.",
-                "Elements",
+                message,
+                prefix,
                 selectionIdentifier,
                 inPorts,
                 outPorts)
@@ -889,20 +913,23 @@ namespace Dynamo.Nodes
      NodeDescription("SelectFacesDescription", typeof(DSRevitNodesUI.Properties.Resources)), IsDesignScriptCompatible]
     public class SelectFaces : ReferenceSelection
     {
+        private const string message = "Select faces.";
+        private const string prefix = "Faces";
+
         public SelectFaces()
             : base(
                 SelectionType.Many,
                 SelectionObjectType.Face,
-                "Select faces.",
-                "Faces") { }
+                message,
+                prefix) { }
 
         [JsonConstructor]
         public SelectFaces(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.Many,
                 SelectionObjectType.Face,
-                "Select faces.",
-                "Faces",
+                message,
+                prefix,
                 selectionIdentifier,
                 inPorts,
                 outPorts)

--- a/src/Libraries/RevitNodesUI/SiteLocation.cs
+++ b/src/Libraries/RevitNodesUI/SiteLocation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 using Autodesk.Revit.Creation;
 
@@ -61,6 +62,20 @@ namespace DSRevitNodesUI
             DynamoRevitApp.EventHandlerProxy.DocumentOpened += model_RevitDocumentChanged;
             RevitServicesUpdater.Instance.ElementsUpdated += RevitServicesUpdater_ElementsUpdated;
             
+            DynamoRevitApp.AddIdleAction(() => Update());
+        }
+
+        [JsonConstructor]
+        public SiteLocation(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
+            Location = DynamoUnits.Location.ByLatitudeAndLongitude(0.0, 0.0);
+            Location.Name = string.Empty;
+
+            ArgumentLacing = LacingStrategy.Disabled;
+
+            DynamoRevitApp.EventHandlerProxy.DocumentOpened += model_RevitDocumentChanged;
+            RevitServicesUpdater.Instance.ElementsUpdated += RevitServicesUpdater_ElementsUpdated;
+
             DynamoRevitApp.AddIdleAction(() => Update());
         }
 

--- a/src/Libraries/RevitNodesUI/SunPath.cs
+++ b/src/Libraries/RevitNodesUI/SunPath.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 using Autodesk.Revit.UI.Events;
 
@@ -28,6 +29,15 @@ namespace DSRevitNodesUI
 
             RegisterAllPorts();
 
+            RevitServicesUpdater.Instance.ElementsUpdated += Updater_ElementsUpdated;
+            DynamoRevitApp.EventHandlerProxy.ViewActivated += CurrentUIApplication_ViewActivated;
+
+            DynamoRevitApp.AddIdleAction(() => CurrentUIApplicationOnViewActivated());
+        }
+
+        [JsonConstructor]
+        public SunSettings(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(inPorts, outPorts)
+        {
             RevitServicesUpdater.Instance.ElementsUpdated += Updater_ElementsUpdated;
             DynamoRevitApp.EventHandlerProxy.ViewActivated += CurrentUIApplication_ViewActivated;
 

--- a/test/Libraries/RevitIntegrationTests/RegressionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RegressionTests.cs
@@ -3,10 +3,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
+using Dynamo.Search.SearchElements;
 using NUnit.Framework;
 using RevitServices.Elements;
 using RevitTestServices;
+using RTF.Framework;
 
 namespace RevitSystemTests
 {
@@ -77,6 +80,155 @@ namespace RevitSystemTests
             {
                 Assert.Fail(exception.Message);
             }
+        }
+
+        [Test]
+        [TestModel(@".\empty.rfa")]
+        public void NoUINodesLeftBehind()
+        {
+            // This verifies Revit UI Nodes are not lost in translation by comparing
+            // the overall node count on the active ws pre and post save
+
+            // Assertion variables
+            int preSaveNodeCount = 0;
+            int postSaveNodeCount = 0;
+
+            // Setup home ws
+            var homespace = Model.CurrentWorkspace as HomeWorkspaceModel;
+            Assert.NotNull(homespace, "The current workspace is not a HomeWorkspaceModel");
+
+            // Iterate through all loaded nodes in library & add Revit UI nodes to ws
+            var nodeList = Model.SearchModel.SearchEntries.OfType<NodeSearchElement>();
+            foreach (var node in nodeList)
+            {
+                var assembly = Path.GetFileName(node.Assembly);
+
+                var searchElement = node as NodeSearchElement;
+                if (assembly == "DSRevitNodesUI.dll")
+                {
+                    var currentNode = searchElement.CreateNode();
+                    Model.AddNodeToCurrentWorkspace(currentNode, true);
+                }
+            }
+
+            // Number of nodes sucessfully added to ws before saving
+            preSaveNodeCount = Model.CurrentWorkspace.Nodes.Count();
+
+            // Save workspace
+            ViewModel.CurrentSpace.Save(Path.Combine(workingDirectory, @".\AllNodes.dyn"));
+
+            // Close workspace
+            Assert.IsTrue(ViewModel.CloseHomeWorkspaceCommand.CanExecute(null));
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            // Open Json temp file
+            OpenAndAssertNoDummyNodes(Path.Combine(workingDirectory, @".\AllNodes.dyn"));
+            RunCurrentModel();
+
+            // Number of nodes sucessfully restored to ws after saving/opening
+            postSaveNodeCount = Model.CurrentWorkspace.Nodes.Count();
+
+            // Active node count is the same after reopening saved file
+            Assert.IsTrue(preSaveNodeCount == postSaveNodeCount);
+
+            // Close workspace
+            Assert.IsTrue(ViewModel.CloseHomeWorkspaceCommand.CanExecute(null));
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            // Delete temp file
+            File.Delete(Path.Combine(workingDirectory, @".\AllNodes.dyn"));
+        }
+
+        [Test]
+        [TestModel(@".\empty.rfa")]
+        public void NoDuplicatePortsOnUINodes()
+        {
+            // This test verifies Revit UI Nodes are not producing duplicate
+            // outports upon deserialization due to a lack of a JSON constructor
+
+            // Assertion variables
+            List<int> preSaveOutPortCount = new List<int>();
+            List<int> postSaveOutPortCount = new List<int>();
+            List<string> nodeCreationNames = new List<string>();
+            string outputData = "";
+
+            // Setup home ws
+            var homespace = Model.CurrentWorkspace as HomeWorkspaceModel;
+            Assert.NotNull(homespace, "The current workspace is not a HomeWorkspaceModel");
+
+            // Iterate through all loaded nodes in library & add Revit UI nodes to ws
+            var nodeList = Model.SearchModel.SearchEntries.OfType<NodeSearchElement>();
+            foreach (var node in nodeList)
+            {
+                var searchElement = node as NodeSearchElement;
+                var assembly = Path.GetFileName(node.Assembly);
+
+                if (assembly == "DSRevitNodesUI.dll")
+                {
+                    var currentNode = searchElement.CreateNode();
+                    Model.AddNodeToCurrentWorkspace(currentNode, true);
+                    nodeCreationNames.Add(searchElement.CreationName);
+                }
+            }
+
+            // Build list of outport counts for each active nodes before saving
+            foreach (var node in ViewModel.CurrentSpace.Nodes)
+            {
+                preSaveOutPortCount.Add(node.OutPorts.Count);
+            }
+
+            // Save workspace
+            ViewModel.CurrentSpace.Save(Path.Combine(workingDirectory, @".\DupePorts.dyn"));
+
+            // Close workspace
+            Assert.IsTrue(ViewModel.CloseHomeWorkspaceCommand.CanExecute(null));
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            // Open Json temp file
+            OpenAndAssertNoDummyNodes(Path.Combine(workingDirectory, @".\DupePorts.dyn"));
+            RunCurrentModel();
+
+            // Build list of outport counts for each sucessfully restored nodes after saving/opening
+            foreach (var node in ViewModel.CurrentSpace.Nodes)
+            {
+                postSaveOutPortCount.Add(node.OutPorts.Count);
+            }
+
+            // PortCount lists have matching lengths pre/post save
+            Assert.IsTrue(preSaveOutPortCount.Count == postSaveOutPortCount.Count);
+            // PortCount values for each node match pre/post save
+            for (int i = 0; i < preSaveOutPortCount.Count; i++)
+            {
+                // Write node name to the xml results if assertion is false
+                if (preSaveOutPortCount[i] != postSaveOutPortCount[i])
+                {
+                    outputData += nodeCreationNames[i] + ", ";
+                }
+            }
+
+            if (outputData.Length > 0)
+            {
+                Assert.Fail("OutPort Count Inconsistency: " + outputData.Remove(outputData.Length - 2));
+            }
+
+            // Close workspace
+            Assert.IsTrue(ViewModel.CloseHomeWorkspaceCommand.CanExecute(null));
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            // Delete temp file
+            File.Delete(Path.Combine(workingDirectory, @".\DupePorts.dyn"));
+        }
+
+        // Helper Functions
+   
+        private void OpenAndAssertNoDummyNodes(string samplePath)
+        {
+            var testPath = Path.GetFullPath(samplePath);
+
+            // Open the test file
+            ViewModel.OpenCommand.Execute(testPath);
+
+            AssertNoDummyNodes();
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

**[Cherry Picked](https://github.com/DynamoDS/DynamoRevit/pull/1783) From Revit 2018**

[Task: QNTM-1708](https://jira.autodesk.com/browse/QNTM-1708)

[Coinciding DynamoCore Changes ](https://github.com/DynamoDS/Dynamo/pull/8167)
(Dynamo Beta NuGet packages must be updated for successful Jenkins build of D4R)

This PR addresses the duplicate port issue during deserialization.  This is related to the recent changes in the node model base class affecting all the Revit UI nodes that inherent from this base.  Json constructors must be added throughout the inheritance chain to prevent this from occurring.

### Testing
Added new regression testing to verify no nodes are lost in translation after saving/reopening and that port counts are consistent.  The tests:
- iterate through specified assemblies in the library, adding all those nodes to the canvas
- store specific data (active node count, port count, etc)
- save temp file, close, reopen
- verify data is consistent with original state after serialization/deserialization
- close/delete temp file

No corresponding dyn is required reducing testing maintenance.

### Affected Nodes (49):
**[Elements.cs]**
- All Elements of Family Type
- All Elements of Type
- All Elements of Category
- All Elements at Level
- All Elements in Active View

**[RevitDropDown.cs]**
- Family Types
- Get Family Parameter
- Floor Types
- Wall Types
- Performance Adviser Rules
- Categories
- Levels
- Structural Framing Types
- Spacing Rule Layout
- Element Types
- Views

**[RevitTypes.cs]**
- Select Phase
- Select Revision
- Select Filled Region Type
- Select Rule Type
- Select Revision Numbering
- Select Revision Numbering Type
- Select Parameter Type
- Select BuiltIn Parameter Group
- Select Revision Visibility
- Select Direct Shape Room Bounding Option
- Detail Level
- Select Horizontal Text Alignment
- Select Vertical Text Alignment
- Wall Location
- Schedule Type
- Export Column Headers
- Export Text Qualifier
- Fill Patterns
- FIll Pattern Targets
- Line Patterns
- Schedule Filter Type

**[Selection.cs]** (these were addressed in [1768](https://github.com/DynamoDS/DynamoRevit/pull/1768))
- Select Model Element
- Select Face
-  Select Edge
- Select Point on Face
- Select UV on Face
- Select Divided Surface Families
- Select Model Elements
- Select Faces
- Select Edges

**[SiteLocation.cs]**
- Site Location

**[SunPath.cs]**
- SunSettings Current

### Outstanding Issues
- Resolve `SiteLocation` Deserialization Issues (verified this is old behavior in 1.3 and filed [QNTM-1903](https://jira.autodesk.com/browse/QNTM-1903))
- Node State is inconsistent pre/post save (verified this is also old behavior in 1.3 and the behavior is consistent with the existing 2.0 core custom UI nodes(filed [QNTM-1902](https://jira.autodesk.com/browse/QNTM-1902) with more info/examples)
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

**[Cherry Picked](https://github.com/DynamoDS/DynamoRevit/pull/1783) From Revit 2018**

### FYIs