### PR TITLE
Update RayBounceTests.cs 2018 2.0.2

### DIFF
--- a/test/Libraries/RevitIntegrationTests/RayBounceTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RayBounceTests.cs
@@ -54,7 +54,7 @@ namespace RevitSystemTests
 
             // Validation for Reference Points.
             var modelCurve = "64b62b8e-a07e-477e-ba5d-9e33eb03debf";
-            AssertPreviewCount(modelCurve, 50);
+            AssertPreviewCount(modelCurve, 52);
 
             for (int i = 0; i <= 42; i++)
             {


### PR DESCRIPTION
update test now that circle constructor uses plane normal
