### PR TITLE
Fix crash when exit Revit Host Doc and undo/redo in Dynamo

### DIFF
--- a/src/DynamoRevit/Properties/Resources.Designer.cs
+++ b/src/DynamoRevit/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Dynamo.Applications.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -106,7 +106,7 @@ namespace Dynamo.Applications.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dynamo no longer has an active document. Please open a document..
+        ///   Looks up a localized string similar to Dynamo no longer has an active document and won&apos;t run the graph. Please open a document..
         /// </summary>
         public static string DocumentLostWarning {
             get {

--- a/src/DynamoRevit/Properties/Resources.resx
+++ b/src/DynamoRevit/Properties/Resources.resx
@@ -127,7 +127,7 @@
     <value>Dynamo {0}.{1}</value>
   </data>
   <data name="DocumentLostWarning" xml:space="preserve">
-    <value>Dynamo no longer has an active document. Please open a document.</value>
+    <value>Dynamo no longer has an active document and won't run the graph. Please open a document.</value>
   </data>
   <data name="DocumentPointerMessage" xml:space="preserve">
     <value>Dynamo is now running on {0}.</value>

--- a/src/DynamoRevit/ViewModel/DynamoRevitViewModel.cs
+++ b/src/DynamoRevit/ViewModel/DynamoRevitViewModel.cs
@@ -80,6 +80,7 @@ namespace Dynamo.Applications.ViewModel
             var hsvm = (HomeWorkspaceViewModel)HomeSpaceViewModel;
             hsvm.CurrentNotificationLevel = NotificationLevel.Error;
             hsvm.CurrentNotificationMessage = Resources.DocumentLostWarning;
+            CloseHomeWorkspaceCommand.Execute(null);
         }
 
         private void model_RevitContextUnavailable()

--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -96,7 +96,7 @@ namespace Dynamo.Applications.ViewModel
 
         private void Draw(NodeModel node = null)
         {
-            if (!Active) return;
+            if (!Active || DocumentManager.Instance.CurrentDBDocument == null) return;
             IEnumerable<IGraphicItem> graphicItems = new List<IGraphicItem>();
 
             if (node != null)

--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -96,6 +96,7 @@ namespace Dynamo.Applications.ViewModel
 
         private void Draw(NodeModel node = null)
         {
+            // If there is no open Revit document, some nodes cannot be executed.
             if (!Active || DocumentManager.Instance.CurrentDBDocument == null) return;
             IEnumerable<IGraphicItem> graphicItems = new List<IGraphicItem>();
 

--- a/src/Libraries/RevitServices/Threading/RevitSchedulerThread.cs
+++ b/src/Libraries/RevitServices/Threading/RevitSchedulerThread.cs
@@ -42,6 +42,7 @@ namespace RevitServices.Threading
                 return;
             }
 
+            // Don't run the graph if no active Revit doucment.
             if (revitApplication.ActiveUIDocument == null)
                 return;
 

--- a/src/Libraries/RevitServices/Threading/RevitSchedulerThread.cs
+++ b/src/Libraries/RevitServices/Threading/RevitSchedulerThread.cs
@@ -42,6 +42,9 @@ namespace RevitServices.Threading
                 return;
             }
 
+            if (revitApplication.ActiveUIDocument == null)
+                return;
+
             const bool waitIfTaskQueueIsEmpty = false;
             while (scheduler.ProcessNextTask(waitIfTaskQueueIsEmpty))
             {


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Fix crash when exit Revit Host Doc and undo/redo in Dynamo

Steps to reproduce the crash:

1. Launch Revit and create a new project
2. Launch Dynamo
3. In Dynamo, open the sample project, "Geometry_Solids.dyn", let the dynamo script produce some solids in the Revit model
4. In the Dynamo viewer, do a change to the script (keep the Dynamo app window open)
5. Switch to the Revit application window, close current Revit Document without saving
6. Switch back to Dynamo, click Undo

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

QilongTang, ZiyunShang
