### PR TITLE
3dview wrapper 2018

### DIFF
--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -2,7 +2,7 @@
 using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 using Revit.Elements.Views;
-using View3D = Revit.Elements.Views.View3D;
+using AbstractView3D = Revit.Elements.Views.AbstractView3D;
 
 namespace Revit.Elements
 {
@@ -151,16 +151,14 @@ namespace Revit.Elements
             return WallType.FromExisting(ele, isRevitOwned);
         }
 
-        public static View3D Wrap(Autodesk.Revit.DB.View3D view, bool isRevitOwned)
+        public static AbstractView3D Wrap(Autodesk.Revit.DB.View3D view, bool isRevitOwned)
         {
-            if (!view.IsTemplate)
-            {
-                if (view.IsPerspective)
-                    return PerspectiveView.FromExisting(view, isRevitOwned);
-                else
-                    return AxonometricView.FromExisting(view, isRevitOwned);
-            }
-            return null;
+            if (view.IsTemplate)
+                return Revit.Elements.Views.View3D.FromExisting(view, isRevitOwned);
+            if (view.IsPerspective)
+                return PerspectiveView.FromExisting(view, isRevitOwned);
+
+            return AxonometricView.FromExisting(view, isRevitOwned);
         }
 
         public static Element Wrap(Autodesk.Revit.DB.ViewPlan view, bool isRevitOwned)

