### PR TITLE
DO NOT MERGE DynamoRevit should load more specific version of libG using major minor build

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -384,8 +384,9 @@ namespace Dynamo.Applications
             var utilities = assembly.GetType("DynamoShapeManager.Utilities");
             var getGeometryFactoryPath = utilities.GetMethod("GetGeometryFactoryPath2");
 
+            //if old method is called default to 224.4.0
             return (getGeometryFactoryPath.Invoke(null,
-                new object[] { corePath, 224  }) as string);
+                new object[] { corePath, new Version(224,4,0)  }) as string);
         }
 
 

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -476,15 +476,21 @@ namespace Dynamo.Applications
         {
             var asmLocation = AppDomain.CurrentDomain.BaseDirectory;
 
-            var lookup = new InstalledProductLookUp("Revit", "ASMAHL*.dll");
-            var product = lookup.GetProductFromInstallPath(asmLocation);
-            var libGversion = new Version(product.VersionInfo.Item1, product.VersionInfo.Item2, product.VersionInfo.Item3);
+            Version libGversion = findRevitASMVersion(asmLocation);
 
             var dynCorePath = DynamoRevitApp.DynamoCorePath;
-            var libGFolderName = string.Format("libg_{0}_{1}_{2}", libGversion.Major, libGversion.Minor, libGversion.Build );
+            var libGFolderName = string.Format("libg_{0}_{1}_{2}", libGversion.Major, libGversion.Minor, libGversion.Build);
             var preloaderLocation = Path.Combine(dynCorePath, libGFolderName);
 
             DynamoShapeManager.Utilities.PreloadAsmFromPath(preloaderLocation, asmLocation);
+            return libGversion;
+        }
+
+        internal static Version findRevitASMVersion(string asmLocation)
+        {
+            var lookup = new InstalledProductLookUp("Revit", "ASMAHL*.dll");
+            var product = lookup.GetProductFromInstallPath(asmLocation);
+            var libGversion = new Version(product.VersionInfo.Item1, product.VersionInfo.Item2, product.VersionInfo.Item3);
             return libGversion;
         }
 

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -182,7 +182,6 @@ namespace Dynamo.Applications
      Regeneration(RegenerationOption.Manual)]
     public class DynamoRevit : IExternalCommand
     {
-        enum Versions { ShapeManager = 224 };
 
         /// <summary>
         /// Based on the RevitDynamoModelState a dependent component can take certain 
@@ -233,7 +232,7 @@ namespace Dynamo.Applications
         }
 
         public Result ExecuteCommand(DynamoRevitCommandData commandData)
