### PR TITLE
use fromexisting constructor for creating family from name via document

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Family.cs
+++ b/src/Libraries/RevitNodes/Elements/Family.cs
@@ -125,7 +125,7 @@ namespace Revit.Elements
 
             TransactionManager.Instance.TransactionTaskDone();
 
-            return new Family(family);
+            return Family.FromExisting(family, true);
         }
 
         #endregion

--- a/test/Libraries/RevitIntegrationTests/FamilyTests.cs
+++ b/test/Libraries/RevitIntegrationTests/FamilyTests.cs
@@ -52,7 +52,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            //assert number of loaded families in document:
+            //get the number of loaded families in document:
             var fec = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument);
             fec.OfClass(typeof(Autodesk.Revit.DB.Family));
 
@@ -66,7 +66,7 @@ namespace RevitSystemTests
             //now delete the node
             model.CurrentWorkspace.RemoveAndDisposeNode(node);
 
-            //now assert the families count is the same.
+            //get the number of loaded families in document after removing the family.byname node from the graph:
             var fec2 = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument);
             fec2.OfClass(typeof(Autodesk.Revit.DB.Family));
 
@@ -74,6 +74,7 @@ namespace RevitSystemTests
             var families2 = fec2.Cast<Autodesk.Revit.DB.Family>();
             var newcount = families.Count();
 
+            //now assert the families count is the same.
             Assert.AreEqual(oldcount, newcount);
 
         }

--- a/test/Libraries/RevitIntegrationTests/FamilyTests.cs
+++ b/test/Libraries/RevitIntegrationTests/FamilyTests.cs
@@ -62,7 +62,7 @@ namespace RevitSystemTests
 
             //find the node
             var node = this.Model.CurrentWorkspace.Nodes.Where(currentNode => currentNode.Name == "Family.ByName").FirstOrDefault();
-
+            Assert.IsNotNull(node);
             //now delete the node
             model.CurrentWorkspace.RemoveAndDisposeNode(node);
 

--- a/test/Libraries/RevitIntegrationTests/FamilyTests.cs
+++ b/test/Libraries/RevitIntegrationTests/FamilyTests.cs
@@ -10,6 +10,9 @@ using RevitTestServices;
 
 using RTF.Framework;
 using FamilyInstance = Revit.Elements.FamilyInstance;
+using Dynamo.Applications.Models;
+using RevitServices.Persistence;
+using System.Linq;
 
 namespace RevitSystemTests
 {
@@ -34,6 +37,45 @@ namespace RevitSystemTests
             
 
             Assert.AreEqual(100, GetPreviewValue("5eac6ab9-e736-49a9-a90a-8b6d93676813"));
+        }
+
+        [Test]
+        [TestModel(@".\Family\GetFamilyInstancesByType.rvt")]
+        public void GetFamilyInstancesByName()
+        {
+            var model = ViewModel.Model;
+
+            string samplePath = Path.Combine(workingDirectory, @".\Family\GetFamilyInstancesByName.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+
+            RunCurrentModel();
+
+            //assert number of loaded families in document:
+            var fec = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument);
+            fec.OfClass(typeof(Autodesk.Revit.DB.Family));
+
+            // obtain the family type with the provided name
+            var families = fec.Cast<Autodesk.Revit.DB.Family>();
+            var oldcount = families.Count();
+
+            //find the node
+            var node = this.Model.CurrentWorkspace.Nodes.Where(currentNode => currentNode.Name == "Family.ByName").FirstOrDefault();
+
+            //now delete the node
+            model.CurrentWorkspace.RemoveAndDisposeNode(node);
+
+            //now assert the families count is the same.
+            var fec2 = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument);
+            fec2.OfClass(typeof(Autodesk.Revit.DB.Family));
+
+            // obtain the family type with the provided name
+            var families2 = fec2.Cast<Autodesk.Revit.DB.Family>();
+            var newcount = families.Count();
+
+            Assert.AreEqual(oldcount, newcount);
+
         }
 
         [Test]
@@ -321,5 +363,6 @@ namespace RevitSystemTests
             Assert.IsTrue(typeof(Revit.Elements.FamilyType) == famInst.GetType());
             
         }
+
     }
 }

--- a/test/System/Family/GetFamilyInstancesByName.dyn
+++ b/test/System/Family/GetFamilyInstancesByName.dyn
@@ -1,0 +1,115 @@
+{
+  "Uuid": "f21e6473-caad-4f46-a59f-e173603ebc6e",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "Home",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"AC_panel\";",
+      "Id": "94d32bffd61a410ea8787377c58d9c9e",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4386f76d72384df095a33e8cd58d2b7c",
+          "Name": "",
+          "Description": "t6BBA4B28C5E54CF89F300D510499A00E_0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Family.ByName@string",
+      "Id": "f8932b8d6eff458899666e734fc33cbd",
+      "Inputs": [
+        {
+          "Id": "8d34f98b43c947e09227439b54b4cdc4",
+          "Name": "name",
+          "Description": "The name of the family in the current document\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "988c26561480463fb40db31fec7ec645",
+          "Name": "Family",
+          "Description": "Family",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Obtain a Family from the current document given it's name\n\nFamily.ByName (name: string): Family"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "4386f76d72384df095a33e8cd58d2b7c",
+      "End": "8d34f98b43c947e09227439b54b4cdc4",
+      "Id": "1ca1d16b0554450d8eb5fec01cc0c1da"
+    }
+  ],
+  "Dependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.0.0.3090",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "94d32bffd61a410ea8787377c58d9c9e",
+        "Excluded": false,
+        "X": 46.028991721737441,
+        "Y": 228.88277260340982
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Family.ByName",
+        "Id": "f8932b8d6eff458899666e734fc33cbd",
+        "Excluded": false,
+        "X": 229.55943516995913,
+        "Y": 222.04003422976771
+      }
+    ],
+    "Annotations": [],
+    "X": 23.849201002712306,
+    "Y": -109.57626929408161,
+    "Zoom": 1.0065043104810645
+  }
+}


### PR DESCRIPTION

### Purpose

when we create families using the byBame node this implies that the elements already exist in the document and are revit owned - use the from existing constructor to set the `RevitOwned` bool to false.

add a test which checks the total number of families before and after removing this node from the graph.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@ColinDayOrg 

### FYIs

@QilongTang 