### PR TITLE
Deserialize json element binding data [test]

### DIFF
--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -207,6 +207,69 @@ namespace RevitSystemTests
         }
 
         [Test]
+        [TestModel(@".\ElementBinding\CreateWallInDynamo.rvt")]
+        public void VerifyJsonRestoresExpectedBinding()
+        {
+            // Test variables
+            int wallElementCountPresave;
+            int wallElementCountPostsave;
+            ElementId wallElementIdPresave;
+            ElementId wallElementIdPostsave;
+
+            // Load Dynamo xml file containing trace data
+            string dynFilePath = Path.Combine(workingDirectory, @".\ElementBinding\CreateWallInDynamo.dyn");
+            string testPath = Path.GetFullPath(dynFilePath);
+            ViewModel.OpenCommand.Execute(testPath);
+
+            // Run
+            RunCurrentModel();
+
+            // Get binding element id for wall node presave
+            var selNodes = ViewModel.Model.CurrentWorkspace.Nodes.Where(x => string.Equals(x.GUID.ToString(), "b568d298-f7be-4619-99a1-cae16efaed58"));
+            Assert.IsTrue(selNodes.Any());
+            var node = selNodes.First();
+            wallElementIdPresave = GetBindingElementIdForNode(node.GUID);
+
+            // Get initial wall count
+            var doc = DocumentManager.Instance.CurrentUIDocument.Document;
+            IEnumerable<Element> wallsPresave = Utils.AllElementsOfType<Wall>(doc);
+            wallElementCountPresave = wallsPresave.Count();
+
+            // Save in temp location
+            ViewModel.CurrentSpace.Save(Path.Combine(workingDirectory, @".\ElementBinding\CreateWallInDynamo_temp.dyn"));
+
+            // Close workspace
+            Assert.IsTrue(ViewModel.CloseHomeWorkspaceCommand.CanExecute(null));
+            ViewModel.CloseHomeWorkspaceCommand.Execute(null);
+
+            // Open Json temp file
+            dynFilePath = Path.Combine(workingDirectory, @".\ElementBinding\CreateWallInDynamo_temp.dyn");
+            testPath = Path.GetFullPath(dynFilePath);
+            ViewModel.OpenCommand.Execute(testPath);
+
+            // Run
+            RunCurrentModel();
+
+            // Get binding element id for wall node postsave
+            selNodes = ViewModel.Model.CurrentWorkspace.Nodes.Where(x => string.Equals(x.GUID.ToString(), "b568d298-f7be-4619-99a1-cae16efaed58"));
+            Assert.IsTrue(selNodes.Any());
+            node = selNodes.First();
+            wallElementIdPostsave = GetBindingElementIdForNode(node.GUID);
+
+            // Get wall count upon reopening to verify no duplicate walls exist
+            doc = DocumentManager.Instance.CurrentUIDocument.Document;
+            IEnumerable<Element> wallsPostsave = Utils.AllElementsOfType<Wall>(doc);
+            wallElementCountPostsave = wallsPostsave.Count();
+
+            // Verify xml results against json
+            Assert.AreEqual(wallElementIdPresave, wallElementIdPostsave);
+            Assert.AreEqual(wallElementCountPresave, wallElementCountPostsave);
+
+            // Delete temp file
+            File.Delete(Path.Combine(workingDirectory, @".\ElementBinding\CreateWallInDynamo_temp.dyn"));
+        }
+
+        [Test]
         [TestModel(@".\empty.rfa")]
         public void CreateInDynamoModifyInRevitReRun()
         {

--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -236,7 +236,8 @@ namespace RevitSystemTests
             wallElementCountPresave = wallsPresave.Count();
 
             // Save in temp location
-            ViewModel.CurrentSpace.Save(Path.Combine(workingDirectory, @".\ElementBinding\CreateWallInDynamo_temp.dyn"));
+            string tempPath = Path.Combine(workingDirectory, @".\ElementBinding\CreateWallInDynamo_temp.dyn");
+            ViewModel.SaveAsCommand.Execute(tempPath);
 
             // Close workspace
             Assert.IsTrue(ViewModel.CloseHomeWorkspaceCommand.CanExecute(null));
@@ -266,7 +267,7 @@ namespace RevitSystemTests
             Assert.AreEqual(wallElementCountPresave, wallElementCountPostsave);
 
             // Delete temp file
-            File.Delete(Path.Combine(workingDirectory, @".\ElementBinding\CreateWallInDynamo_temp.dyn"));
+            File.Delete(tempPath);
         }
 
         [Test]


### PR DESCRIPTION
### Purpose

*Cherry-Pick From 2018*

[QNTM-1734](https://jira.autodesk.com/browse/QNTM-1734)

Currently we only serialize element binding data so relationships that depend on this trace data are broken when opening a previously saved dyn file.  The purpose of [Dyn PR-8198](https://github.com/DynamoDS/Dynamo/pull/8198) is to properly deserialize and restore element bindings.

### Testing

This PR includes tests that compare element counts and element Id's to verify no duplicate elements have been created and original element Id's have been restored after saving to Json and rerunning the graph.  Previously to this PR a new element would be created every time the file was run, this test verifies this is no longer the case.  MultipleCustomNodeInstance (recursive custom nodes) failure is a previously known issue and has never worked in 2.0.

![elementbinding_rtf_results](https://user-images.githubusercontent.com/13341935/30928160-c9c1a064-a388-11e7-9001-40174a9fccda.jpg)

### Outstanding Issues

Initially I thought the trace data was not being restored because any modifications upon reopening a json graph containing trace data were not reflected in the Revit viewport.  However, after some digging I realized the Revit viewport loses all communication with Dynamo after loading a Json graph (even with simple Core geometry - not D4R related).  This issue is outside the scope of this deserialization task and has been filed as [QNTM-2124](https://jira.autodesk.com/browse/QNTM-2124)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

### FYIs
