### PR TITLE
Prevent SiteLocation node in D4R from disappearing after save/reopen - Cherry-picked

### DIFF
--- a/src/Libraries/RevitNodesUI/SiteLocation.cs
+++ b/src/Libraries/RevitNodesUI/SiteLocation.cs
@@ -47,6 +47,7 @@ namespace DSRevitNodesUI
     {
         private readonly RevitDynamoModel model;
 
+        [JsonIgnore]
         public DynamoUnits.Location Location { get; set; }
 
         public SiteLocation()


### PR DESCRIPTION
### Purpose

Cherry-picked from [2018](https://github.com/DynamoDS/DynamoRevit/pull/1934)

[QNTM-1903](https://jira.autodesk.com/browse/QNTM-1903)

Add JSON ignore attribute to property we do not wish to serialize/deserialize.  This property was being serialized in JSON and failing to deserialize causing the node to disappear when opening a JSON graph containing the node.