--- a/src/Libraries/RevitNodes/Elements/Views/AbstractView3D.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/AbstractView3D.cs
@@ -1,0 +1,515 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.DesignScript.Runtime;
+using Autodesk.Revit.DB;
+using RevitServices.Persistence;
+using RevitServices.Transactions;
+
+namespace Revit.Elements.Views
+{
+    [IsVisibleInDynamoLibrary(false)]
+    [DynamoServices.RegisterForTrace]
+    public abstract class AbstractView3D : View
+    {
+        [IsVisibleInDynamoLibrary(false)]
+        public const string DefaultViewName = "dynamo3D";
+
+        #region Internal properties
+
+        /// <summary>
+        /// An internal handle on the Revit element
+        /// </summary>
+        internal Autodesk.Revit.DB.View3D InternalView3D
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Reference to the Element
+        /// </summary>
+        public override Autodesk.Revit.DB.Element InternalElement
+        {
+            get { return InternalView3D; }
+        }
+
+        #endregion
+
+        #region Private helper methods
+
+        /// <summary>
+        /// Build Orientation3D object for eye point and a target point 
+        /// </summary>
+        /// <param name="eyePoint"></param>
+        /// <param name="target"></param>
+        /// <returns></returns>
+        protected static ViewOrientation3D BuildOrientation3D(XYZ eyePoint, XYZ target)
+        {
+            var globalUp = XYZ.BasisZ;
+            var direction = target.Subtract(eyePoint).Normalize();
+
+            // If the direction is zero length (ex. the eye and target
+            // points are coincident) than set the direction to look
+            // along the x axis by default. Otherwise, the call to
+            // create a ViewOrientation3D object will fail.
+            if (direction.IsZeroLength())
+            {
+                direction = XYZ.BasisX;
+            }
+
+            // If the direction points along Z, then 
+            // switch the global up to Y
+            if (direction.IsAlmostEqualTo(globalUp) ||
+                (direction.Negate().IsAlmostEqualTo(globalUp)))
+            {
+                globalUp = XYZ.BasisY;
+            }
+
+            var up = direction.CrossProduct(globalUp).CrossProduct(direction);
+
+            if (up.IsZeroLength())
+            {
+                up = XYZ.BasisZ;
+            }
+
+            // If up is zero length (ex. the direction vector is the z axis),
+            // set the up to be along the Z axis.
+            return new ViewOrientation3D(eyePoint, up, direction);
+
+        }
+
+        /// <summary>
+        /// Obtain a sparse point collection outlining a Revit element bt traversing it's
+        /// GeometryObject representation
+        /// </summary>
+        /// <param name="e"></param>
+        /// <param name="pts"></param>
+        protected static void GetPointCloud(Autodesk.Revit.DB.Element e, List<XYZ> pts)
+        {
+            var options = new Options
+            {
+                ComputeReferences = true,
+                DetailLevel = ViewDetailLevel.Coarse,
+                IncludeNonVisibleObjects = false
+            };
+
+            foreach (var gObj in e.get_Geometry(options))
+            {
+                if (gObj is Solid)
+                {
+                    GetPointCloud(gObj as Solid, pts);
+                }
+                else if (gObj is GeometryInstance)
+                {
+                    GetPointCloud(gObj as GeometryInstance, pts);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Obtain a point collection outlining a GeometryObject
+        /// </summary>
+        /// <param name="geomInst"></param>
+        /// <param name="pts"></param>
+        protected static void GetPointCloud(GeometryInstance geomInst, List<XYZ> pts)
+        {
+            foreach (var gObj in geomInst.GetInstanceGeometry())
+            {
+                if (gObj is Solid)
+                {
+                    GetPointCloud(gObj as Solid, pts);
+                }
+                else if (gObj is GeometryInstance)
+                {
+                    GetPointCloud(gObj as GeometryInstance, pts);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Obtain a point collection outlining a Solid GeometryObject
+        /// </summary>
+        /// <param name="solid"></param>
+        /// <param name="pts"></param>
+        protected static void GetPointCloud(Solid solid, List<XYZ> pts)
+        {
+            foreach (Edge gEdge in solid.Edges)
+            {
+                var c = gEdge.AsCurve();
+                if (c is Line)
+                {
+                    pts.Add(c.Evaluate(0, true));
+                    pts.Add(c.Evaluate(1, true));
+                }
+                else
+                {
+                    IList<XYZ> xyzArray = gEdge.Tessellate();
+                    pts.AddRange(xyzArray);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Make a single element appear in a particular view
+        /// </summary>
+        /// <param name="view"></param>
+        /// <param name="element"></param>
+        protected static void IsolateInView(Autodesk.Revit.DB.View3D view, Autodesk.Revit.DB.Element element)
+        {
+            var fec = GetVisibleElementFilter();
+
+            view.CropBoxActive = true;
+
+            var toHide =
+                fec.ToElements().Where(x => !x.IsHidden(view) && x.CanBeHidden(view) && x.Id != element.Id).Select(x => x.Id).ToList();
+
+            if (toHide.Count > 0)
+                view.HideElements(toHide);
+
+            DocumentManager.Regenerate();
+
+            // After a regeneration, we need to ensure that a 
+            // transaction is re-opened.
+            TransactionManager.Instance.EnsureInTransaction(DocumentManager.Instance.CurrentDBDocument);
+
+            if (view.IsPerspective)
+            {
+                var farClip = view.LookupParameter("Far Clip Active");
+                farClip.Set(0);
+            }
+            else
+            {
+                var pts = new List<XYZ>();
+
+                GetPointCloud(element, pts);
+
+                var bounding = view.CropBox;
+                var transInverse = bounding.Transform.Inverse;
+                var transPts = pts.Select(transInverse.OfPoint);
+
+                //ingore the Z coordindates and find
+                //the max X ,Y and Min X, Y in 3d view.
+                double dMaxX = 0, dMaxY = 0, dMinX = 0, dMinY = 0;
+
+                var bFirstPt = true;
+                foreach (var pt1 in transPts)
+                {
+                    if (bFirstPt)
+                    {
+                        dMaxX = pt1.X;
+                        dMaxY = pt1.Y;
+                        dMinX = pt1.X;
+                        dMinY = pt1.Y;
+                        bFirstPt = false;
+                    }
+                    else
+                    {
+                        if (dMaxX < pt1.X)
+                            dMaxX = pt1.X;
+                        if (dMaxY < pt1.Y)
+                            dMaxY = pt1.Y;
+                        if (dMinX > pt1.X)
+                            dMinX = pt1.X;
+                        if (dMinY > pt1.Y)
+                            dMinY = pt1.Y;
+                    }
+                }
+
+                bounding.Max = new XYZ(dMaxX, dMaxY, bounding.Max.Z);
+                bounding.Min = new XYZ(dMinX, dMinY, bounding.Min.Z);
+                view.CropBox = bounding;
+            }
+
+            view.CropBoxVisible = false;
+
+        }
+
+        /// <summary>
+        /// Set the cropping for the current view
+        /// </summary>
+        /// <param name="view3D"></param>
+        /// <param name="bbox"></param>
+        private void IsolateInView(Autodesk.Revit.DB.View3D view3D, BoundingBoxXYZ bbox)
+        {
+            view3D.CropBox = bbox;
+        }
+
+        /// <summary>
+        /// Create a Revit 3D View
+        /// </summary>
+        /// <param name="orient"></param>
+        /// <param name="name"></param>
+        /// <param name="isPerspective"></param>
+        /// <returns></returns>
+        protected static Autodesk.Revit.DB.View3D Create3DView(ViewOrientation3D orient, string name, bool isPerspective)
+        {
+            // (sic) From the Dynamo legacy implementation
+            var viewFam = DocumentManager.Instance.ElementsOfType<ViewFamilyType>()
+                .FirstOrDefault(x => x.ViewFamily == ViewFamily.ThreeDimensional);
+
+            if (viewFam == null)
+            {
+                throw new Exception("There is no three dimensional view family int he document");
+            }
+
+            var view = isPerspective 
+                ? Autodesk.Revit.DB.View3D.CreatePerspective(Document, viewFam.Id) 
+                : Autodesk.Revit.DB.View3D.CreateIsometric(Document, viewFam.Id);
+
+            view.SetOrientation(orient);
+            view.SaveOrientationAndLock();
+            view.Name = CreateUniqueViewName(name);
+
+            return view;
+        }
+
+        /// <summary>
+        /// Determines whether a view with the provided name already exists.
+        /// If a view exists with the provided name, and new view is created with
+        /// a unique name. Otherwise, the original view name is returned.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns>The original name if it is already unique, or 
+        /// a unique version of the name.</returns>
+        public static string CreateUniqueViewName(string name)
+        {
+            var collector = new FilteredElementCollector(Document);
+            collector.OfClass(typeof(Autodesk.Revit.DB.View));
+
+            // If the name is already unique then return it.
+            if (collector.All(x => x.Name != name))
+                return name;
+
+            // Create a unique name by appending a guid to
+            // the end of the view name
+            var viewName = $"{name}_{Guid.NewGuid()}";
+
+            return viewName;
+        }
+
+        /// <summary>
+        /// Utility method to create a filtered element collector which collects all elements in a view
+        /// which Dynamo would like to view or on which Dynamo would like to operate.
+        /// </summary>
+        /// <returns></returns>
+        protected static FilteredElementCollector GetVisibleElementFilter()
+        {
+            var fec = new FilteredElementCollector(Document);
+            var filterList = new List<ElementFilter>();
+
+            var fContinuousRail = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.ContinuousRail));
+            var fRailing = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.Railing));
+            var fStairs = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.Stairs));
+            var fStairsLanding = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.StairsLanding));
+            var fTopographySurface = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.TopographySurface));
+            var fAssemblyInstance = new ElementClassFilter(typeof(AssemblyInstance));
+            var fBaseArray = new ElementClassFilter(typeof(BaseArray));
+            var fBeamSystem = new ElementClassFilter(typeof(BeamSystem));
+            var fBoundaryConditions = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.BoundaryConditions));
+            var fConnectorElement = new ElementClassFilter(typeof(ConnectorElement));
+            var fControl = new ElementClassFilter(typeof(Control));
+            var fCurveElement = new ElementClassFilter(typeof(Autodesk.Revit.DB.CurveElement));
+            var fDividedSurface = new ElementClassFilter(typeof(Autodesk.Revit.DB.DividedSurface));
+            var fCableTrayConduitRunBase = new ElementClassFilter(typeof(Autodesk.Revit.DB.Electrical.CableTrayConduitRunBase));
+            var fHostObject = new ElementClassFilter(typeof(HostObject));
+            var fInstance = new ElementClassFilter(typeof(Instance));
+            var fmepSystem = new ElementClassFilter(typeof(MEPSystem));
+            var fModelText = new ElementClassFilter(typeof(Autodesk.Revit.DB.ModelText));
+            var fOpening = new ElementClassFilter(typeof(Opening));
+            var fPart = new ElementClassFilter(typeof(Part));
+            var fPartMaker = new ElementClassFilter(typeof(PartMaker));
+            var fReferencePlane = new ElementClassFilter(typeof(Autodesk.Revit.DB.ReferencePlane));
+            var fReferencePoint = new ElementClassFilter(typeof(Autodesk.Revit.DB.ReferencePoint));
+            var fSpatialElement = new ElementClassFilter(typeof(SpatialElement));
+            var fAreaReinforcement = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.AreaReinforcement));
+            var fHub = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.Hub));
+            var fPathReinforcement = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.PathReinforcement));
+            var fRebar = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.Rebar));
+            var fTruss = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.Truss));
+
+            #region Unused
+            //Autodesk.Revit.DB.Analysis.AnalysisDisplayLegend;
+            //Autodesk.Revit.DB.Analysis.AnalysisDisplayStyle;
+            //Autodesk.Revit.DB.Analysis.MassEnergyAnalyticalModel;
+            //Autodesk.Revit.DB.Analysis.MassLevelData;
+            //Autodesk.Revit.DB.Analysis.MassSurfaceData;
+            //Autodesk.Revit.DB.Analysis.MassZone;
+            //Autodesk.Revit.DB.Analysis.SpatialFieldManager;
+            //Autodesk.Revit.DB.AreaScheme;
+            //Autodesk.Revit.DB.AppearanceAssetElement;
+            //var FStairsPath = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.StairsPath));
+            //var FStairsRun = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.StairsRun));
+            //Autodesk.Revit.DB.AreaScheme;
+            //ElementClassFilter FBasePoint = new ElementClassFilter(typeof(Autodesk.Revit.DB.BasePoint));
+            //ElementClassFilter FCombinableElement = new ElementClassFilter(typeof(Autodesk.Revit.DB.CombinableElement));
+            //Autodesk.Revit.DB..::..ComponentRepeater
+            //Autodesk.Revit.DB..::..ComponentRepeaterSlot
+            //Autodesk.Revit.DB.DesignOption;
+            //Autodesk.Revit.DB.Dimension;
+            //Autodesk.Revit.DB..::..DisplacementElement
+            //Autodesk.Revit.DB.Electrical.ElectricalDemandFactorDefinition;
+            //Autodesk.Revit.DB.Electrical.ElectricalLoadClassification;
+            //Autodesk.Revit.DB.Electrical.PanelScheduleSheetInstance;
+            //Autodesk.Revit.DB.Electrical.PanelScheduleTemplate;
+            //var fElementType = new ElementClassFilter(typeof(ElementType));
+            //Autodesk.Revit.DB..::..ElevationMarker
+            //ElementClassFilter FFamilyBase = new ElementClassFilter(typeof(Autodesk.Revit.DB.FamilyBase));
+            //Autodesk.Revit.DB.FilledRegion;
+            //Autodesk.Revit.DB.FillPatternElement;
+            //Autodesk.Revit.DB.FilterElement;
+            //Autodesk.Revit.DB.GraphicsStyle;
+            //Autodesk.Revit.DB.Grid;
+            //ElementClassFilter FGroup = new ElementClassFilter(typeof(Autodesk.Revit.DB.Group));
+            //Autodesk.Revit.DB.IndependentTag;
+            //Autodesk.Revit.DB.Level;
+            //Autodesk.Revit.DB.LinePatternElement;
+            //Autodesk.Revit.DB.Material;
+            //Autodesk.Revit.DB.Mechanical.Zone;
+            //Autodesk.Revit.DB..::..MultiReferenceAnnotation
+            //Autodesk.Revit.DB.Phase;
+            //Autodesk.Revit.DB..::..PhaseFilter
+            //Autodesk.Revit.DB.PrintSetting;
+            //Autodesk.Revit.DB.ProjectInfo;
+            //Autodesk.Revit.DB.PropertyLine;
+            //ElementClassFilter FPropertySetElement = new ElementClassFilter(typeof(Autodesk.Revit.DB.PropertySetElement));
+            //Autodesk.Revit.DB.PropertySetLibrary;
+            //Autodesk.Revit.DB..::..ScheduleSheetInstance
+            //Autodesk.Revit.DB..::..Segment
+            //ElementClassFilter FSketchBase = new ElementClassFilter(typeof(Autodesk.Revit.DB.SketchBase));
+            //ElementClassFilter FSketchPlane = new ElementClassFilter(typeof(Autodesk.Revit.DB.SketchPlane));
+            //Autodesk.Revit.DB..::..SpatialElementCalculationLocation
+            //ElementClassFilter FSpatialElementTag = new ElementClassFilter(typeof(Autodesk.Revit.DB.SpatialElementTag));
+            //Autodesk.Revit.DB.Structure..::..AnalyticalLink
+            //Autodesk.Revit.DB.Structure.AnalyticalModel;
+            //Autodesk.Revit.DB.Structure..::..FabricArea
+            //Autodesk.Revit.DB.Structure..::..FabricReinSpanSymbolControl
+            //Autodesk.Revit.DB.Structure..::..FabricSheet
+            //Autodesk.Revit.DB.Structure.LoadBase;
+            //Autodesk.Revit.DB.Structure.LoadCase;
+            //Autodesk.Revit.DB.Structure.LoadCombination;
+            //Autodesk.Revit.DB.Structure.LoadNature;
+            //Autodesk.Revit.DB.Structure.LoadUsage;
+            //Autodesk.Revit.DB.Structure..::..RebarInSystem
+            //Autodesk.Revit.DB.SunAndShadowSettings;
+            //Autodesk.Revit.DB.TextElement;
+            //Autodesk.Revit.DB.View;
+            //Autodesk.Revit.DB..::..Viewport
+            //Autodesk.Revit.DB.ViewSheetSet;
+            //Autodesk.Revit.DB.WorksharingDisplaySettings;
+            #endregion
+
+            filterList.Add(fContinuousRail);
+            filterList.Add(fRailing);
+            filterList.Add(fStairs);
+            filterList.Add(fStairsLanding);
+            filterList.Add(fTopographySurface);
+            filterList.Add(fAssemblyInstance);
+            filterList.Add(fBaseArray);
+            filterList.Add(fBeamSystem);
+            filterList.Add(fBoundaryConditions);
+            filterList.Add(fConnectorElement);
+            filterList.Add(fControl);
+            filterList.Add(fCurveElement);
+            filterList.Add(fDividedSurface);
+            filterList.Add(fCableTrayConduitRunBase);
+            filterList.Add(fHostObject);
+            filterList.Add(fInstance);
+            filterList.Add(fmepSystem);
+            filterList.Add(fModelText);
+            filterList.Add(fOpening);
+            filterList.Add(fPart);
+            filterList.Add(fPartMaker);
+            filterList.Add(fReferencePlane);
+            filterList.Add(fReferencePoint);
+            filterList.Add(fAreaReinforcement);
+            filterList.Add(fHub);
+            filterList.Add(fPathReinforcement);
+            filterList.Add(fRebar);
+            filterList.Add(fTruss);
+            filterList.Add(fSpatialElement);
+
+            var cRvtLinks = new ElementCategoryFilter(BuiltInCategory.OST_RvtLinks);
+            filterList.Add(cRvtLinks);
+
+            var filters = new LogicalOrFilter(filterList);
+            fec.WherePasses(filters).WhereElementIsNotElementType();
+
+            return fec;
+        }
+
+        #endregion
+
+        #region Protected mutators
+
+        /// <summary>
+        /// Set the name of the current view
+        /// </summary>
+        /// <param name="name"></param>
+        protected void InternalSetName(string name)
+        {
+            if (name == DefaultViewName && InternalView3D.Name.Contains(DefaultViewName + "_"))
+            {
+                // Assume that this has already been set unique.
+                return;
+            }
+
+            if (!InternalView3D.Name.Equals(name))
+                InternalView3D.Name = CreateUniqueViewName(name);
+        }
+
+        /// <summary>
+        /// Set the orientation of the view
+        /// </summary>
+        /// <param name="orient"></param>
+        protected void InternalSetOrientation(ViewOrientation3D orient)
+        {
+            if (InternalView3D.ViewDirection.IsAlmostEqualTo(-orient.ForwardDirection) &&
+                InternalView3D.Origin.IsAlmostEqualTo(orient.EyePosition)) return;
+
+            InternalView3D.Unlock();
+            InternalView3D.SetOrientation(orient);
+            InternalView3D.SaveOrientationAndLock();
+        }
+
+        /// <summary>
+        /// Isolate the element in the current view by creating a mininum size crop box around it
+        /// </summary>
+        /// <param name="element"></param>
+        protected void InternalIsolateInView(Autodesk.Revit.DB.Element element)
+        {
+            IsolateInView(InternalView3D, element);
+        }
+
+        /// <summary>
+        /// Isolate the bounding box in the current view
+        /// </summary>
+        /// <param name="bbox"></param>
+        protected void InternalIsolateInView(BoundingBoxXYZ bbox)
+        {
+            IsolateInView(InternalView3D, bbox);
+        }
+
+        /// <summary>
+        /// Show all hiddent elements in the view
+        /// </summary>
+        protected void InternalRemoveIsolation()
+        {
+            InternalView3D.UnhideElements(GetVisibleElementFilter().ToElementIds());
+            InternalView3D.CropBoxActive = false;
+        }
+
+        /// <summary>
+        /// Set the InternalView3D property and the associated element id and unique id
+        /// </summary>
+        /// <param name="view"></param>
+        protected void InternalSetView3D(Autodesk.Revit.DB.View3D view)
+        {
+            InternalView3D = view;
+            InternalElementId = view.Id;
+            InternalUniqueId = view.UniqueId;
+        }
+
+        #endregion
+    }
+}

