### PR TITLE
small fix to restore packages batch script to handle spaces in paths 2018

### DIFF
--- a/src/restorepackages.bat
+++ b/src/restorepackages.bat
@@ -1,4 +1,4 @@
-@echo off
+﻿@echo off
 REM ***********************************************************************
 REM This bat file uses Aget: https://git.autodesk.com/Dynamo/Aget to 
 REM download the nuget packages from NuGet server or closest Artifactory server for 
@@ -13,6 +13,7 @@ setlocal EnableExtensions
 
 REM 1. set variable values
 set DynamoPackages=%~dp0\packages\_packages
+echo %DynamoPackages%
 set CurrentDir=%~dp0
 if %CurrentDir:~-1%==\ (
     set CurrentDir=%CurrentDir:~0,-1%
@@ -27,16 +28,17 @@ set NugetConfig=%ConfigDir%\dynamo-nuget.config
 REM 2. replace "LatestBeta" strings in packages-template.aget with the latest
 REM    pre-release version of DynamoVisualProgramming.Core package,
 REM    and save the replaced file as packages.aget
-set versionQuery=%NugetExe% list DynamoVisualProgramming.Core -prerelease -config "%NugetConfig%"
-for /F "tokens=2 delims= " %%F in ( '%versionQuery%' ) do (set LatestBeta=%%F)
-echo Latest pre-release version of "DynamoVisualProgramming.Core" package is "%LatestBeta%"
-
+set versionQuery=list DynamoVisualProgramming.Core -prerelease -config "%NugetConfig%"
+for /F "tokens=2 delims= " %%F in ( 'call "%NugetExe%" %versionQuery%' ) do (
+    set LatestBeta=%%F
+)
+echo Latest pre-release version of "DynamoVisualProgramming.Core" package is %LatestBeta%
 if exist %ConfigDir%\packages.aget del %ConfigDir%\packages.aget
-for /f "tokens=* delims=¶" %%i in ( '"type %ConfigDir%\packages-template.aget"' ) do (
+for /f "tokens=* delims=¶" %%i in ( 'type "%ConfigDir%\packages-template.aget"' ) do (
     set line=%%i
     setlocal EnableDelayedExpansion
     set line=!line:LatestBeta=%LatestBeta%!
-    echo !line!>>%ConfigDir%\packages.aget
+    echo !line!>>"%ConfigDir%\packages.aget"
     endlocal
 )
 


### PR DESCRIPTION
### Purpose

This slightly changes the restorepackages.bat file to handle spaces in file paths. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 

### FYIs

There was a [PR](https://github.com/DynamoDS/DynamoRevit/pull/1447) for this before. Somehow it regressed again. 
