### PR TITLE
Prevent SiteLocation node in D4R from disappearing after save/reopen

### DIFF
--- a/src/Libraries/RevitNodesUI/SiteLocation.cs
+++ b/src/Libraries/RevitNodesUI/SiteLocation.cs
@@ -47,6 +47,7 @@ namespace DSRevitNodesUI
     {
         private readonly RevitDynamoModel model;
 
+        [JsonIgnore]
         public DynamoUnits.Location Location { get; set; }
 
         public SiteLocation()


### PR DESCRIPTION
### Purpose

[QNTM-1903](https://jira.autodesk.com/browse/QNTM-1903)

Add JSON ignore attribute to property we do not wish to serialize/deserialize.  This property was being serialized in JSON and failing to deserialize causing the node to disappear when opening a JSON graph containing the node.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] Snapshot of UI changes, if any.

### Reviewers

@ramramps 