-        {
+        {   
             var startupTimer = Stopwatch.StartNew();
             if (ModelState == RevitDynamoModelState.StartedUIless)
             {
@@ -374,6 +373,7 @@ namespace Dynamo.Applications
         /// located.</param>
         /// <returns>Returns the full path to geometry factory assembly.</returns>
         /// 
+        [Obsolete("Please use the overload which specifies the version of the geometry library to load")]
         public static string GetGeometryFactoryPath(string corePath)
         {
             var dynamoAsmPath = Path.Combine(corePath, "DynamoShapeManager.dll");
@@ -382,11 +382,28 @@ namespace Dynamo.Applications
                 throw new FileNotFoundException("File not found", dynamoAsmPath);
 
             var utilities = assembly.GetType("DynamoShapeManager.Utilities");
-            var getGeometryFactoryPath = utilities.GetMethod("GetGeometryFactoryPath");
+            var getGeometryFactoryPath = utilities.GetMethod("GetGeometryFactoryPath2");
 
             return (getGeometryFactoryPath.Invoke(null,
-                new object[] { corePath, Versions.ShapeManager }) as string);
+                new object[] { corePath, 224  }) as string);
         }
+
+
+        public static string GetGeometryFactoryPath(string corePath,Version version)
+        {
+            var dynamoAsmPath = Path.Combine(corePath, "DynamoShapeManager.dll");
+            var assembly = Assembly.LoadFrom(dynamoAsmPath);
+            if (assembly == null)
+                throw new FileNotFoundException("File not found", dynamoAsmPath);
+
+            var utilities = assembly.GetType("DynamoShapeManager.Utilities");
+            var getGeometryFactoryPath = utilities.GetMethod("GetGeometryFactoryPath2");
+
+            return (getGeometryFactoryPath.Invoke(null,
+                new object[] { corePath, version }) as string);
+        }
+
+
 
         private static void PreloadDynamoCoreDlls()
         {
@@ -414,11 +431,11 @@ namespace Dynamo.Applications
             var dynamoRevitRoot = Path.GetDirectoryName(dynamoRevitExePath);// ...\Revit_xxxx\ folder
 
             // get Dynamo Revit Version
-            var revitVersion = Assembly.GetExecutingAssembly().GetName().Version;
+            var dynRevitVersion = Assembly.GetExecutingAssembly().GetName().Version;
 
             var umConfig = UpdateManagerConfiguration.GetSettings(new DynamoRevitLookUp());
             var revitUpdateManager = new DynUpdateManager(umConfig);
-            revitUpdateManager.HostVersion = revitVersion; // update RevitUpdateManager with the current DynamoRevit Version
+            revitUpdateManager.HostVersion = dynRevitVersion; // update RevitUpdateManager with the current DynamoRevit Version
             revitUpdateManager.HostName = "Dynamo Revit";
 
             Debug.Assert(umConfig.DynamoLookUp != null);
@@ -432,14 +449,17 @@ namespace Dynamo.Applications
 
             bool isAutomationMode = CheckJournalForKey(extCommandData,JournalKeys.AutomationModeKey);
 
-            PreloadAsmFromRevit();
+            // when Dynamo runs on top of revit we must load the same version of ASM as revit
+            // so tell Dynamo core we've loaded that version.
+            var loadedLibGVersion = PreloadAsmFromRevit();
 
-            return RevitDynamoModel.Start(
+
+                return RevitDynamoModel.Start(
                 new RevitDynamoModel.RevitStartConfiguration()
                 {
                     DynamoCorePath = corePath,
                     DynamoHostPath = dynamoRevitRoot,
-                    GeometryFactoryPath = GetGeometryFactoryPath(corePath),
+                    GeometryFactoryPath = GetGeometryFactoryPath(corePath, loadedLibGVersion),
                     PathResolver = new RevitPathResolver(userDataFolder, commonDataFolder),
                     Context = GetRevitContext(commandData),
                     SchedulerThread = new RevitSchedulerThread(commandData.Application),
@@ -451,18 +471,20 @@ namespace Dynamo.Applications
                 });
         }
 
-        private static void PreloadAsmFromRevit()
+        private static Version PreloadAsmFromRevit()
         {
             var asmLocation = AppDomain.CurrentDomain.BaseDirectory;
 
             var lookup = new InstalledProductLookUp("Revit", "ASMAHL*.dll");
             var product = lookup.GetProductFromInstallPath(asmLocation);
+            var libGversion = new Version(product.VersionInfo.Item1, product.VersionInfo.Item2, product.VersionInfo.Item3);
 
             var dynCorePath = DynamoRevitApp.DynamoCorePath;
-            var libGFolderName = string.Format("libg_{0}", product.VersionInfo.Item1);
+            var libGFolderName = string.Format("libg_{0}_{1}_{2}", libGversion.Major, libGversion.Minor, libGversion.Build );
             var preloaderLocation = Path.Combine(dynCorePath, libGFolderName);
 
             DynamoShapeManager.Utilities.PreloadAsmFromPath(preloaderLocation, asmLocation);
+            return libGversion;
         }
 
         private static DynamoViewModel InitializeCoreViewModel(RevitDynamoModel revitDynamoModel)

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -486,6 +486,12 @@ namespace Dynamo.Applications
             return libGversion;
         }
 
+        /// <summary>
+        /// Returns the version of ASM which is installed with Revit at the requested path.
+        /// This version number can be used to load the appropriate libG version.
+        /// </summary>
+        /// <param name="asmLocation">path where asm dlls are located, this is usually the product(Revit) install path</param>
+        /// <returns></returns>
         internal static Version findRevitASMVersion(string asmLocation)
         {
             var lookup = new InstalledProductLookUp("Revit", "ASMAHL*.dll");

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -472,7 +472,7 @@ namespace Dynamo.Applications
                 });
         }
 
