### PR TITLE
QNTM-2101: Mark RTF tests as failures to enable daily builds

### DIFF
--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -75,7 +75,7 @@ namespace RevitSystemTests
             RunCurrentModel();
         }
 
-        [Test]
+        [Test, Ignore, Category("Failure")]
         [Category("RegressionTests")]
         [TestModel(@".\Bugs\MAGN-122_wallsAndFloorsAndLevels.rvt")]
         public void MAGN_122()

--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -859,7 +859,7 @@ namespace RevitSystemTests
             Assert.AreEqual(initialNumber, finalNumber);
         }
 
-        [Test]
+        [Test, Ignore, Category("Failure")]
         [TestModel(@".\ElementBinding\MultipleCustomInstance.rvt")]
         public void MultipleCustomNodeInstance()
         {

--- a/test/Libraries/RevitIntegrationTests/IntersectionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/IntersectionTests.cs
@@ -92,7 +92,7 @@ namespace RevitSystemTests
             Assert.AreEqual(GetPreviewValue(nurbsCurve3ID), null);
         }
 
-        [Test]
+        [Test, Ignore, Category("Failure")]
         [TestModel(@".\Intersect\EdgePlaneIntersection.rfa")]
         public void EdgePlaneIntersection()
         {

--- a/test/Libraries/RevitIntegrationTests/SampleTests.cs
+++ b/test/Libraries/RevitIntegrationTests/SampleTests.cs
@@ -1116,7 +1116,7 @@ namespace RevitSystemTests
             }
         }
 
-        [Test, Category("SmokeTests")]
+        [Test, Ignore, Category("Failure"), Category("SmokeTests")]
         [TestModel(@".\empty.rfa")]
         public void Geometry_Solids()
         {


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

The purpose of this PR is to mark 4 RTF tests as failures so that we can enable daily builds

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)

### Reviewers

@QilongTang @mjkkirschner 

### FYIs

@aparajit-pratap 
