### PR TITLE
.Net 47 Build change for Revit 2019

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,9 @@ ipch/
 *.sdf
 *.cachefile
 
+# Visual Studio cache directory
+.vs
+
 # Visual Studio profiler
 *.psess
 *.vsp

--- a/src/Config/packages-template.aget
+++ b/src/Config/packages-template.aget
@@ -1,6 +1,7 @@
 {
   "nuget": {
     "references": {
+      "DynamicLanguageRuntime" : "1.2.1",
       "DynamoVisualProgramming.Core" : "LatestBeta",
       "DynamoVisualProgramming.DynamoCoreNodes" : "LatestBeta",
       "DynamoVisualProgramming.DynamoServices" : "LatestBeta",
@@ -9,7 +10,7 @@
       "DynamoVisualProgramming.ZeroTouchLibrary" : "LatestBeta",
       "Greg" : "1.0.6176.18754",
       "GregRevitAuth" : "1.0.5907.17451",
-      "IronPython" : "2.7.2",
+      "IronPython" : "2.7.8.1",
       "Newtonsoft.Json" : "8.0.3",
       "NUnit" : "2.6.3",
       "Prism" : "4.1.0",

--- a/src/Config/user_local.props
+++ b/src/Config/user_local.props
@@ -6,5 +6,6 @@
 	<DYNAMOTESTAPI Condition=" '$(DYNAMOTESTAPI)' == '' ">$(SolutionDir)..\bin\$(Platform)\$(Configuration)</DYNAMOTESTAPI>
 	<OutputPath Condition=" '$(OutputPath)' == '' ">$(SolutionDir)..\bin\AnyCPU\$(Configuration)\$(REVIT_VERSION)</OutputPath>
 	<TestOutputPath Condition=" '$(TestOutputPath)' == '' ">$(OutputPath)</TestOutputPath>
+  <REVITAPI Condition=" '$(REVITAPI)' == '' ">$(SolutionDir)..\..\Revit\$(Configuration)x64</REVITAPI>
   </PropertyGroup>
 </Project>

--- a/src/DynamoRevit.2017.sln
+++ b/src/DynamoRevit.2017.sln
@@ -1,0 +1,141 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2050
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamoRevit", "DynamoRevit\DynamoRevit.csproj", "{FD56AE51-739E-4893-8DE4-925D60C7097C}"
+	ProjectSection(ProjectDependencies) = postProject
+		{133FC760-5699-46D9-BEA6-E816B5F01016} = {133FC760-5699-46D9-BEA6-E816B5F01016}
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{FA7BE306-A3B0-45FA-9D87-0C69E6932C13}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitNodes", "Libraries\RevitNodes\RevitNodes.csproj", "{0BC2A611-BD0E-4FCC-A1DE-81F14ED369B2}"
+	ProjectSection(ProjectDependencies) = postProject
+		{133FC760-5699-46D9-BEA6-E816B5F01016} = {133FC760-5699-46D9-BEA6-E816B5F01016}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitNodesUI", "Libraries\RevitNodesUI\RevitNodesUI.csproj", "{75940ACC-3708-4526-8D91-7E3365BAF682}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitServices", "Libraries\RevitServices\RevitServices.csproj", "{E4701F9E-41AB-4044-8166-85D924FEB632}"
+	ProjectSection(ProjectDependencies) = postProject
+		{133FC760-5699-46D9-BEA6-E816B5F01016} = {133FC760-5699-46D9-BEA6-E816B5F01016}
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{F4D44BC0-32CF-4E58-AD2A-F19CE1450B00}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{0E492D35-2310-4849-9694-A2A53C09F21B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitNodesTests", "..\test\Libraries\RevitNodesTests\RevitNodesTests.csproj", "{9E79DC8D-25B1-491F-B094-EA39DE1BBC66}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitServicesTests", "..\test\Libraries\RevitServicesTests\RevitServicesTests.csproj", "{AD0499ED-50D3-46F4-9FC9-3F71D88C4870}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Migrations", "Libraries\Migrations\Migrations.csproj", "{06B9E5B0-7C50-4351-9D88-E159DC25755F}"
+	ProjectSection(ProjectDependencies) = postProject
+		{133FC760-5699-46D9-BEA6-E816B5F01016} = {133FC760-5699-46D9-BEA6-E816B5F01016}
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Legacy", "Legacy", "{398542E6-659A-48C8-86EB-33164D227C90}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamoRevitVersionSelector", "Legacy\DynamoRevitVersionSelector\DynamoRevitVersionSelector.csproj", "{53D05530-CF64-4883-8F86-B2B819934F83}"
+	ProjectSection(ProjectDependencies) = postProject
+		{133FC760-5699-46D9-BEA6-E816B5F01016} = {133FC760-5699-46D9-BEA6-E816B5F01016}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitTestServices", "..\test\Libraries\RevitTestServices\RevitTestServices.csproj", "{589F14D7-2937-479C-834A-D44197CB1930}"
+	ProjectSection(ProjectDependencies) = postProject
+		{133FC760-5699-46D9-BEA6-E816B5F01016} = {133FC760-5699-46D9-BEA6-E816B5F01016}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyInfoGenerator", "AssemblySharedInfoGenerator\AssemblyInfoGenerator.csproj", "{133FC760-5699-46D9-BEA6-E816B5F01016}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitSystemTests", "..\test\Libraries\RevitIntegrationTests\RevitSystemTests.csproj", "{9ADADC68-36A3-4A21-9B54-298154A88720}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4466E6F6-F644-43AB-96B3-5ECE1622E711}"
+	ProjectSection(SolutionItems) = preProject
+		Config.xml = Config.xml
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamoRevitIcons", "DynamoRevitIcons\DynamoRevitIcons.csproj", "{A31E274C-524A-40CA-85FF-595D3DB53777}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{821DE75A-8C7C-4747-B838-BA0354B15592}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamoAddinGenerator", "Tools\DynamoAddinGenerator\DynamoAddinGenerator.csproj", "{92A46535-D870-4E1A-AED0-7492789E9C4A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FD56AE51-739E-4893-8DE4-925D60C7097C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD56AE51-739E-4893-8DE4-925D60C7097C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD56AE51-739E-4893-8DE4-925D60C7097C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD56AE51-739E-4893-8DE4-925D60C7097C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BC2A611-BD0E-4FCC-A1DE-81F14ED369B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BC2A611-BD0E-4FCC-A1DE-81F14ED369B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BC2A611-BD0E-4FCC-A1DE-81F14ED369B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BC2A611-BD0E-4FCC-A1DE-81F14ED369B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75940ACC-3708-4526-8D91-7E3365BAF682}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75940ACC-3708-4526-8D91-7E3365BAF682}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75940ACC-3708-4526-8D91-7E3365BAF682}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75940ACC-3708-4526-8D91-7E3365BAF682}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4701F9E-41AB-4044-8166-85D924FEB632}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4701F9E-41AB-4044-8166-85D924FEB632}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4701F9E-41AB-4044-8166-85D924FEB632}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4701F9E-41AB-4044-8166-85D924FEB632}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E79DC8D-25B1-491F-B094-EA39DE1BBC66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E79DC8D-25B1-491F-B094-EA39DE1BBC66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E79DC8D-25B1-491F-B094-EA39DE1BBC66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E79DC8D-25B1-491F-B094-EA39DE1BBC66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD0499ED-50D3-46F4-9FC9-3F71D88C4870}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD0499ED-50D3-46F4-9FC9-3F71D88C4870}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD0499ED-50D3-46F4-9FC9-3F71D88C4870}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD0499ED-50D3-46F4-9FC9-3F71D88C4870}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06B9E5B0-7C50-4351-9D88-E159DC25755F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06B9E5B0-7C50-4351-9D88-E159DC25755F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06B9E5B0-7C50-4351-9D88-E159DC25755F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06B9E5B0-7C50-4351-9D88-E159DC25755F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53D05530-CF64-4883-8F86-B2B819934F83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53D05530-CF64-4883-8F86-B2B819934F83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53D05530-CF64-4883-8F86-B2B819934F83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53D05530-CF64-4883-8F86-B2B819934F83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{589F14D7-2937-479C-834A-D44197CB1930}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{589F14D7-2937-479C-834A-D44197CB1930}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{589F14D7-2937-479C-834A-D44197CB1930}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{589F14D7-2937-479C-834A-D44197CB1930}.Release|Any CPU.Build.0 = Release|Any CPU
+		{133FC760-5699-46D9-BEA6-E816B5F01016}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{133FC760-5699-46D9-BEA6-E816B5F01016}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{133FC760-5699-46D9-BEA6-E816B5F01016}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{133FC760-5699-46D9-BEA6-E816B5F01016}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9ADADC68-36A3-4A21-9B54-298154A88720}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9ADADC68-36A3-4A21-9B54-298154A88720}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9ADADC68-36A3-4A21-9B54-298154A88720}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9ADADC68-36A3-4A21-9B54-298154A88720}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A31E274C-524A-40CA-85FF-595D3DB53777}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A31E274C-524A-40CA-85FF-595D3DB53777}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A31E274C-524A-40CA-85FF-595D3DB53777}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A31E274C-524A-40CA-85FF-595D3DB53777}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92A46535-D870-4E1A-AED0-7492789E9C4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92A46535-D870-4E1A-AED0-7492789E9C4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92A46535-D870-4E1A-AED0-7492789E9C4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92A46535-D870-4E1A-AED0-7492789E9C4A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0BC2A611-BD0E-4FCC-A1DE-81F14ED369B2} = {FA7BE306-A3B0-45FA-9D87-0C69E6932C13}
+		{75940ACC-3708-4526-8D91-7E3365BAF682} = {FA7BE306-A3B0-45FA-9D87-0C69E6932C13}
+		{E4701F9E-41AB-4044-8166-85D924FEB632} = {FA7BE306-A3B0-45FA-9D87-0C69E6932C13}
+		{0E492D35-2310-4849-9694-A2A53C09F21B} = {F4D44BC0-32CF-4E58-AD2A-F19CE1450B00}
+		{9E79DC8D-25B1-491F-B094-EA39DE1BBC66} = {0E492D35-2310-4849-9694-A2A53C09F21B}
+		{AD0499ED-50D3-46F4-9FC9-3F71D88C4870} = {0E492D35-2310-4849-9694-A2A53C09F21B}
+		{06B9E5B0-7C50-4351-9D88-E159DC25755F} = {FA7BE306-A3B0-45FA-9D87-0C69E6932C13}
+		{398542E6-659A-48C8-86EB-33164D227C90} = {FA7BE306-A3B0-45FA-9D87-0C69E6932C13}
+		{53D05530-CF64-4883-8F86-B2B819934F83} = {398542E6-659A-48C8-86EB-33164D227C90}
+		{589F14D7-2937-479C-834A-D44197CB1930} = {0E492D35-2310-4849-9694-A2A53C09F21B}
+		{9ADADC68-36A3-4A21-9B54-298154A88720} = {0E492D35-2310-4849-9694-A2A53C09F21B}
+		{92A46535-D870-4E1A-AED0-7492789E9C4A} = {821DE75A-8C7C-4747-B838-BA0354B15592}
+	EndGlobalSection
+EndGlobal

