### PR TITLE
Cherry-Pick RenderPackageCache API changes from D4R 2017

### DIFF
--- a/src/DynamoRevit/ViewModel/DynamoRevitViewModel.cs
+++ b/src/DynamoRevit/ViewModel/DynamoRevitViewModel.cs
@@ -49,6 +49,7 @@ namespace Dynamo.Applications.ViewModel
             {
                 startConfiguration.Watch3DViewModel =
                     HelixWatch3DViewModel.TryCreateHelixWatch3DViewModel(
+                        null,
                         new Watch3DViewModelStartupParams(startConfiguration.DynamoModel),
                         startConfiguration.DynamoModel.Logger);
             }

--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -30,7 +30,7 @@ namespace Dynamo.Applications.ViewModel
 
         public override string PreferenceWatchName { get { return "IsRevitBackgroundPreviewActive"; } }
 
-        public RevitWatch3DViewModel(Watch3DViewModelStartupParams parameters) : base(parameters)
+        public RevitWatch3DViewModel(Watch3DViewModelStartupParams parameters) : base(null, parameters)
         {
             Name = Resources.BackgroundPreviewName;
             Draw();
@@ -108,7 +108,7 @@ namespace Dynamo.Applications.ViewModel
             }
             else
             {
-                graphicItems = model.CurrentWorkspace.Nodes
+                graphicItems = dynamoModel.CurrentWorkspace.Nodes
                  .Where(n => n.IsVisible)
                  .SelectMany(n => n.GeneratedGraphicItems(engineManager.EngineController));
             }

--- a/test/Libraries/RevitIntegrationTests/DisplayTests.cs
+++ b/test/Libraries/RevitIntegrationTests/DisplayTests.cs
@@ -10,6 +10,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.UI;
 using Dynamo.Wpf.Rendering;
+using Dynamo.Visualization;
 using NUnit.Framework;
 using RevitTestServices;
 using RTF.Framework;
@@ -47,9 +48,9 @@ namespace RevitSystemTests
             RunCurrentModel();
         }
 
-        void NodeRenderPackagesUpdated(NodeModel node, IEnumerable<IRenderPackage> packages)
+        void NodeRenderPackagesUpdated(NodeModel node, RenderPackageCache packages)
         {
-            var curvePackage = packages.FirstOrDefault(p => p.LineVertexCount > 0);
+            var curvePackage = packages.Packages.FirstOrDefault(p => p.LineVertexCount > 0);
             if (curvePackage == null)
                 return;
 


### PR DESCRIPTION
Purpose

This PR cherry-picks the RenderPackageCache fixes for D4R from 2017 to 2019

Declarations

Check these if you believe they are true

 The code base is in a better state after this PR
 Is documented according to the standards
 The level of testing this PR includes is appropriate
 User facing strings, if any, are extracted into *.resx files
 Snapshot of UI changes, if any.
Reviewers

n/a

FYIs

n/a