### PR TITLE
stop tessellating textElements and curveElements 2017

### DIFF
--- a/src/Libraries/RevitNodes/Elements/CurveElement.cs
+++ b/src/Libraries/RevitNodes/Elements/CurveElement.cs
@@ -123,19 +123,18 @@ namespace Revit.Elements
 
         #endregion
 
+        /// <summary>
+        /// Empty method - we don't want to tessellate curves automatically
+        /// but it seems we need this method to correctly import this library into Dynamo.
+        /// See description in base class.
+        /// </summary>
+        /// <param name="package"></param>
+        /// <param name="parameters"></param>
         [IsVisibleInDynamoLibrary(false)]
         public new void Tessellate(IRenderPackage package, TessellationParameters parameters)
         {
-            //Ensure that the object is still alive
-            if (!IsAlive) return;
-
-            this.Curve.Tessellate(package, parameters);
-
-            if (package.LineVertexCount > 0)
-            {
-                package.ApplyLineVertexColors(CreateColorByteArrayOfSize(package.LineVertexCount, DefR, DefG, DefB, DefA));
-            }
-       }
+            
+        }
 
        private static byte[] CreateColorByteArrayOfSize(int size, byte red, byte green, byte blue, byte alpha)
        {

--- a/src/Libraries/RevitNodes/Elements/TextElement.cs
+++ b/src/Libraries/RevitNodes/Elements/TextElement.cs
@@ -9,6 +9,8 @@ using Autodesk.DesignScript.Runtime;
 using DS = Autodesk.DesignScript.Geometry;
 using System.Windows.Media;
 using System.Windows;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Revit.Elements
 {
@@ -153,12 +155,18 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Text Tesselation
+        /// Empty method - we don't want to tessellate text automatically
+        /// but it seems we need this method to correctly import this library into Dynamo.
         /// </summary>
         /// <param name="package"></param>
         /// <param name="parameters"></param>
         [IsVisibleInDynamoLibrary(false)]
         public new void Tessellate(IRenderPackage package, TessellationParameters parameters)
+        {
+         
+        }
+
+        protected Autodesk.DesignScript.Geometry.Curve[] Curves()
         {
             // Offset for text adjustments
             double horizontalOffset = 0;
@@ -172,41 +180,39 @@ namespace Revit.Elements
             // Apply horizontal Text offset            
             if (Alignment == HorizontalTextAlignment.Center) { horizontalOffset = path.Bounds.Width / 2; }
             if (Alignment == HorizontalTextAlignment.Right) { horizontalOffset = path.Bounds.Width; }
-            
+
+            return convertPathToLines(horizontalOffset, path);
+        }
+        //TODO dispose points
+        private DS.Curve[] convertPathToLines(double horizontalOffset, PathGeometry path)
+        {
+            var outputCurves = new List<List<DS.Curve>>();
             // Walk thorugh all figures and draw lines
             foreach (PathFigure figure in path.Figures)
             {
+                var figureCurves = new List<DS.Curve>();
                 // Rotate the start point and apply offsets
-                var startPoint = RotatePoint(new System.Windows.Point(figure.StartPoint.X - horizontalOffset, figure.StartPoint.Y * -1), this.Rotation);
-                package.AddLineStripVertex(startPoint.X + Location.X , startPoint.Y + Location.Y, this.Location.Z);
-
                 foreach (PathSegment segment in figure.Segments)
                 {
+                    var points = new List<DS.Point>();
+
                     if (segment is System.Windows.Media.PolyLineSegment)
                     {
                         System.Windows.Media.PolyLineSegment pline = segment as System.Windows.Media.PolyLineSegment;
                         for (int i = 0; i < pline.Points.Count; i++)
                         {
                             System.Windows.Point point = pline.Points[i];
-
                             // rotate point and apply offsets
                             var pLinePoint = RotatePoint(new System.Windows.Point(point.X - horizontalOffset, point.Y * -1), this.Rotation);
-                            package.AddLineStripVertex(pLinePoint.X + Location.X , pLinePoint.Y + Location.Y, this.Location.Z);
+                            points.Add(DS.Point.ByCoordinates(pLinePoint.X, pLinePoint.Y, 0));
 
-                            // send the same point again to continue drawing
-                            if (i < pline.Points.Count - 1)
-                            {
-                                package.AddLineStripVertex(pLinePoint.X + Location.X, pLinePoint.Y + Location.Y, this.Location.Z);
-                            }
                         }
                     }
+                    figureCurves.Add(DS.PolyCurve.ByPoints(points, true));
                 }
+                outputCurves.Add(figureCurves);
             }
-
-            if (package.LineVertexCount > 0)
-            {
-                package.ApplyLineVertexColors(CreateColorByteArrayOfSize(package.LineVertexCount, DefR, DefG, DefB, DefA));
-            }
+            return outputCurves.SelectMany(list => list).ToArray();
         }
 
         /// <summary>

--- a/src/Libraries/RevitNodes/Elements/TextElement.cs
+++ b/src/Libraries/RevitNodes/Elements/TextElement.cs
@@ -157,6 +157,7 @@ namespace Revit.Elements
         /// <summary>
         /// Empty method - we don't want to tessellate text automatically
         /// but it seems we need this method to correctly import this library into Dynamo.
+        /// See description in base class.
         /// </summary>
         /// <param name="package"></param>
         /// <param name="parameters"></param>
@@ -176,14 +177,13 @@ namespace Revit.Elements
 
             // Get Text outline path at 0,0
             PathGeometry path = CreateText(this.Value, this.Bold, this.Italic, new FontFamily(this.FontFamilyName), this.FontSize * Scale / factor, new System.Windows.Point(0, 0));
-
+            
             // Apply horizontal Text offset            
             if (Alignment == HorizontalTextAlignment.Center) { horizontalOffset = path.Bounds.Width / 2; }
             if (Alignment == HorizontalTextAlignment.Right) { horizontalOffset = path.Bounds.Width; }
 
             return convertPathToLines(horizontalOffset, path);
         }
-        //TODO dispose points
         private DS.Curve[] convertPathToLines(double horizontalOffset, PathGeometry path)
         {
             var outputCurves = new List<List<DS.Curve>>();
@@ -205,10 +205,11 @@ namespace Revit.Elements
                             // rotate point and apply offsets
                             var pLinePoint = RotatePoint(new System.Windows.Point(point.X - horizontalOffset, point.Y * -1), this.Rotation);
                             points.Add(DS.Point.ByCoordinates(pLinePoint.X, pLinePoint.Y, 0));
-
+                            
                         }
                     }
                     figureCurves.Add(DS.PolyCurve.ByPoints(points, true));