--- a/src/Libraries/RevitNodes/Elements/Views/AxonometricView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/AxonometricView.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-
 using Autodesk.Revit.DB;
-
 using DynamoServices;
-
 using Revit.GeometryConversion;
-
 using RevitServices.Persistence;
 using RevitServices.Transactions;
 
@@ -15,7 +11,7 @@ namespace Revit.Elements.Views
     /// A Revit View3D
     /// </summary>
     [RegisterForTrace]
-    public class AxonometricView : View3D
+    public class AxonometricView : AbstractView3D
     {
         #region Private constructors
 
@@ -30,7 +26,7 @@ namespace Revit.Elements.Views
         /// <summary>
         /// Private constructor
         /// </summary>
-        private AxonometricView(XYZ eye, XYZ target, BoundingBoxXYZ bbox, string name = DEFAULT_VIEW_NAME,
+        private AxonometricView(XYZ eye, XYZ target, BoundingBoxXYZ bbox, string name = DefaultViewName,
             bool isolate = false)
         {
             SafeInit(() => InitAxonometricView(eye, target, bbox, name, isolate));
@@ -39,7 +35,7 @@ namespace Revit.Elements.Views
         /// <summary>
         /// Private constructor
         /// </summary>
-        private AxonometricView(XYZ eye, XYZ target, string name = DEFAULT_VIEW_NAME, Autodesk.Revit.DB.Element element = null, bool isolate = false)
+        private AxonometricView(XYZ eye, XYZ target, string name = DefaultViewName, Autodesk.Revit.DB.Element element = null, bool isolate = false)
         {
             SafeInit(() => InitAxonometricView(eye, target, name, element, isolate));
         }
@@ -59,7 +55,7 @@ namespace Revit.Elements.Views
         /// <summary>
         /// Initialize an AxonometricView element
         /// </summary>
-        private void InitAxonometricView(XYZ eye, XYZ target, BoundingBoxXYZ bbox, string name = DEFAULT_VIEW_NAME, bool isolate = false)
+        private void InitAxonometricView(XYZ eye, XYZ target, BoundingBoxXYZ bbox, string name = DefaultViewName, bool isolate = false)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldEle =
@@ -91,7 +87,7 @@ namespace Revit.Elements.Views
         /// <summary>
         /// Initialize an AxonometricView element
         /// </summary>
-        private void InitAxonometricView(XYZ eye, XYZ target, string name = DEFAULT_VIEW_NAME, Autodesk.Revit.DB.Element element = null, bool isolate = false)
+        private void InitAxonometricView(XYZ eye, XYZ target, string name = DefaultViewName, Autodesk.Revit.DB.Element element = null, bool isolate = false)
         {
             //Phase 1 - Check to see if the object exists and should be rebound
             var oldEle =
@@ -130,7 +126,7 @@ namespace Revit.Elements.Views
                 InternalRemoveIsolation();
         }
 
-        private void InternalSetIsolation(Autodesk.Revit.DB.BoundingBoxXYZ bbox, bool isolate)
+        private void InternalSetIsolation(BoundingBoxXYZ bbox, bool isolate)
         {
             if (isolate && bbox != null)
                 InternalIsolateInView(bbox);
@@ -151,7 +147,7 @@ namespace Revit.Elements.Views
         public static AxonometricView ByEyePointAndTarget(
             Autodesk.DesignScript.Geometry.Point eyePoint,
             Autodesk.DesignScript.Geometry.Point target, 
-            string name = DEFAULT_VIEW_NAME)
+            string name = DefaultViewName)
         {
             if (eyePoint == null)
                 throw new ArgumentNullException("eyePoint");
@@ -161,7 +157,7 @@ namespace Revit.Elements.Views
 
             if (name == null)
             {
-                name = DEFAULT_VIEW_NAME;
+                name = DefaultViewName;
             }
 
             return ByEyePointTargetAndElement(eyePoint,
@@ -183,7 +179,7 @@ namespace Revit.Elements.Views
         public static AxonometricView ByEyePointTargetAndElement(
             Autodesk.DesignScript.Geometry.Point eyePoint, 
             Autodesk.DesignScript.Geometry.Point target,
-            string name = DEFAULT_VIEW_NAME, 
+            string name = DefaultViewName, 
             Element element = null, 
             bool isolateElement = false)
         {
@@ -195,7 +191,7 @@ namespace Revit.Elements.Views
 
             if (name == null)
             {
-                name = DEFAULT_VIEW_NAME;
+                name = DefaultViewName;
             }
 
             if (element == null)
@@ -233,7 +229,7 @@ namespace Revit.Elements.Views
         public static AxonometricView ByEyePointTargetAndBoundingBox(Autodesk.DesignScript.Geometry.Point eyePoint, 
             Autodesk.DesignScript.Geometry.Point target, 
             Autodesk.DesignScript.Geometry.BoundingBox boundingBox, 
-            string name = DEFAULT_VIEW_NAME, 
+            string name = DefaultViewName, 
             bool isolateElement = false)
         {
             if (boundingBox == null)
@@ -249,7 +245,7 @@ namespace Revit.Elements.Views
 
             if (name == null)
             {
-                name = DEFAULT_VIEW_NAME;
+                name = DefaultViewName;
             }
 
             return new AxonometricView(eyePoint.ToXyz(true), target.ToXyz(true), boundingBox.ToRevitType(true), name, isolateElement);

--- a/src/Libraries/RevitNodes/Elements/Views/DraftingView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/DraftingView.cs
@@ -82,7 +82,7 @@ namespace Revit.Elements.Views
 
             //rename the view
             if (!vd.Name.Equals(name))
-                vd.Name = View3D.CreateUniqueViewName(name);
+                vd.Name = AbstractView3D.CreateUniqueViewName(name);
 
             InternalSetDraftingView(vd);
 

--- a/src/Libraries/RevitNodes/Elements/Views/PerspectiveView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/PerspectiveView.cs
@@ -15,7 +15,7 @@ namespace Revit.Elements.Views
     /// A Revit View3D
     /// </summary>
     [RegisterForTrace]
-    public class PerspectiveView : View3D
+    public class PerspectiveView : AbstractView3D
     {
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Views/View3D.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View3D.cs
@@ -1,532 +1,59 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Autodesk.DesignScript.Runtime;
-using Autodesk.Revit.DB;
-using RevitServices.Persistence;
-using RevitServices.Transactions;
+using DynamoServices;
 
 namespace Revit.Elements.Views
 {
-    public abstract class View3D : View
+    /// <summary>
+    /// A Revit View3D
+    /// </summary>
+    [RegisterForTrace]
+    public class View3D : AbstractView3D
     {
-        [IsVisibleInDynamoLibrary(false)]
-        public const string DEFAULT_VIEW_NAME = "dynamo3D";
-
-        #region Internal properties
+        #region Private constructors
 
         /// <summary>
-        /// An internal handle on the Revit element
+        /// Private constructor
         /// </summary>
-        internal Autodesk.Revit.DB.View3D InternalView3D
+        private View3D(Autodesk.Revit.DB.View3D view)
         {
-            get;
-            private set;
-        }
-
-        /// <summary>
-        /// Reference to the Element
-        /// </summary>
-        public override Autodesk.Revit.DB.Element InternalElement
-        {
-            get { return InternalView3D; }
+            SafeInit(() => Init3DView(view));
         }
 
         #endregion
 
-        #region Private helper methods
+        #region Helpers for private constructors
 
         /// <summary>
-        /// Build Orientation3D object for eye point and a target point 
+        /// Initialize a 3d view
         /// </summary>
-        /// <param name="eyePoint"></param>
-        /// <param name="target"></param>
-        /// <returns></returns>
-        protected static ViewOrientation3D BuildOrientation3D(XYZ eyePoint, XYZ target)
+        private void Init3DView(Autodesk.Revit.DB.View3D view)
         {
-            var globalUp = XYZ.BasisZ;
-            var direction = target.Subtract(eyePoint).Normalize();
-
-            // If the direction is zero length (ex. the eye and target
-            // points are coincident) than set the direction to look
-            // along the x axis by default. Otherwise, the call to
-            // create a ViewOrientation3D object will fail.
-            if (direction.IsZeroLength())
-            {
-                direction = XYZ.BasisX;
-            }
-
-            // If the direction points along Z, then 
-            // switch the global up to Y
-            if (direction.IsAlmostEqualTo(globalUp) ||
-                (direction.Negate().IsAlmostEqualTo(globalUp)))
-            {
-                globalUp = XYZ.BasisY;
-            }
-
-            var up = direction.CrossProduct(globalUp).CrossProduct(direction);
-
-            if (up.IsZeroLength())
-            {
-                up = XYZ.BasisZ;
-            }
-
-            // If up is zero length (ex. the direction vector is the z axis),
-            // set the up to be along the Z axis.
-            return new ViewOrientation3D(eyePoint, up, direction);
-
+            InternalSetView3D(view);
         }
 
+        #endregion
+
+        #region Internal methods
+
         /// <summary>
-        /// Obtain a sparse point collection outlining a Revit element bt traversing it's
-        /// GeometryObject representation
+        /// Create from existing view
         /// </summary>
-        /// <param name="e"></param>
-        /// <param name="pts"></param>
-        protected static void GetPointCloud(Autodesk.Revit.DB.Element e, List<XYZ> pts)
+        /// <param name="view"></param>
+        /// <param name="isRevitOwned"></param>
+        /// <returns></returns>
+        internal static View3D FromExisting(Autodesk.Revit.DB.View3D view, bool isRevitOwned)
         {
-            var options = new Options()
+            if (view == null)
             {
-                ComputeReferences = true,
-                DetailLevel = ViewDetailLevel.Coarse,
-                IncludeNonVisibleObjects = false
+                throw new ArgumentNullException(nameof(view));
+            }
+
+            return new View3D(view)
+            {
+                IsRevitOwned = isRevitOwned
             };
-
-            foreach (var gObj in e.get_Geometry(options))
-            {
-                if (gObj is Autodesk.Revit.DB.Solid)
-                {
-                    GetPointCloud(gObj as Autodesk.Revit.DB.Solid, pts);
-                }
-                else if (gObj is GeometryInstance)
-                {
-                    GetPointCloud(gObj as GeometryInstance, pts);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Obtain a point collection outlining a GeometryObject
-        /// </summary>
-        /// <param name="geomInst"></param>
-        /// <param name="pts"></param>
-        protected static void GetPointCloud(GeometryInstance geomInst, List<XYZ> pts)
-        {
-            foreach (var gObj in geomInst.GetInstanceGeometry())
-            {
-                if (gObj is Autodesk.Revit.DB.Solid)
-                {
-                    GetPointCloud(gObj as Autodesk.Revit.DB.Solid, pts);
-                }
-                else if (gObj is GeometryInstance)
-                {
-                    GetPointCloud(gObj as GeometryInstance, pts);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Obtain a point collection outlining a Solid GeometryObject
-        /// </summary>
-        /// <param name="solid"></param>
-        /// <param name="pts"></param>
-        protected static void GetPointCloud(Autodesk.Revit.DB.Solid solid, List<XYZ> pts)
-        {
-            foreach (Edge gEdge in solid.Edges)
-            {
-                var c = gEdge.AsCurve();
-                if (c is Line)
-                {
-                    pts.Add(c.Evaluate(0, true));
-                    pts.Add(c.Evaluate(1, true));
-                }
-                else
-                {
-                    IList<XYZ> xyzArray = gEdge.Tessellate();
-                    pts.AddRange(xyzArray);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Make a single element appear in a particular view
-        /// </summary>
-        /// <param name="view"></param>
-        /// <param name="element"></param>
-        protected static void IsolateInView(Autodesk.Revit.DB.View3D view, Autodesk.Revit.DB.Element element)
-        {
-            var fec = GetVisibleElementFilter();
-
-            view.CropBoxActive = true;
-                
-            var all = fec.ToElements();
-            var toHide =
-                fec.ToElements().Where(x => !x.IsHidden(view) && x.CanBeHidden(view) && x.Id != element.Id).Select(x => x.Id).ToList();
-
-            if (toHide.Count > 0)
-                view.HideElements(toHide);
-
-            DocumentManager.Regenerate();
-
-            // After a regeneration, we need to ensure that a 
-            // transaction is re-opened.
-            TransactionManager.Instance.EnsureInTransaction(DocumentManager.Instance.CurrentDBDocument);
-
-            if (view.IsPerspective)
-            {
-                var farClip = view.LookupParameter("Far Clip Active");
-                farClip.Set(0);
-            }
-            else
-            {
-                var pts = new List<XYZ>();
-
-                GetPointCloud(element, pts);
-
-                var bounding = view.CropBox;
-                var transInverse = bounding.Transform.Inverse;
-                var transPts = pts.Select(transInverse.OfPoint);
-
-                //ingore the Z coordindates and find
-                //the max X ,Y and Min X, Y in 3d view.
-                double dMaxX = 0, dMaxY = 0, dMinX = 0, dMinY = 0;
-
-                bool bFirstPt = true;
-                foreach (var pt1 in transPts)
-                {
-                    if (true == bFirstPt)
-                    {
-                        dMaxX = pt1.X;
-                        dMaxY = pt1.Y;
-                        dMinX = pt1.X;
-                        dMinY = pt1.Y;
-                        bFirstPt = false;
-                    }
-                    else
-                    {
-                        if (dMaxX < pt1.X)
-                            dMaxX = pt1.X;
-                        if (dMaxY < pt1.Y)
-                            dMaxY = pt1.Y;
-                        if (dMinX > pt1.X)
-                            dMinX = pt1.X;
-                        if (dMinY > pt1.Y)
-                            dMinY = pt1.Y;
-                    }
-                }
-
-                bounding.Max = new XYZ(dMaxX, dMaxY, bounding.Max.Z);
-                bounding.Min = new XYZ(dMinX, dMinY, bounding.Min.Z);
-                view.CropBox = bounding;
-            }
-
-            view.CropBoxVisible = false;
-
-        }
-
-        /// <summary>
-        /// Set the cropping for the current view
-        /// </summary>
-        /// <param name="view3D"></param>
-        /// <param name="bbox"></param>
-        private void IsolateInView(Autodesk.Revit.DB.View3D view3D, BoundingBoxXYZ bbox)
-        {
-            view3D.CropBox = bbox;
-        }
-
-        /// <summary>
-        /// Create a Revit 3D View
-        /// </summary>
-        /// <param name="orient"></param>
-        /// <param name="name"></param>
-        /// <param name="isPerspective"></param>
-        /// <returns></returns>
-        protected static Autodesk.Revit.DB.View3D Create3DView(ViewOrientation3D orient, string name, bool isPerspective)
-        {
-            // (sic) From the Dynamo legacy implementation
-            var viewFam = DocumentManager.Instance.ElementsOfType<ViewFamilyType>()
-                .FirstOrDefault(x => x.ViewFamily == ViewFamily.ThreeDimensional);
-
-            if (viewFam == null)
-            {
-                throw new Exception("There is no three dimensional view family int he document");
-            }
-
-            Autodesk.Revit.DB.View3D view;
-            if (isPerspective)
-            {
-                view = Autodesk.Revit.DB.View3D.CreatePerspective(Document, viewFam.Id);
-            }
-            else
-            {
-                view = Autodesk.Revit.DB.View3D.CreateIsometric(Document, viewFam.Id);
-            }
-
-            view.SetOrientation(orient);
-            view.SaveOrientationAndLock();
-
-
-            view.Name = CreateUniqueViewName(name);
-
-            return view;
-        }
-
-        /// <summary>
-        /// Determines whether a view with the provided name already exists.
-        /// If a view exists with the provided name, and new view is created with
-        /// a unique name. Otherwise, the original view name is returned.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns>The original name if it is already unique, or 
-        /// a unique version of the name.</returns>
-        public static string CreateUniqueViewName(string name)
-        {
-            var collector = new FilteredElementCollector(Document);
-            collector.OfClass(typeof(Autodesk.Revit.DB.View));
-
-            // If the name is already unique then return it.
-            if (collector.All(x => x.Name != name))
-                return name;
-
-            // Create a unique name by appending a guid to
-            // the end of the view name
-            var viewName = string.Format("{0}_{1}", name, Guid.NewGuid());
-
-            return viewName;
-        }
-
-        // (sic) From Dynamo legacy
-
-        /// <summary>
-        /// Utility method to create a filtered element collector which collects all elements in a view
-        /// which Dynamo would like to view or on which Dynamo would like to operate.
-        /// </summary>
-        /// <returns></returns>
-        protected static FilteredElementCollector GetVisibleElementFilter()
-        {
-            var fec = new FilteredElementCollector(Document);
-            var filterList = new List<ElementFilter>();
-
-            //Autodesk.Revit.DB.Analysis.AnalysisDisplayLegend;
-            //Autodesk.Revit.DB.Analysis.AnalysisDisplayStyle;
-            //Autodesk.Revit.DB.Analysis.MassEnergyAnalyticalModel;
-            //Autodesk.Revit.DB.Analysis.MassLevelData;
-            //Autodesk.Revit.DB.Analysis.MassSurfaceData;
-            //Autodesk.Revit.DB.Analysis.MassZone;
-            //Autodesk.Revit.DB.Analysis.SpatialFieldManager;
-            //Autodesk.Revit.DB.AreaScheme;
-            //Autodesk.Revit.DB.AppearanceAssetElement;
-            var FContinuousRail = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.ContinuousRail));
-            var FRailing = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.Railing));
-            var FStairs = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.Stairs));
-            var FStairsLanding = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.StairsLanding));
-            //var FStairsPath = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.StairsPath));
-            //var FStairsRun = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.StairsRun));
-            var FTopographySurface = new ElementClassFilter(typeof(Autodesk.Revit.DB.Architecture.TopographySurface));
-            //Autodesk.Revit.DB.AreaScheme;
-            var FAssemblyInstance = new ElementClassFilter(typeof(Autodesk.Revit.DB.AssemblyInstance));
-            var FBaseArray = new ElementClassFilter(typeof(Autodesk.Revit.DB.BaseArray));
-            //ElementClassFilter FBasePoint = new ElementClassFilter(typeof(Autodesk.Revit.DB.BasePoint));
-            var FBeamSystem = new ElementClassFilter(typeof(Autodesk.Revit.DB.BeamSystem));
-            var FBoundaryConditions = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.BoundaryConditions));
-            //ElementClassFilter FCombinableElement = new ElementClassFilter(typeof(Autodesk.Revit.DB.CombinableElement));
-            //Autodesk.Revit.DB..::..ComponentRepeater
-            //Autodesk.Revit.DB..::..ComponentRepeaterSlot
-            var FConnectorElement = new ElementClassFilter(typeof(Autodesk.Revit.DB.ConnectorElement));
-            var FControl = new ElementClassFilter(typeof(Autodesk.Revit.DB.Control));
-            var FCurveElement = new ElementClassFilter(typeof(Autodesk.Revit.DB.CurveElement));
-            //Autodesk.Revit.DB.DesignOption;
-            //Autodesk.Revit.DB.Dimension;
-            //Autodesk.Revit.DB..::..DisplacementElement
-            var FDividedSurface = new ElementClassFilter(typeof(Autodesk.Revit.DB.DividedSurface));
-            var FCableTrayConduitRunBase = new ElementClassFilter(typeof(Autodesk.Revit.DB.Electrical.CableTrayConduitRunBase));
-            //Autodesk.Revit.DB.Electrical.ElectricalDemandFactorDefinition;
-            //Autodesk.Revit.DB.Electrical.ElectricalLoadClassification;
-            //Autodesk.Revit.DB.Electrical.PanelScheduleSheetInstance;
-            //Autodesk.Revit.DB.Electrical.PanelScheduleTemplate;
-            var FElementType = new ElementClassFilter(typeof(Autodesk.Revit.DB.ElementType));
-            //Autodesk.Revit.DB..::..ElevationMarker
-            //ElementClassFilter FFamilyBase = new ElementClassFilter(typeof(Autodesk.Revit.DB.FamilyBase));
-            //Autodesk.Revit.DB.FilledRegion;
-            //Autodesk.Revit.DB.FillPatternElement;
-            //Autodesk.Revit.DB.FilterElement;
-            //Autodesk.Revit.DB.GraphicsStyle;
-            //Autodesk.Revit.DB.Grid;
-            //ElementClassFilter FGroup = new ElementClassFilter(typeof(Autodesk.Revit.DB.Group));
-            var FHostObject = new ElementClassFilter(typeof(Autodesk.Revit.DB.HostObject));
-            //Autodesk.Revit.DB.IndependentTag;
-            var FInstance = new ElementClassFilter(typeof(Autodesk.Revit.DB.Instance));
-            //Autodesk.Revit.DB.Level;
-            //Autodesk.Revit.DB.LinePatternElement;
-            //Autodesk.Revit.DB.Material;
-            //Autodesk.Revit.DB.Mechanical.Zone;
-            var FMEPSystem = new ElementClassFilter(typeof(Autodesk.Revit.DB.MEPSystem));
-            var FModelText = new ElementClassFilter(typeof(Autodesk.Revit.DB.ModelText));
-            //Autodesk.Revit.DB..::..MultiReferenceAnnotation
-            var FOpening = new ElementClassFilter(typeof(Autodesk.Revit.DB.Opening));
-            var FPart = new ElementClassFilter(typeof(Autodesk.Revit.DB.Part));
-            var FPartMaker = new ElementClassFilter(typeof(Autodesk.Revit.DB.PartMaker));
-            //Autodesk.Revit.DB.Phase;
-            //Autodesk.Revit.DB..::..PhaseFilter
-            //Autodesk.Revit.DB.PrintSetting;
-            //Autodesk.Revit.DB.ProjectInfo;
-            //Autodesk.Revit.DB.PropertyLine;
-            //ElementClassFilter FPropertySetElement = new ElementClassFilter(typeof(Autodesk.Revit.DB.PropertySetElement));
-            //Autodesk.Revit.DB.PropertySetLibrary;
-            var FReferencePlane = new ElementClassFilter(typeof(Autodesk.Revit.DB.ReferencePlane));
-            var FReferencePoint = new ElementClassFilter(typeof(Autodesk.Revit.DB.ReferencePoint));
-            //Autodesk.Revit.DB..::..ScheduleSheetInstance
-            //Autodesk.Revit.DB..::..Segment
-            //ElementClassFilter FSketchBase = new ElementClassFilter(typeof(Autodesk.Revit.DB.SketchBase));
-            //ElementClassFilter FSketchPlane = new ElementClassFilter(typeof(Autodesk.Revit.DB.SketchPlane));
-            var FSpatialElement = new ElementClassFilter(typeof(Autodesk.Revit.DB.SpatialElement));
-            //Autodesk.Revit.DB..::..SpatialElementCalculationLocation
-            //ElementClassFilter FSpatialElementTag = new ElementClassFilter(typeof(Autodesk.Revit.DB.SpatialElementTag));
-            //Autodesk.Revit.DB.Structure..::..AnalyticalLink
-            //Autodesk.Revit.DB.Structure.AnalyticalModel;
-            var FAreaReinforcement = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.AreaReinforcement));
-            //Autodesk.Revit.DB.Structure..::..FabricArea
-            //Autodesk.Revit.DB.Structure..::..FabricReinSpanSymbolControl
-            //Autodesk.Revit.DB.Structure..::..FabricSheet
-            var FHub = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.Hub));
-            //Autodesk.Revit.DB.Structure.LoadBase;
-            //Autodesk.Revit.DB.Structure.LoadCase;
-            //Autodesk.Revit.DB.Structure.LoadCombination;
-            //Autodesk.Revit.DB.Structure.LoadNature;
-            //Autodesk.Revit.DB.Structure.LoadUsage;
-            var FPathReinforcement = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.PathReinforcement));
-            var FRebar = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.Rebar));
-            //Autodesk.Revit.DB.Structure..::..RebarInSystem
-            var FTruss = new ElementClassFilter(typeof(Autodesk.Revit.DB.Structure.Truss));
-            //Autodesk.Revit.DB.SunAndShadowSettings;
-            //Autodesk.Revit.DB.TextElement;
-            //Autodesk.Revit.DB.View;
-            //Autodesk.Revit.DB..::..Viewport
-            //Autodesk.Revit.DB.ViewSheetSet;
-            //Autodesk.Revit.DB.WorksharingDisplaySettings;
-
-            filterList.Add(FContinuousRail);
-            filterList.Add(FRailing);
-            filterList.Add(FStairs);
-            filterList.Add(FStairsLanding);
-            filterList.Add(FTopographySurface);
-            filterList.Add(FAssemblyInstance);
-            filterList.Add(FBaseArray);
-            filterList.Add(FBeamSystem);
-            filterList.Add(FBoundaryConditions);
-            filterList.Add(FConnectorElement);
-            filterList.Add(FControl);
-            filterList.Add(FCurveElement);
-            filterList.Add(FDividedSurface);
-            filterList.Add(FCableTrayConduitRunBase);
-            filterList.Add(FHostObject);
-            filterList.Add(FInstance);
-            filterList.Add(FMEPSystem);
-            filterList.Add(FModelText);
-            filterList.Add(FOpening);
-            filterList.Add(FPart);
-            filterList.Add(FPartMaker);
-            filterList.Add(FReferencePlane);
-            filterList.Add(FReferencePoint);
-            filterList.Add(FAreaReinforcement);
-            filterList.Add(FHub);
-            filterList.Add(FPathReinforcement);
-            filterList.Add(FRebar);
-            filterList.Add(FTruss);
-            filterList.Add(FSpatialElement);
-
-            //ElementCategoryFilter CRailings = new ElementCategoryFilter(BuiltInCategory.OST_StairsRailing);
-            //ElementCategoryFilter CStairs = new ElementCategoryFilter(BuiltInCategory.OST_Stairs);
-
-            var CRvtLinks = new ElementCategoryFilter(BuiltInCategory.OST_RvtLinks);
-            filterList.Add(CRvtLinks);
-
-            //List<ElementFilter> ignores = new List<ElementFilter>();
-            //ElementCategoryFilter CLightFixtureSource = new ElementCategoryFilter(BuiltInCategory.OST_LightingFixtureSource, true);
-            //ignores.Add(CLightFixtureSource);
-
-            var filters = new LogicalOrFilter(filterList);
-            //LogicalOrFilter exclusions = new LogicalOrFilter(ignores);
-
-            fec.WherePasses(filters).WhereElementIsNotElementType();
-
-            return fec;
         }
 
         #endregion
-
-        #region Protected mutators
-
-        /// <summary>
-        /// Set the name of the current view
-        /// </summary>
-        /// <param name="name"></param>
-        protected void InternalSetName(string name)
-        {
-            if (name == DEFAULT_VIEW_NAME && InternalView3D.Name.Contains(DEFAULT_VIEW_NAME + "_"))
-            {
-                // Assume that this has already been set unique.
-                return;
-            }
-
-            if (!this.InternalView3D.Name.Equals(name))
-                this.InternalView3D.Name = CreateUniqueViewName(name);
-        }
-
-        /// <summary>
-        /// Set the orientation of the view
-        /// </summary>
-        /// <param name="orient"></param>
-        protected void InternalSetOrientation( ViewOrientation3D orient)
-        {
-            if (this.InternalView3D.ViewDirection.IsAlmostEqualTo(-orient.ForwardDirection) &&
-                this.InternalView3D.Origin.IsAlmostEqualTo(orient.EyePosition)) return;
-
-            this.InternalView3D.Unlock();
-            this.InternalView3D.SetOrientation(orient);
-            this.InternalView3D.SaveOrientationAndLock();
-        }
-
-        /// <summary>
-        /// Isolate the element in the current view by creating a mininum size crop box around it
-        /// </summary>
-        /// <param name="element"></param>
-        protected void InternalIsolateInView(Autodesk.Revit.DB.Element element)
-        {
-            IsolateInView(this.InternalView3D, element);
-        }
-    
-        /// <summary>
-        /// Isolate the bounding box in the current view
-        /// </summary>
-        /// <param name="bbox"></param>
-        protected void InternalIsolateInView(BoundingBoxXYZ bbox)
-        {
-            IsolateInView(this.InternalView3D, bbox);
-        }
-
-        /// <summary>
-        /// Show all hiddent elements in the view
-        /// </summary>
-        protected void InternalRemoveIsolation()
-        {
-            InternalView3D.UnhideElements(GetVisibleElementFilter().ToElementIds());
-            InternalView3D.CropBoxActive = false;
-        }
-
-        /// <summary>
-        /// Set the InternalView3D property and the associated element id and unique id
-        /// </summary>
-        /// <param name="view"></param>
-        protected void InternalSetView3D(Autodesk.Revit.DB.View3D view)
-        {
-            this.InternalView3D = view;
-            this.InternalElementId = view.Id;
-            this.InternalUniqueId = view.UniqueId;
-        }
-
-        #endregion
-
     }
 }
