### PR TITLE
Update path resolver assembly for Dictionary built-in type

### DIFF
--- a/src/DynamoRevit/RevitPathResolver.cs
+++ b/src/DynamoRevit/RevitPathResolver.cs
@@ -37,7 +37,7 @@ namespace Dynamo.Applications
             {
                 "VMDataBridge.dll",
                 "ProtoGeometry.dll",
-                "Builtin.dll",
+                "DesignScriptBuiltin.dll",
                 "DSCoreNodes.dll",
                 "DSOffice.dll",
                 "DSIronPython.dll",

--- a/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
+++ b/test/Libraries/RevitTestServices/RevitTestPathResolver.cs
@@ -11,7 +11,7 @@ namespace RevitTestServices
         {
             AddPreloadLibraryPath("VMDataBridge.dll");
             AddPreloadLibraryPath("ProtoGeometry.dll");
-            AddPreloadLibraryPath("Builtin.dll");
+            AddPreloadLibraryPath("DesignScriptBuiltin.dll");
             AddPreloadLibraryPath("DSCoreNodes.dll");
             AddPreloadLibraryPath("DSOffice.dll");
             AddPreloadLibraryPath("DSIronPython.dll");


### PR DESCRIPTION
### Purpose

This PR is to update the path resolver for the changes in https://github.com/DynamoDS/Dynamo/pull/8636 to the assembly name for the Dictionary builtin types.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@aparajit-pratap @QilongTang 

### FYIs

@mjkkirschner @ramramps 