### PR TITLE
Force Nuget to use 2.0 packages

### DIFF
--- a/src/Config/packages-template.aget
+++ b/src/Config/packages-template.aget
@@ -1,12 +1,12 @@
 {
   "nuget": {
     "references": {
-      "DynamoVisualProgramming.Core" : "LatestBeta",
-      "DynamoVisualProgramming.DynamoCoreNodes" : "LatestBeta",
-      "DynamoVisualProgramming.DynamoServices" : "LatestBeta",
-      "DynamoVisualProgramming.Tests" : "LatestBeta",
-      "DynamoVisualProgramming.WpfUILibrary" : "LatestBeta",
-      "DynamoVisualProgramming.ZeroTouchLibrary" : "LatestBeta",
+      "DynamoVisualProgramming.Core" : "2.0.0-beta1",
+      "DynamoVisualProgramming.DynamoCoreNodes" : "2.0.0-beta1",
+      "DynamoVisualProgramming.DynamoServices" : "2.0.0-beta1",
+      "DynamoVisualProgramming.Tests" : "2.0.0-beta1",
+      "DynamoVisualProgramming.WpfUILibrary" : "2.0.0-beta1",
+      "DynamoVisualProgramming.ZeroTouchLibrary" : "2.0.0-beta1",
       "Greg" : "1.0.6176.18754",
       "GregRevitAuth" : "1.0.5907.17451",
       "IronPython" : "2.7.2",


### PR DESCRIPTION
### Purpose

Force a 2.0 nuget package version

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate

### Reviewers

@QilongTang @mjkkirschner 


### FYIs

@ramramps 
