### PR TITLE
Serialization RTF test to Re-Save all Json files

### DIFF
--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="AsynchronousModeTests.cs" />
     <Compile Include="GlobalParameterTests.cs" />
     <Compile Include="PerformanceAdviserTests.cs" />
+    <Compile Include="SerializationTests.cs" />
     <Compile Include="WallTests.cs" />
     <Compile Include="CurtainSystemTests.cs" />
     <Compile Include="RoomTests.cs" />

--- a/test/Libraries/RevitIntegrationTests/SerializationTests.cs
+++ b/test/Libraries/RevitIntegrationTests/SerializationTests.cs
@@ -38,7 +38,6 @@ namespace RevitSystemTests
                 // Open XMLs in new Dynamo Core which should take care of
                 // Migration but element binding might be lost
                 ViewModel.OpenCommand.Execute(filePath);
-                AssertNoDummyNodes();
 
                 // Get new file path under temp folder
                 var fileNameSameStructure = filePath.Split(new string[] { "\\test" }, StringSplitOptions.None).Last();

--- a/test/Libraries/RevitIntegrationTests/SerializationTests.cs
+++ b/test/Libraries/RevitIntegrationTests/SerializationTests.cs
@@ -1,0 +1,63 @@
+﻿using System.IO;
+using NUnit.Framework;
+using RevitTestServices;
+using RTF.Framework;
+using Revit.Elements;
+using System.Linq;
+using Autodesk.DesignScript.Geometry;
+using System;
+
+namespace RevitSystemTests
+{
+    [TestFixture]
+    class SerializationTests : RevitSystemTestBase
+    {
+        /// <summary>
+        /// This function gathers all dyn and dyf in 
+        /// workingDirectory into paths array.
+        /// </summary>
+        /// <returns>Test files paths array</returns>
+        public object[] FindWorkspaces()
+        {
+            var config = RevitTestConfiguration.LoadConfiguration();
+
+            //get the test path
+            workingDirectory = config.WorkingDirectory;
+            var di = new DirectoryInfo(workingDirectory);
+            var fis = new string[] { "*.dyn", "*.dyf" }
+            .SelectMany(i => di.GetFiles(i, SearchOption.AllDirectories))
+            .ToArray();
+
+            //di.GetFiles("*.dyn, *.dyf", SearchOption.AllDirectories);
+            return fis.Select(fi => fi.FullName).ToArray();
+        }
+
+        protected string JsonFolderName = "DynamoRevitJsons";
+
+        [Test, TestModel(@".\empty.rfa"), TestCaseSource("FindWorkspaces")]
+        public void SaveXMLTestFilesToJson(string filePath)
+        {
+            ViewModel.OpenCommand.Execute(filePath);
+            AssertNoDummyNodes();
+
+            bool isCustomNodeWorkspace = filePath.Contains(".dyf");
+
+            var tempPath = Path.GetTempPath();
+            var jsonFolder = Path.Combine(tempPath, JsonFolderName);
+
+            if (!System.IO.Directory.Exists(jsonFolder))
+            {
+                System.IO.Directory.CreateDirectory(jsonFolder);
+            }
+
+            // Get file name
+            var fileNameSameStructure = filePath.Split(new string[] { "\\test" }, StringSplitOptions.None).Last();
+            var jsonPath = isCustomNodeWorkspace? jsonFolder + fileNameSameStructure + ".dyf" : jsonFolder + fileNameSameStructure + ".dyn";
+            if (File.Exists(jsonPath))
+            {
+                File.Delete(jsonPath);
+            }
+            ViewModel.SaveAsCommand.Execute(jsonPath);
+        }
+    }
+}


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

[QNTM-2235](https://jira.autodesk.com/browse/QNTM-2235) All RTF tests should be run against both xml and json file formats

PR to add a test case under SystemTests to open and resave all RTF XML DYN and DYFs into Json format.

New test can be run by RTF but timeout need to be increased from 12000 to 16000 because it is taking some time to open and re-save the ~260 Dyns. I also failed to use TestSource so I am doing everything in a single test
![image](https://user-images.githubusercontent.com/3942418/32065828-df03b6ea-ba4b-11e7-8900-80fae3b07f29.png)

Jsons are created under [SystemTempFolder]/DynamoRevitJsons:
![image](https://user-images.githubusercontent.com/3942418/32065858-f1bde094-ba4b-11e7-9f93-3482952d8371.png)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @ramramps @ColinDayOrg 

### FYIs

@alfarok @smangarole 
