### PR TITLE
 Grammar fixes (it's vs its) in node/param descriptions

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Floor.cs
+++ b/src/Libraries/RevitNodes/Elements/Floor.cs
@@ -114,7 +114,7 @@ namespace Revit.Elements
         #region Public static constructors
 
         /// <summary>
-        /// Create a Revit Floor given it's curve outline and Level
+        /// Create a Revit Floor given its curve outline and Level
         /// </summary>
         /// <param name="outlineCurves"></param>
         /// <param name="floorType"></param>
@@ -133,7 +133,7 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Create a Revit Floor given it's curve outline and Level
+        /// Create a Revit Floor given its curve outline and Level
         /// </summary>
         /// <param name="outline"></param>
         /// <param name="floorType"></param>

--- a/src/Libraries/RevitNodes/Elements/Parameter.cs
+++ b/src/Libraries/RevitNodes/Elements/Parameter.cs
@@ -186,7 +186,7 @@ namespace Revit.Elements
         /// <param name="groupName">Group of the parameter for shared parameters</param>
         /// <param name="type">Parameter Type</param>
         /// <param name="group">Parameter Group</param>
-        /// <param name="instance">Is instance parameter, otherwise its a type parameter</param>
+        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
         public static void CreateSharedParameterForAllCategories(string parameterName, string groupName, string type, string group, bool instance)
         {
             CreateSharedParameter(parameterName, groupName, type, group, instance, null); 
@@ -199,7 +199,7 @@ namespace Revit.Elements
         /// <param name="groupName">Group of the parameter for shared parameters</param>
         /// <param name="type">Parameter Type</param>
         /// <param name="group">Parameter Group</param>
-        /// <param name="instance">Is instance parameter, otherwise its a type parameter</param>
+        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
         /// <param name="categoryList">List of categories this parameter applies to, If no category is supplied, all possible categories are selected</param>
         public static void CreateSharedParameter(string parameterName, string groupName, string type, string group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
@@ -278,7 +278,7 @@ namespace Revit.Elements
         /// <param name="groupName">Group of the parameter for shared parameters</param>
         /// <param name="type">Parameter Type</param>
         /// <param name="group">Parameter Group</param>
-        /// <param name="instance">Is instance parameter, otherwise its a type parameter</param>
+        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
         public static void CreateProjectParameterForAllCategories(string parameterName, string groupName, string type, string group, bool instance)
         {
             CreateProjectParameter(parameterName, groupName, type, group, instance, null);
@@ -291,7 +291,7 @@ namespace Revit.Elements
         /// <param name="groupName">Group of the parameter for shared parameters</param>
         /// <param name="type">Parameter Type</param>
         /// <param name="group">Parameter Group</param>
-        /// <param name="instance">Is instance parameter, otherwise its a type parameter</param>
+        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
         /// <param name="categoryList">List of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
         public static void CreateProjectParameter(string parameterName, string groupName, string type, string group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {

--- a/src/Libraries/RevitNodes/Elements/Roof.cs
+++ b/src/Libraries/RevitNodes/Elements/Roof.cs
@@ -144,7 +144,7 @@ namespace Revit.Elements
         #region Public static constructors
 
         /// <summary>
-        /// Create a Revit Roof given it's curve outline and Level
+        /// Create a Revit Roof given its curve outline and Level
         /// </summary>
         /// <param name="outline"></param>
         /// <param name="RoofType"></param>


### PR DESCRIPTION
### Purpose

Just typo fixes I noticed when using the Floor.ByOutlineTypeAndLevel node. Checked it's vs its usage in all node descriptions and param descriptions.

### Reviewers

- @QilongTang ? _(is there a list of potential reviewers / who to tag for what type of PR?)_

### FYIs

N/A