### PR TITLE
Restore tests from failure category

### DIFF
--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -75,7 +75,7 @@ namespace RevitSystemTests
             RunCurrentModel();
         }
 
-        [Test, Ignore, Category("Failure")]
+        [Test]
         [Category("RegressionTests")]
         [TestModel(@".\Bugs\MAGN-122_wallsAndFloorsAndLevels.rvt")]
         public void MAGN_122()

--- a/test/Libraries/RevitIntegrationTests/IntersectionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/IntersectionTests.cs
@@ -92,7 +92,7 @@ namespace RevitSystemTests
             Assert.AreEqual(GetPreviewValue(nurbsCurve3ID), null);
         }
 
-        [Test, Ignore, Category("Failure")]
+        [Test]
         [TestModel(@".\Intersect\EdgePlaneIntersection.rfa")]
         public void EdgePlaneIntersection()
         {


### PR DESCRIPTION
### Purpose

Restore tests from "Failure" category after fixes to https://github.com/DynamoDS/Dynamo/pull/8283

### FYIs

@smangarole @QilongTang 
