### PR TITLE
Update D4R to consume Dynamo 2.0 interface modifications - Cherry-picked

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -48,6 +48,7 @@ namespace Dynamo.Applications.Models
             public IPathResolver PathResolver { get; set; }
             public IPreferences Preferences { get; set; }
             public bool StartInTestMode { get; set; }
+            public bool IsHeadless { get; set; }
             public IUpdateManager UpdateManager { get; set; }
             public ISchedulerThread SchedulerThread { get; set; }
             public string GeometryFactoryPath { get; set; }


### PR DESCRIPTION
### Purpose

Cherry-picked from [2018](https://github.com/DynamoDS/DynamoRevit/pull/1933)

This is a required addition after Core API changes in Dynamo [PR#8515](https://github.com/DynamoDS/Dynamo/pull/8515/files/85ca6c44e39c9d5a14451982c03e3982d0d61981#diff-be38827fb9c4b33572680d7ff6dc430f).

RevitStartConfiguration : IRevitStartConfiguration : IStartConfiguration
(IStartConfiguration now requires the `IsHeadless` property)

### Testing

I built D4R against the latest Dynamo Core locally and ran a subset of the many failing RTF tests which now all seem to be passing.  Once the NuGet packages are update we should see the same results on the build machine.

![image](https://user-images.githubusercontent.com/13341935/35994925-d8775a20-0cdf-11e8-8d1b-0c249fb1ef13.png)