### PR TITLE
QNTM-2101 Audit all Revit Nodes to remove lower-ranked-parameter overloads (RC2.0.0 Revit 2017)

### DIFF
--- a/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
+++ b/src/Libraries/RevitNodes/Elements/AdaptiveComponent.cs
@@ -336,28 +336,6 @@ namespace Revit.Elements
             return new AdaptiveComponent(uvs, ElementFaceReference.TryGetFaceReference(faceReference), familyType);
         }
 
-        [Obsolete]
-        [SupressImportIntoVM]
-        public static AdaptiveComponent[] ByParametersOnFace(double[][][] uvs, ElementFaceReference faceReference, FamilyType familyType)
-        {
-            if (uvs == null)
-            {
-                throw new ArgumentNullException("uvs");
-            }
-
-            if (faceReference == null)
-            {
-                throw new ArgumentNullException("faceReference");
-            }
-
-            if (familyType == null)
-            {
-                throw new ArgumentNullException("familyType");
-            }
-
-            return uvs.Select(x => ByParametersOnFace(x, faceReference, familyType)).ToArray();
-        }
-
         [IsVisibleInDynamoLibrary(false)]
         public static AdaptiveComponent ByParametersOnFace(Autodesk.DesignScript.Geometry.UV[] uvs, ElementFaceReference faceReference, FamilyType familyType)
         {
@@ -377,28 +355,6 @@ namespace Revit.Elements
             }
 
             return new AdaptiveComponent(uvs.Select(x => new[] { x.U, x.V }).ToArray(), ElementFaceReference.TryGetFaceReference(faceReference), familyType);
-        }
-
-        [Obsolete]
-        [SupressImportIntoVM]
-        public static AdaptiveComponent[] ByParametersOnFace(Autodesk.DesignScript.Geometry.UV[][] uvs, ElementFaceReference faceReference, FamilyType familyType)
-        {
-            if (uvs == null)
-            {
-                throw new ArgumentNullException("uvs");
-            }
-
-            if (faceReference == null)
-            {
-                throw new ArgumentNullException("faceReference");
-            }
-
-            if (familyType == null)
-            {
-                throw new ArgumentNullException("familyType");
-            }
-
-            return uvs.Select(x => ByParametersOnFace(x, faceReference, familyType)).ToArray();
         }
 
         [IsVisibleInDynamoLibrary(false)]
@@ -422,28 +378,6 @@ namespace Revit.Elements
             return new AdaptiveComponent(uvs, ElementFaceReference.TryGetFaceReference(surface), familyType);
         }
 
-        [Obsolete]
-        [SupressImportIntoVM]
-        public static AdaptiveComponent[] ByParametersOnFace(double[][][] uvs, Surface surface, FamilyType familyType)
-        {
-            if (uvs == null)
-            {
-                throw new ArgumentNullException("uvs");
-            }
-
-            if (surface == null)
-            {
-                throw new ArgumentNullException("surface");
-            }
-
-            if (familyType == null)
-            {
-                throw new ArgumentNullException("familyType");
-            }
-
-            return uvs.Select(x => ByParametersOnFace(x, surface, familyType)).ToArray();
-        }
-
         [IsVisibleInDynamoLibrary(false)]
         public static AdaptiveComponent ByParametersOnCurveReference(double[] parameters, Revit.Elements.Element revitCurve, FamilyType familyType)
         {
@@ -465,28 +399,6 @@ namespace Revit.Elements
             return new AdaptiveComponent(parameters, ElementCurveReference.TryGetCurveReference(revitCurve).InternalReference, familyType);
         }
 
-        [Obsolete]
-        [SupressImportIntoVM]
-        public static AdaptiveComponent[] ByParametersOnCurveReference(double[][] parameters, Revit.Elements.Element revitCurve, FamilyType familyType)
-        {
-            if (parameters == null)
-            {
-                throw new ArgumentNullException("parameters");
-            }
-
-            if (revitCurve == null)
-            {
-                throw new ArgumentNullException("revitCurve");
-            }
-
-            if (familyType == null)
-            {
-                throw new ArgumentNullException("familyType");
-            }
-
-            return parameters.Select(x => ByParametersOnCurveReference(x, revitCurve, familyType)).ToArray();
-        }
-
         [IsVisibleInDynamoLibrary(false)]
         public static AdaptiveComponent ByParametersOnCurveReference(double[] parameters, ElementCurveReference revitCurve, FamilyType familyType)
         {
@@ -506,28 +418,6 @@ namespace Revit.Elements
             }
 
             return new AdaptiveComponent(parameters, ElementCurveReference.TryGetCurveReference(revitCurve).InternalReference, familyType);
-        }
-
-        [Obsolete]
-        [SupressImportIntoVM]
-        public static AdaptiveComponent[] ByParametersOnCurveReference(double[][] parameters, ElementCurveReference revitCurve, FamilyType familyType)
-        {
-            if (parameters == null)
-            {
-                throw new ArgumentNullException("parameters");
-            }
-
-            if (revitCurve == null)
-            {
-                throw new ArgumentNullException("revitCurve");
-            }
-
-            if (familyType == null)
-            {
-                throw new ArgumentNullException("familyType");
-            }
-
-            return parameters.Select(x => ByParametersOnCurveReference(x, revitCurve, familyType)).ToArray();
         }
 
         #endregion
@@ -583,28 +473,6 @@ namespace Revit.Elements
             return new AdaptiveComponent(uvs.Select(x => new[] { x.U, x.V }).ToArray(), ElementFaceReference.TryGetFaceReference(surface), familyType);
         }
 
