### PR TITLE
Adding Version Baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,11 +214,11 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
-src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
 test/Libraries/RevitIntegrationTests/RevitTestConfiguration.xml
 test/**/*.txt
 test/**/*.addin
 test/SystemInJson
 
+.vs
 # Icon resources
 /src/DynamoRevitIcons/*.resources

--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Reflection;
+using System.Resources;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyCompany("Autodesk, Inc")]
+[assembly: AssemblyProduct("Dynamo For Revit 2019")]
+[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2017-2018")]
+[assembly: AssemblyTrademark("")]
+
+//In order to begin building localizable applications, set 
+//<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
+//inside a <PropertyGroup>.  For example, if you are using US english
+//in your source files, set the <UICulture> to en-US.  Then uncomment
+//the NeutralResourceLanguage attribute below.  Update the "en-US" in
+//the line below to match the UICulture setting in the project file.
+
+[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
+
+// Make it easy to distinguish Debug and Release (i.e. Retail) builds;
+// for example, through the file properties window.
+#if DEBUG
+[assembly: AssemblyConfiguration("Debug")]
+[assembly: AssemblyDescription("Flavor=Debug")] // a.k.a. "Comments"
+#else
+[assembly: AssemblyConfiguration("Release")]
+[assembly: AssemblyDescription("Flavor=Release")] // a.k.a. "Comments"
+#endif
+
+[assembly: CLSCompliant(true)]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Note that the assembly version does not get incremented for every build
+// to avoid problems with assembly binding (or requiring a policy or
+// <bindingRedirect> in the config file).
+//
+// The AssemblyFileVersionAttribute is incremented with every build in order
+// to distinguish one build from another. AssemblyFileVersion is specified
+// in AssemblyVersionInfo.cs so that it can be easily incremented by the
+// automated build process.
+[assembly: AssemblyVersion("2.0.2.6067")]
+
+
+// By default, the "Product version" shown in the file properties window is
+// the same as the value specified for AssemblyFileVersionAttribute.
+// Set AssemblyInformationalVersionAttribute to be the same as
+// AssemblyVersionAttribute so that the "Product version" in the file
+// properties window matches the version displayed in the GAC shell extension.
+//[assembly: AssemblyInformationalVersion("1.0.0.0")] // a.k.a. "Product version"
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyFileVersion("2.0.2.6067")]


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

@varvaratou and I noticed there is bug with current setup. Since the assemblysharedinfo.cs is ignored, and this repo does not contain it, when a dev is switching from 2.1 to 2.0.2 on windows machine, the about box will display the wrong build number because this file is not overwritten. It does not happen on build machine though somehow.

It is hard for me to argue which is the better practice but seems we do need some kind of baseline at least in each release branch, otherwise, devs switching between will just get lost. Let me know if you have good work around @mjkkirschner @alfarok or you prefer not touch the way it is now and let devs remember to remove this file after switching branches.

The other ignore change is just for ignoring some setting VS trying to add

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @alfarok 

### FYIs

@varvaratou 