--- a/src/DynamoRevit.2017.sln.DotSettings
+++ b/src/DynamoRevit.2017.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ARGB/@EntryIndexedValue">ARGB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CSV/@EntryIndexedValue">CSV</s:String></wpf:ResourceDictionary>

--- a/src/DynamoRevit/DynamoRevit.csproj
+++ b/src/DynamoRevit/DynamoRevit.csproj
@@ -70,13 +70,16 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Dynamic" />
+    <Reference Include="Microsoft.Dynamic">
+      <HintPath>$(PACKAGESPATH)\DynamicLanguageRuntime\lib\net45\Microsoft.Dynamic.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.Practices.Prism">
       <HintPath>$(PACKAGESPATH)\Prism\lib\NET40\Microsoft.Practices.Prism.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Scripting">
-      <HintPath>$(PACKAGESPATH)\IronPython\lib\Net40\Microsoft.Scripting.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamicLanguageRuntime\lib\net45\Microsoft.Scripting.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/src/DynamoRevitIcons/DynamoRevitIcons.csproj
+++ b/src/DynamoRevitIcons/DynamoRevitIcons.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)Config/CS.props" />
   </ImportGroup>
@@ -11,7 +11,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DynamoRevitIcons</RootNamespace>
     <AssemblyName>DynamoRevitIcons</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -51,6 +50,14 @@
     <AL TargetType="library" EmbedResources="$(ProjectDir)SimpleRaaSImages.resources" OutputAssembly="$(OutputPath)SimpleRaaS.customization.dll" />
     <GenerateResource UseSourcePath="true" Sources="$(ProjectDir)DynamoRaaSImages.resx" OutputResources="$(ProjectDir)DynamoRaaSImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
     <AL TargetType="library" EmbedResources="$(ProjectDir)DynamoRaaSImages.resources" OutputAssembly="$(OutputPath)DynamoRaaS.customization.dll" />
