### PR TITLE
update DynamoRevit for Revit2019 to Revit 2020

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyCompany("Autodesk, Inc")]
-[assembly: AssemblyProduct("Dynamo For Revit 2019")]
-[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2017-2018")]
+[assembly: AssemblyProduct("Dynamo For Revit 2020")]
+[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2019-2020")]
 [assembly: AssemblyTrademark("")]
 
 //In order to begin building localizable applications, set 

--- a/src/Config/CS.props
+++ b/src/Config/CS.props
@@ -6,7 +6,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
 	<VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-	<RevitVersionNumber Condition=" '$(RevitVersionNumber)' == '' ">2019</RevitVersionNumber>
+	<RevitVersionNumber Condition=" '$(RevitVersionNumber)' == '' ">2020</RevitVersionNumber>
 	<REVIT_VERSION>Revit_$(RevitVersionNumber)</REVIT_VERSION>
 	<OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)\$(REVIT_VERSION)</OutputPath>
     <NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\extern\NUnit</NunitPath>
@@ -30,7 +30,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
 	<VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-	<RevitVersionNumber Condition=" '$(RevitVersionNumber)' == '' ">2019</RevitVersionNumber>
+	<RevitVersionNumber Condition=" '$(RevitVersionNumber)' == '' ">2020</RevitVersionNumber>
 	<REVIT_VERSION>Revit_$(RevitVersionNumber)</REVIT_VERSION>
 	<OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)\$(REVIT_VERSION)</OutputPath>
     <NunitPath Condition=" '$(NunitPath)' == '' ">$(SolutionDir)..\extern\NUnit</NunitPath>

--- a/src/Config/user_local.props
+++ b/src/Config/user_local.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RevitVersionNumber Condition=" '$(RevitVersionNumber)' == '' ">2019</RevitVersionNumber>
+    <RevitVersionNumber Condition=" '$(RevitVersionNumber)' == '' ">2020</RevitVersionNumber>
 	<REVIT_VERSION>Revit_$(RevitVersionNumber)</REVIT_VERSION>
 	<DYNAMOTESTAPI Condition=" '$(DYNAMOTESTAPI)' == '' ">$(SolutionDir)..\..\Dynamo\bin\$(Platform)\$(Configuration)</DYNAMOTESTAPI>
 	<OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\..\Dynamo\bin\AnyCPU\$(Configuration)\$(REVIT_VERSION)</OutputPath>

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -380,8 +380,8 @@ namespace Revit.Elements
             Autodesk.Revit.DB.FillPatternElement solidFill = patternCollector.ToElements().Cast<Autodesk.Revit.DB.FillPatternElement>().First(x => x.GetFillPattern().IsSolidFill);
 
             var overrideColor = new Autodesk.Revit.DB.Color(color.Red, color.Green, color.Blue);
-            ogs.SetProjectionFillColor(overrideColor);
-            ogs.SetProjectionFillPatternId(solidFill.Id);
+            ogs.SetSurfaceForegroundPatternColor(overrideColor);
+            ogs.SetSurfaceForegroundPatternId(solidFill.Id);
             ogs.SetProjectionLineColor(overrideColor);
             view.SetElementOverrides(InternalElementId, ogs);
             TransactionManager.Instance.TransactionTaskDone();

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -380,6 +380,11 @@ namespace Revit.Elements
             Autodesk.Revit.DB.FillPatternElement solidFill = patternCollector.ToElements().Cast<Autodesk.Revit.DB.FillPatternElement>().First(x => x.GetFillPattern().IsSolidFill);
 
             var overrideColor = new Autodesk.Revit.DB.Color(color.Red, color.Green, color.Blue);
+            
+            // the old functions SetProjectionFillColor and SetProjectionFillPatternId,
+            // are obsoleted and suggested by the documentation that will be removed and 
+            // replaced by SetSurfaceForegroundPatternColor and SetSurfaceForegroundPatternId.
+
             ogs.SetSurfaceForegroundPatternColor(overrideColor);
             ogs.SetSurfaceForegroundPatternId(solidFill.Id);
             ogs.SetProjectionLineColor(overrideColor);

--- a/src/Libraries/RevitNodes/Filter/OverrideGraphicSettings.cs
+++ b/src/Libraries/RevitNodes/Filter/OverrideGraphicSettings.cs
@@ -66,6 +66,12 @@ namespace Revit.Filter
         {
             Autodesk.Revit.DB.OverrideGraphicSettings filterSettings = new Autodesk.Revit.DB.OverrideGraphicSettings();
 
+            // the old functions SetCutFillColor, SetCutFillPatternId,
+            // SetProjectionFillColor and SetProjectionFillPatternId,
+            // are obsoleted and suggested by the documentation that will be removed and 
+            // replaced by SetCutForegroundPatternColor, SetCutForegroundPatternId,
+            // SetSurfaceForegroundPatternColor, SetSurfaceForegroundPatternId.
+
             // Apply Colors
             if (cutFillColor != null) filterSettings.SetCutForegroundPatternColor(ToRevitColor(cutFillColor));
             if (projectionFillColor != null) filterSettings.SetSurfaceForegroundPatternColor(ToRevitColor(projectionFillColor));

--- a/src/Libraries/RevitNodes/Filter/OverrideGraphicSettings.cs
+++ b/src/Libraries/RevitNodes/Filter/OverrideGraphicSettings.cs
@@ -67,8 +67,8 @@ namespace Revit.Filter
             Autodesk.Revit.DB.OverrideGraphicSettings filterSettings = new Autodesk.Revit.DB.OverrideGraphicSettings();
 
             // Apply Colors
-            if (cutFillColor != null) filterSettings.SetCutFillColor(ToRevitColor(cutFillColor));
-            if (projectionFillColor != null) filterSettings.SetProjectionFillColor(ToRevitColor(projectionFillColor));
+            if (cutFillColor != null) filterSettings.SetCutForegroundPatternColor(ToRevitColor(cutFillColor));
+            if (projectionFillColor != null) filterSettings.SetSurfaceForegroundPatternColor(ToRevitColor(projectionFillColor));
             if (cutLineColor != null) filterSettings.SetCutLineColor(ToRevitColor(cutLineColor));
             if (projectionLineColor != null) filterSettings.SetProjectionLineColor(ToRevitColor(projectionLineColor));
 
@@ -77,8 +77,8 @@ namespace Revit.Filter
             if (projectionLineWeight != -1) filterSettings.SetProjectionLineWeight(projectionLineWeight);
 
             // Apply Patterns          
-            if (cutFillPattern != null) filterSettings.SetCutFillPatternId(cutFillPattern.InternalElement.Id);
-            if (projectionFillPattern != null) filterSettings.SetProjectionFillPatternId(projectionFillPattern.InternalElement.Id);
+            if (cutFillPattern != null) filterSettings.SetCutForegroundPatternId(cutFillPattern.InternalElement.Id);
+            if (projectionFillPattern != null) filterSettings.SetSurfaceForegroundPatternId(projectionFillPattern.InternalElement.Id);
             if (cutLinePattern != null) filterSettings.SetCutLinePatternId(cutLinePattern.InternalElement.Id);
             if (projectionLinePattern != null) filterSettings.SetProjectionLinePatternId(projectionLinePattern.InternalElement.Id);
 


### PR DESCRIPTION
The Revit version is updated to Revit 2020, so that the DynamoRevit should change the output from 2019 to 2020. Some functions are deprecated in Revit 2019 and should be replaced in the new version.