+                    points.ForEach(pt => pt.Dispose());
                 }
                 outputCurves.Add(figureCurves);
             }

--- a/src/Libraries/RevitNodes/Elements/TextNote.cs
+++ b/src/Libraries/RevitNodes/Elements/TextNote.cs
@@ -233,6 +233,14 @@ namespace Revit.Elements
         }
 
         /// <summary>
+        /// Get geometrical curves from the text this TextNote contains.
+        /// </summary>
+        public new Autodesk.DesignScript.Geometry.Curve[] Curves
+        {
+            get { return base.Curves(); }
+        }
+
+        /// <summary>
         /// Set Text
         /// </summary>
         /// <param name="value"></param>

--- a/test/Libraries/RevitNodesTests/Elements/DetailCurveTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DetailCurveTests.cs
@@ -31,8 +31,8 @@ namespace RevitNodesTests.Elements
             curve.Length.ShouldBeApproximately(100);
         }
 
-        [Test, Ignore, Category("Failure")]
-        [TestModel(@".\emptyAnnotativeView.rfa")]
+        [Test]
+        [TestModel(@".\emptyAnnotativeView.rvt")]
         public void ByCurve_Curve_AcceptsStraightDegree3NurbsCurve()
         {
             var points =


### PR DESCRIPTION
### Purpose
https://jira.autodesk.com/browse/DYN-906

This PR removes some functionality from DynamoRevit. TextElements (tags, textNotes) and Curve Elements (DetailCurves,ModelCurves,CurveByPoints,ElementCurveReference) will no longer tessellate in the Background or Revit Geometry preview automatically - instead one will need to use a element.geometry or curves or curve node to extract the curves which will render them.

Any of these will work for curve elements, **but** to get the text from TextElements users will need to use TextNote.Curves as this type is not really a geometry type. Note in the image below that the Element.Curves node will return an empty list.

- [ ] I still need to investigate if there are any broken tests


![screen shot 2017-10-26 at 2 54 29 pm](https://user-images.githubusercontent.com/508936/32073280-8917c786-ba63-11e7-8cbb-fdd48314baed.png)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@QilongTang @sm6srw 

### FYIs

@Racel @kronz 