+    <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)RevitNodesImages.resx" OutputResources="$(ProjectDir)RevitNodesImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)RevitNodesImages.resources" FileVersion="1.0.0.0" ProductName="Dynamo For Revit 2019" ProductVersion="1.0.0.0" Copyright="Copyright © Autodesk, Inc 2017-2018" OutputAssembly="$(OutputPath)RevitNodes.customization.dll" />
+    <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)DSRevitNodesUIImages.resx" OutputResources="$(ProjectDir)DSRevitNodesUIImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DSRevitNodesUIImages.resources" FileVersion="1.0.0.0" ProductName="Dynamo For Revit 2019" ProductVersion="1.0.0.0" Copyright="Copyright © Autodesk, Inc 2017-2018" OutputAssembly="$(OutputPath)DSRevitNodesUI.customization.dll" />
+    <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)SimpleRaaSImages.resx" OutputResources="$(ProjectDir)SimpleRaaSImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)SimpleRaaSImages.resources" FileVersion="1.0.0.0" ProductName="Dynamo For Revit 2019" ProductVersion="1.0.0.0" Copyright="Copyright © Autodesk, Inc 2017-2018" OutputAssembly="$(OutputPath)SimpleRaaS.customization.dll" />
+    <GenerateResource SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)" UseSourcePath="true" Sources="$(ProjectDir)DynamoRaaSImages.resx" OutputResources="$(ProjectDir)DynamoRaaSImages.resources" References="$(FrameworkAssembliesPath)System.Drawing.dll" />
+    <AL TargetType="library" EmbedResources="$(ProjectDir)DynamoRaaSImages.resources" FileVersion="1.0.0.0" ProductName="Dynamo For Revit 2019" ProductVersion="1.0.0.0" Copyright="Copyright © Autodesk, Inc 2017-2018" OutputAssembly="$(OutputPath)DynamoRaaS.customization.dll" />
   </Target>
   <Target Name="AfterBuild">
     <ItemGroup>