-

--- a/src/Libraries/RevitNodes/GeometryReferences/RayBounce.cs
+++ b/src/Libraries/RevitNodes/GeometryReferences/RayBounce.cs
@@ -22,7 +22,7 @@ namespace Revit.References
         /// <param name="view"></param>
         /// <returns></returns>
         [MultiReturn(new[] { "points", "elements" })]
-        public static Dictionary<string,object> ByOriginDirection(Point origin, Vector direction, int maxBounces, Elements.Views.View3D view)
+        public static Dictionary<string,object> ByOriginDirection(Point origin, Vector direction, int maxBounces, Elements.Views.AbstractView3D view)
         {
             var startpt = origin.ToXyz();
             var rayCount = 0;

--- a/src/Libraries/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/RevitNodes/RevitNodes.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Elements\Room.cs" />
     <Compile Include="Elements\Revision.cs" />
     <Compile Include="Elements\RevisionCloud.cs" />
+    <Compile Include="Elements\Views\AbstractView3D.cs" />
     <Compile Include="Elements\Views\AreaPlanView.cs" />
     <Compile Include="Elements\Views\Legend.cs" />
     <Compile Include="PerformanceAdviser\FailureMessage.cs" />

--- a/test/Libraries/RevitNodesTests/Elements/Views/AxonometricViewTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/Views/AxonometricViewTests.cs
@@ -77,7 +77,7 @@ namespace RevitNodesTests.Elements.Views
             var target = Point.ByCoordinates(0, 1, 2);
 
             var v = AxonometricView.ByEyePointAndTarget(eye, target);
-            Assert.AreEqual(v.InternalElement.Name, View3D.DEFAULT_VIEW_NAME);
+            Assert.AreEqual(v.InternalElement.Name, AbstractView3D.DefaultViewName);
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace RevitNodesTests.Elements.Views
 
             var v = AxonometricView.ByEyePointTargetAndBoundingBox(eye, target, famInst.BoundingBox);
             var view = (Autodesk.Revit.DB.View3D)v.InternalElement;
-            Assert.AreEqual(view.Name, View3D.DEFAULT_VIEW_NAME);
+            Assert.AreEqual(view.Name, AbstractView3D.DefaultViewName);
             Assert.False(view.CropBoxActive);
         }
 