-        [Obsolete]
-        [SupressImportIntoVM]
-        public static AdaptiveComponent[] ByParametersOnFace(Autodesk.DesignScript.Geometry.UV[][] uvs, Surface surface, FamilyType familyType)
-        {
-            if (uvs == null)
-            {
-                throw new ArgumentNullException("uvs");
-            }
-
-            if (surface == null)
-            {
-                throw new ArgumentNullException("surface");
-            }
-
-            if (familyType == null)
-            {
-                throw new ArgumentNullException("familyType");
-            }
-
-            return uvs.Select(x => ByParametersOnFace(x, surface, familyType)).ToArray();
-        }
-
         /// <summary>
         /// Create an adaptive component referencing the parameters on a Curve reference
         /// </summary>
@@ -630,28 +498,6 @@ namespace Revit.Elements
             }
 
             return new AdaptiveComponent(parameters, ElementCurveReference.TryGetCurveReference(curve).InternalReference, familyType);
-        }
-
-        [Obsolete]
-        [SupressImportIntoVM]
-        public static AdaptiveComponent[] ByParametersOnCurveReference(double[][] parameters, Autodesk.DesignScript.Geometry.Curve curve, FamilyType familyType)
-        {
-            if (parameters == null)
-            {
-                throw new ArgumentNullException("parameters");
-            }
-
-            if (curve == null)
-            {
-                throw new ArgumentNullException("curve");
-            }
-
-            if (familyType == null)
-            {
-                throw new ArgumentNullException("familyType");
-            }
-
-            return parameters.Select(x => ByParametersOnCurveReference(x, curve, familyType)).ToArray();
         }
 
         /// <summary>

--- a/src/Libraries/RevitNodes/Elements/Form.cs
+++ b/src/Libraries/RevitNodes/Elements/Form.cs
@@ -100,24 +100,10 @@ namespace Revit.Elements
         #region Hidden public static constructors 
 
         [IsVisibleInDynamoLibrary(false)]
-        public static Form ByLoftCrossSections(ElementCurveReference[] curves, bool isSolid = true)
-        {
-            if (curves == null) throw new ArgumentNullException("curves");
-            return ByLoftCrossSectionsInternal(curves, isSolid);
-        }
-
-        [IsVisibleInDynamoLibrary(false)]
         public static Form ByLoftCrossSections(ElementCurveReference[][] curves, bool isSolid = true)
         {
             if (curves == null) throw new ArgumentNullException("curves");
             return ByLoftMultiPartCrossSectionsInternal(curves, isSolid);
-        }
-
-        [IsVisibleInDynamoLibrary(false)]
-        public static Form ByLoftCrossSections(Revit.Elements.Element[] curves, bool isSolid = true)
-        {
-            if (curves == null) throw new ArgumentNullException("curves");
-            return ByLoftCrossSectionsInternal(curves, isSolid);
         }
 
         [IsVisibleInDynamoLibrary(false)]
@@ -130,17 +116,6 @@ namespace Revit.Elements
         #endregion
 
         #region Public static constructors
-        /// <summary>
-        /// Creates a Form by lofting a list of curves
-        /// </summary>
-        /// <param name="curves"></param>
-        /// <param name="isSolid"></param>
-        /// <returns></returns>
-        public static Form ByLoftCrossSections(Autodesk.DesignScript.Geometry.Curve[] curves, bool isSolid = true)
-        {
-            if (curves == null) throw new ArgumentNullException("curves");
-            return ByLoftCrossSectionsInternal(curves, isSolid);
-        }
         /// <summary>
         ///  Creates a Form by lofting a nested list of curves
         /// </summary>
@@ -156,31 +131,6 @@ namespace Revit.Elements
         #endregion
 
         #region Private static constructors
-
-        private static Form ByLoftCrossSectionsInternal(object[] curves, bool isSolid = true)
-        {
-            if (curves == null) throw new ArgumentNullException("curves");
-
-            // if the arguments are polycurves, explode them
-            if (curves.Any(x => x is PolyCurve))
-            {
-                var ca = curves.Select(x => x is PolyCurve ? ((PolyCurve)x).Curves() : new[] { x }).ToArray();
-                return ByLoftMultiPartCrossSectionsInternal(ca, isSolid);
-            }
-
-            var refArrArr = new ReferenceArrayArray();
-
-            foreach (var l in curves)
-            {
-                if (l == null) throw new ArgumentNullException("curves");
-                var refArr = new ReferenceArray();
-
-                refArr.Append(ElementCurveReference.TryGetCurveReference(l, "Form").InternalReference);
-                refArrArr.Append(refArr);
-            }
-
-            return new Form(isSolid, refArrArr);
-        }
 
         private static Form ByLoftMultiPartCrossSectionsInternal(object[][] curves, bool isSolid = true)
         {

--- a/test/Libraries/RevitNodesTests/Elements/FormTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/FormTests.cs
@@ -28,7 +28,14 @@ namespace RevitNodesTests.Elements
 
             Assert.AreEqual(2, eles.Count());
 
-            var loft = Form.ByLoftCrossSections(eles.ToArray(), false);
+            var curveArray = eles.ToArray();
+            ElementCurveReference[][] curveArrayArray =
+            {
+                new ElementCurveReference[] {curveArray[0]},
+                new ElementCurveReference[] {curveArray[1]}
+            };
+
+            var loft = Form.ByLoftCrossSections(curveArrayArray, false);
 
             Assert.NotNull(loft);
             Assert.IsTrue(DocumentManager.Instance.ElementExistsInDocument(


### PR DESCRIPTION
### Purpose
Cherry-picking for RC2.0.0 Revit 2017, see #1959 for more information.

### FYI
@aparajit-pratap 