--- a/src/build.xml
+++ b/src/build.xml
@@ -1,18 +1,18 @@
 <Project
     xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
-    ToolsVersion="4.0"
+    ToolsVersion="15.0"
     DefaultTargets="Build">
 <PropertyGroup>
-    <Solution>DynamoRevit.2013.sln</Solution>
+    <Solution>DynamoRevit.2017.sln</Solution>
     <Configuration>Release</Configuration>
-	<DynamoFolderPath>$(MSBuildProjectDirectory)\..\..\Dynamo</DynamoFolderPath>
+   <DynamoFolderPath>$(MSBuildProjectDirectory)\..\..\Dynamo</DynamoFolderPath>
 </PropertyGroup>
 
 <Import Project="./Config/user_local.props" />
 
 <ItemGroup>
     <ProjectToBuild Include="$(Solution)" >
-        <Properties>Configuration=$(Configuration);DefineConstants=$(Constants);Platform=Any CPU;VisualStudioVersion=12.0</Properties>
+        <Properties>Configuration=$(Configuration);DefineConstants=$(Constants);Platform=Any CPU;VisualStudioVersion=15.0</Properties>
     </ProjectToBuild>
 </ItemGroup>
 

--- a/src/transform_all.bat
+++ b/src/transform_all.bat
@@ -17,26 +17,21 @@ dir *.tt /b > t4list.txt
 echo the following T4 templates will be transformed:
 type t4list.txt
 
-:: clear the environment variable
+:: Use texttransform.exe from the IDE if it is present, otherwise, use legacy locations. 
+
+:: clear text transform path to undefine it
 set TEXTTRANSFORMPATH=
 
-IF EXIST "%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\11.0\TextTransform.exe" (
-    set TEXTTRANSFORMPATH="%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\11.0\TextTransform.exe"
+:: use latest vswhere utility to locate in IDE, where it resides now. 
+IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
+   for /f "usebackq tokens=1* delims=: " %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -all`) do (
+      if /i "%%i" == "installationPath" set TEXTTRANSFORMPATH="%%j\Common7\IDE\TextTransform.exe"
+   )
 )
-IF EXIST "%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\12.0\TextTransform.exe" (
-    set TEXTTRANSFORMPATH="%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\12.0\TextTransform.exe"
-)
-IF EXIST "%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\14.0\TextTransform.exe" (
-    set TEXTTRANSFORMPATH="%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\14.0\TextTransform.exe"
-)
-IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\Common7\IDE\TextTransform.exe" (
-    set TEXTTRANSFORMPATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\Common7\IDE\TextTransform.exe"
-)
-IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\TextTransform.exe" (
-    set TEXTTRANSFORMPATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\TextTransform.exe"
-)
-IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\IDE\TextTransform.exe" (
-    set TEXTTRANSFORMPATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\IDE\TextTransform.exe"
+
+:: not found in IDE, use legacy
+IF NOT DEFINED TEXTTRANSFORMPATH (
+   set TEXTTRANSFORMPATH="%COMMONPROGRAMFILES(x86)%\microsoft shared\TextTemplating\%VisualStudioVersion%\TextTransform.exe"
 )
 
 :: transform all the templates


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

This PR cherry-picks https://github.com/DynamoDS/DynamoRevit/pull/2264/ and https://github.com/DynamoDS/DynamoRevit/pull/2263 so Revit 2019 branch would also build cleanly with .Net 47.

@alfarok @mjkkirschner Although we say we are not going to maintain a Dynamo 2.1 with Revit 2019 release. I think being able to build cleaning and use DynamoRevit there can still be something valuable as an alternative if other team is looking at DynamoRevit integration example.

I am not sure if we want to cherry-pick to RC2.0.2_Revit 2019 since I am hesitate to bring in IronPython update there.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner @alfarok 

### FYIs

@awbushnell