-        private static Version PreloadAsmFromRevit()
+        internal static Version PreloadAsmFromRevit()
         {
             var asmLocation = AppDomain.CurrentDomain.BaseDirectory;
 

--- a/src/DynamoRevit/Properties/AssemblyInfo.cs
+++ b/src/DynamoRevit/Properties/AssemblyInfo.cs
@@ -8,3 +8,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DynamoRevitDS")]
 [assembly: AssemblyCulture("")]
 [assembly: Guid("082cab33-cbc7-4e58-ae25-f0962f325d6e")]
+[assembly: InternalsVisibleTo("RevitTestServices")]

--- a/test/Libraries/RevitTestServices/RevitNodeTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitNodeTestBase.cs
@@ -1,6 +1,7 @@
+using System;
 using System.IO;
 using System.Reflection;
-
+using Dynamo.Applications;
 using DynamoUnits;
 
 using NUnit.Framework;
@@ -43,7 +44,8 @@ namespace RevitTestServices
 
         protected override TestSessionConfiguration GetTestSessionConfiguration()
         {
-            return new TestSessionConfiguration(Dynamo.Applications.DynamoRevitApp.DynamoCorePath);
+            var asmLocation = AppDomain.CurrentDomain.BaseDirectory;
+            return new TestSessionConfiguration(Dynamo.Applications.DynamoRevitApp.DynamoCorePath, DynamoRevit.findRevitASMVersion(asmLocation));
         }
 
         private static void SetupTransactionManager()

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -236,7 +236,9 @@ namespace RevitTestServices
                     new RevitDynamoModel.RevitStartConfiguration()
                     {
                         StartInTestMode = true,
-                        GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(testConfig.DynamoCorePath),
+                        //TODO update reference to new dynamo dlls.]
+                        //TODO update testConfig file.
+                        GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(testConfig.DynamoCorePath,testConfig.RequestedLibraryVersion2),
                         DynamoCorePath = testConfig.DynamoCorePath,
                         PathResolver = revitTestPathResolver,
                         Context = "Revit 2014",

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -239,8 +239,6 @@ namespace RevitTestServices
                     new RevitDynamoModel.RevitStartConfiguration()
                     {
                         StartInTestMode = true,
-                        //TODO update reference to new dynamo dlls.]
-                        //TODO update testConfig file.
                         GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(testConfig.DynamoCorePath, requestedLibGVersion),
                         DynamoCorePath = testConfig.DynamoCorePath,
                         PathResolver = revitTestPathResolver,

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -232,27 +232,16 @@ namespace RevitTestServices
                 var revitTestPathResolver = new RevitTestPathResolver();
                 revitTestPathResolver.InitializePreloadedLibraries();
 
-                var asmLocation = AppDomain.CurrentDomain.BaseDirectory;
-                var libGVersion = DynamoRevit.findRevitASMVersion(asmLocation);
-
-                var loadedLibGVersion = testConfig.RequestedLibraryVersion2;
-                //RequestedLibraryVersion2 is null when the host should decide what version to load.
-                if (loadedLibGVersion == null)
-                {
-                    loadedLibGVersion = DynamoRevit.PreloadAsmFromRevit();
-                }
-                if(loadedLibGVersion != libGVersion)
-                {
-                    Console.WriteLine($"loaded version of libG is not the same as the version the host supports{loadedLibGVersion} , {libGVersion}");
-                }
-
+                //preload ASM and instruct dynamo to load that version of libG.
+                var requestedLibGVersion = DynamoRevit.PreloadAsmFromRevit();
+                
                 DynamoRevit.RevitDynamoModel = RevitDynamoModel.Start(
                     new RevitDynamoModel.RevitStartConfiguration()
                     {
                         StartInTestMode = true,
                         //TODO update reference to new dynamo dlls.]
                         //TODO update testConfig file.
-                        GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(testConfig.DynamoCorePath,loadedLibGVersion),
+                        GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(testConfig.DynamoCorePath, requestedLibGVersion),
                         DynamoCorePath = testConfig.DynamoCorePath,
                         PathResolver = revitTestPathResolver,
                         Context = "Revit 2014",

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -232,11 +232,18 @@ namespace RevitTestServices
                 var revitTestPathResolver = new RevitTestPathResolver();
                 revitTestPathResolver.InitializePreloadedLibraries();
 
+                var asmLocation = AppDomain.CurrentDomain.BaseDirectory;
+                var libGVersion = DynamoRevit.findRevitASMVersion(asmLocation);
+
                 var loadedLibGVersion = testConfig.RequestedLibraryVersion2;
                 //RequestedLibraryVersion2 is null when the host should decide what version to load.
                 if (loadedLibGVersion == null)
                 {
                     loadedLibGVersion = DynamoRevit.PreloadAsmFromRevit();
+                }
+                if(loadedLibGVersion != libGVersion)
+                {
+                    Console.WriteLine($"loaded version of libG is not the same as the version the host supports{loadedLibGVersion} , {libGVersion}");
                 }
 
                 DynamoRevit.RevitDynamoModel = RevitDynamoModel.Start(

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -232,13 +232,20 @@ namespace RevitTestServices
                 var revitTestPathResolver = new RevitTestPathResolver();
                 revitTestPathResolver.InitializePreloadedLibraries();
 
+                var loadedLibGVersion = testConfig.RequestedLibraryVersion2;
+                //RequestedLibraryVersion2 is null when the host should decide what version to load.
+                if (loadedLibGVersion == null)
+                {
+                    loadedLibGVersion = DynamoRevit.PreloadAsmFromRevit();
+                }
+
                 DynamoRevit.RevitDynamoModel = RevitDynamoModel.Start(
                     new RevitDynamoModel.RevitStartConfiguration()
                     {
                         StartInTestMode = true,
                         //TODO update reference to new dynamo dlls.]
                         //TODO update testConfig file.
-                        GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(testConfig.DynamoCorePath,testConfig.RequestedLibraryVersion2),
+                        GeometryFactoryPath = DynamoRevit.GetGeometryFactoryPath(testConfig.DynamoCorePath,loadedLibGVersion),
                         DynamoCorePath = testConfig.DynamoCorePath,
                         PathResolver = revitTestPathResolver,
                         Context = "Revit 2014",

--- a/test/Libraries/RevitTestServices/TestServices.dll.config
+++ b/test/Libraries/RevitTestServices/TestServices.dll.config
@@ -2,6 +2,6 @@
 <configuration>
   <appSettings>
     <add key="DynamoBasePath" value=""/>
-    <add key="RequestedLibraryVersion2" value="224.4.0"/>
+    <add key="RequestedLibraryVersion2" value="hostdefault"/>
   </appSettings>
 </configuration>

--- a/test/Libraries/RevitTestServices/TestServices.dll.config
+++ b/test/Libraries/RevitTestServices/TestServices.dll.config
@@ -2,6 +2,6 @@
 <configuration>
   <appSettings>
     <add key="DynamoBasePath" value=""/>
-    <add key="RequestedLibraryVersion" value="Version223"/>
+    <add key="RequestedLibraryVersion2" value="224.4.0"/>
   </appSettings>
 </configuration>


### PR DESCRIPTION
### Purpose

related to:
https://github.com/mjkkirschner/DynamoRevit.git

Two big changes are made:
* when we preload ASM pick the libG folder by using major minor and build version
* when we ask Dynamo for the geometryFactoryPath we should be able to specify the same version we preloaded.
* when revitSystemTestBase is setup it will preloadASM like normal DynamoRevit startup 
* when revitNodeTest creates a testConfig it will inject the revit version - or it will use the config file with some better fallback rules (want feedback on this first)

### TODO:
- [ ] This PR should not be merged until new nugets exist and this branch targets a new branch of dynamoCore. (2.02, but preferably 2.1)
- [x] cherry pick to 2017, 2018 , 2019
- [ ] cherry pick to 1.3.4 - 2016, 2017, 2018, 2019
- [x] cherry pick to 2.02 - 2017 2018 2019
- [x] verify RTF tests still load asm correctly
- [x] verify unit tests still load asm correctly 
- [x] update testConfiguration xml file with new variable (`RequestedLibraryVersion2`)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

Not ready for full review

### FYIs

@aparajit-pratap 
@kronz 
@philxia1 