@@ -181,7 +181,7 @@ namespace RevitNodesTests.Elements.Views
 
             var v = AxonometricView.ByEyePointTargetAndBoundingBox(eye, target, famInst.BoundingBox);
             var view = (Autodesk.Revit.DB.View3D)v.InternalElement;
-            Assert.AreEqual(view.Name, View3D.DEFAULT_VIEW_NAME);
+            Assert.AreEqual(view.Name, AbstractView3D.DefaultViewName);
             Assert.False(view.CropBoxActive);
         }
     }

--- a/test/Libraries/RevitNodesTests/Elements/Views/ViewTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/Views/ViewTests.cs
@@ -43,7 +43,7 @@ namespace RevitNodesTests.Elements.Views
 
             var v = AxonometricView.ByEyePointAndTarget(eye, target);
             var view = (Autodesk.Revit.DB.View3D)v.InternalElement;
-            Assert.AreEqual(view.Name, View3D.DEFAULT_VIEW_NAME);
+            Assert.AreEqual(view.Name, AbstractView3D.DefaultViewName);
             Assert.False(view.CropBoxActive);
 
             return v;


### PR DESCRIPTION
### Purpose

This addresses this issue: 

https://github.com/DynamoDS/DynamoRevit/issues/1636
https://github.com/DynamoDS/DynamoRevit/issues/2002

It also addresses the issue of plain old skipping 3d view templates from any selection and wrapper routines. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 

### FYIs

This used to be a PR but i messed up so here it is again. I ran tests for all relevant classes: 

![image](https://user-images.githubusercontent.com/529781/38623065-b4be5f48-3d72-11e8-906d-f9ceb9c944d5.png)

![image](https://user-images.githubusercontent.com/529781/38623078-bf452ba4-3d72-11e8-829b-c49e6613e229.png)

