### PR TITLE
Fix compatibility with Revit2019-1

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -384,8 +384,8 @@ namespace Revit.Elements
             Autodesk.Revit.DB.FillPatternElement solidFill = patternCollector.ToElements().Cast<Autodesk.Revit.DB.FillPatternElement>().First(x => x.GetFillPattern().IsSolidFill);
 
             var overrideColor = new Autodesk.Revit.DB.Color(color.Red, color.Green, color.Blue);
-            ogs.SetProjectionFillColor(overrideColor);
-            ogs.SetProjectionFillPatternId(solidFill.Id);
+            ogs.SetSurfaceForegroundPatternColor(overrideColor); 
+            ogs.SetSurfaceForegroundPatternId(solidFill.Id); 
             ogs.SetProjectionLineColor(overrideColor);
             view.SetElementOverrides(InternalElementId, ogs);
             TransactionManager.Instance.TransactionTaskDone();

--- a/src/Libraries/RevitNodes/Filter/OverrideGraphicSettings.cs
+++ b/src/Libraries/RevitNodes/Filter/OverrideGraphicSettings.cs
@@ -67,8 +67,8 @@ namespace Revit.Filter
             Autodesk.Revit.DB.OverrideGraphicSettings filterSettings = new Autodesk.Revit.DB.OverrideGraphicSettings();
 
             // Apply Colors
-            if (cutFillColor != null) filterSettings.SetCutFillColor(ToRevitColor(cutFillColor));
-            if (projectionFillColor != null) filterSettings.SetProjectionFillColor(ToRevitColor(projectionFillColor));
+            if (cutFillColor != null) filterSettings.SetCutForegroundPatternColor(ToRevitColor(cutFillColor));
+            if (projectionFillColor != null) filterSettings.SetSurfaceForegroundPatternColor(ToRevitColor(projectionFillColor));
             if (cutLineColor != null) filterSettings.SetCutLineColor(ToRevitColor(cutLineColor));
             if (projectionLineColor != null) filterSettings.SetProjectionLineColor(ToRevitColor(projectionLineColor));
 
@@ -77,8 +77,8 @@ namespace Revit.Filter
             if (projectionLineWeight != -1) filterSettings.SetProjectionLineWeight(projectionLineWeight);
 
             // Apply Patterns          
-            if (cutFillPattern != null) filterSettings.SetCutFillPatternId(cutFillPattern.InternalElement.Id);
-            if (projectionFillPattern != null) filterSettings.SetProjectionFillPatternId(projectionFillPattern.InternalElement.Id);
+            if (cutFillPattern != null) filterSettings.SetCutForegroundPatternId(cutFillPattern.InternalElement.Id);
+            if (projectionFillPattern != null) filterSettings.SetSurfaceForegroundPatternId(projectionFillPattern.InternalElement.Id);
             if (cutLinePattern != null) filterSettings.SetCutLinePatternId(cutLinePattern.InternalElement.Id);
             if (projectionLinePattern != null) filterSettings.SetProjectionLinePatternId(projectionLinePattern.InternalElement.Id);
 


### PR DESCRIPTION
### Purpose
Fix compatibility with Revit2019-1

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers
@QilongTang
