### PR TITLE
Judge whether Item have no elements or SelectedIndex is invalid and r…

### DIFF
--- a/src/Libraries/RevitNodesUI/GenericClasses.cs
+++ b/src/Libraries/RevitNodesUI/GenericClasses.cs
@@ -104,12 +104,8 @@ namespace DSRevitNodesUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             // If there are no elements in the dropdown or the selected Index is invalid return a Null node.
-            if (Items.Count == 0 ||
-            Items[0].Name == Properties.Resources.NoTypesFound ||
-            SelectedIndex == -1 || Items[SelectedIndex].Name == Properties.Resources.None)
-            {
-                return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
-            }
+            if(!IsItemOrSelectedIndexValid(Properties.Resources.NoTypesFound,Properties.Resources.None))
+               return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
 
             // Cast the selected object to a Revit Element and get its Id
             Autodesk.Revit.DB.ElementId Id = ((Autodesk.Revit.DB.Element)Items[SelectedIndex].Item).Id;
@@ -198,12 +194,8 @@ namespace DSRevitNodesUI
             }
 
             // If there are no elements in the dropdown or the selected Index is invalid return a Null node.
-            if (Items.Count == 0 ||
-            Items[0].Name == Properties.Resources.NoTypesFound ||
-            SelectedIndex == -1 || Items[SelectedIndex].Name == Properties.Resources.None)
-            {
-                return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
-            }
+            if(!IsItemOrSelectedIndexValid(Properties.Resources.NoTypesFound,Properties.Resources.None))
+               return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
 
             // get the selected items name
             var stringNode = AstFactory.BuildStringNode((string)Items[SelectedIndex].Name);

--- a/src/Libraries/RevitNodesUI/GenericClasses.cs
+++ b/src/Libraries/RevitNodesUI/GenericClasses.cs
@@ -197,6 +197,14 @@ namespace DSRevitNodesUI
                 }
             }
 
+            // If there are no elements in the dropdown or the selected Index is invalid return a Null node.
+            if (Items.Count == 0 ||
+            Items[0].Name == Properties.Resources.NoTypesFound ||
+            SelectedIndex == -1 || Items[SelectedIndex].Name == Properties.Resources.None)
+            {
+                return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
+            }
+
             // get the selected items name
             var stringNode = AstFactory.BuildStringNode((string)Items[SelectedIndex].Name);
 

--- a/src/Libraries/RevitNodesUI/GenericClasses.cs
+++ b/src/Libraries/RevitNodesUI/GenericClasses.cs
@@ -104,7 +104,7 @@ namespace DSRevitNodesUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             // If there are no elements in the dropdown or the selected Index is invalid return a Null node.
-            if(!IsItemOrSelectedIndexValid(Properties.Resources.NoTypesFound,Properties.Resources.None))
+            if(!CanBuildOutputAst(Properties.Resources.NoTypesFound,Properties.Resources.None))
                return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
 
             // Cast the selected object to a Revit Element and get its Id
@@ -194,7 +194,7 @@ namespace DSRevitNodesUI
             }
 
             // If there are no elements in the dropdown or the selected Index is invalid return a Null node.
-            if(!IsItemOrSelectedIndexValid(Properties.Resources.NoTypesFound,Properties.Resources.None))
+            if(!CanBuildOutputAst(Properties.Resources.NoTypesFound,Properties.Resources.None))
                return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
 
             // get the selected items name

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -63,13 +63,13 @@ namespace DSRevitNodesUI
             base.Dispose();
         }
 
-        public Boolean IsItemOrSelectedIndexValid(string itemValue = null, string selectedValue = null)
+        public Boolean CanBuildOutputAst(string itemValue = null, string selectedValue = null)
         {
             if(Items.Count == 0 || SelectedIndex < 0)
                 return false;
-            if (string.IsNullOrEmpty(itemValue) && Items[0].Name == itemValue) 
+            if (!string.IsNullOrEmpty(itemValue) && Items[0].Name == itemValue) 
                 return false;
-            if (string.IsNullOrEmpty(selectedValue) && Items[SelectedIndex].Name == selectedValue)
+            if (!string.IsNullOrEmpty(selectedValue) && Items[SelectedIndex].Name == selectedValue)
                 return false;
             return true;
         }
@@ -121,7 +121,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!IsItemOrSelectedIndexValid(NO_FAMILY_TYPES,null))
+            if(!CanBuildOutputAst(NO_FAMILY_TYPES,null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var args = new List<AssociativeNode>
@@ -270,7 +270,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!IsItemOrSelectedIndexValid(noFamilyParameters,null))
+            if(!CanBuildOutputAst(noFamilyParameters,null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             return new[] {AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildStringNode((string)Items[SelectedIndex].Item)) };
@@ -393,7 +393,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!IsItemOrSelectedIndexValid(Properties.Resources.NoFloorTypesAvailable,null))
+            if(!CanBuildOutputAst(Properties.Resources.NoFloorTypesAvailable,null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var args = new List<AssociativeNode>
@@ -443,7 +443,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!IsItemOrSelectedIndexValid(Properties.Resources.NoWallTypesAvailable, null))
+            if(!CanBuildOutputAst(Properties.Resources.NoWallTypesAvailable, null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var args = new List<AssociativeNode>
@@ -498,7 +498,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!IsItemOrSelectedIndexValid(Properties.Resources.NoWallTypesAvailable, null))
+            if(!CanBuildOutputAst(Properties.Resources.NoWallTypesAvailable, null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var args = new List<AssociativeNode>
@@ -706,7 +706,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!IsItemOrSelectedIndexValid(noLevels, null))
+            if(!CanBuildOutputAst(noLevels, null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var node = AstFactory.BuildFunctionCall(
@@ -768,7 +768,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!IsItemOrSelectedIndexValid(noTypesMessage, null))
+            if(!CanBuildOutputAst(noTypesMessage, null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var node = AstFactory.BuildFunctionCall(
@@ -896,7 +896,7 @@ namespace DSRevitNodesUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             AssociativeNode node;
-            if (!IsItemOrSelectedIndexValid())
+            if (!CanBuildOutputAst())
             {
                 node = AstFactory.BuildNullNode();
             }

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -63,13 +63,19 @@ namespace DSRevitNodesUI
             base.Dispose();
         }
 
-        public Boolean CanBuildOutputAst(string itemValue = null, string selectedValue = null)
+        /// <summary>
+        /// whether it have valid Enumeration values to the output
+        /// </summary>
+        /// <param name="itemValueToIgnore"></param>
+        /// <param name="selectedValueToIgnore"></param>
+        /// <returns>true is that there are valid values to output,false is that only a null value to output</returns>
+        public Boolean CanBuildOutputAst(string itemValueToIgnore = null, string selectedValueToIgnore = null)
         {
             if(Items.Count == 0 || SelectedIndex < 0)
                 return false;
-            if (!string.IsNullOrEmpty(itemValue) && Items[0].Name == itemValue) 
+            if (!string.IsNullOrEmpty(itemValueToIgnore) && Items[0].Name == itemValueToIgnore) 
                 return false;
-            if (!string.IsNullOrEmpty(selectedValue) && Items[SelectedIndex].Name == selectedValue)
+            if (!string.IsNullOrEmpty(selectedValueToIgnore) && Items[SelectedIndex].Name == selectedValueToIgnore)
                 return false;
             return true;
         }
@@ -121,7 +127,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!CanBuildOutputAst(NO_FAMILY_TYPES,null))
+            if(!CanBuildOutputAst(NO_FAMILY_TYPES))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var args = new List<AssociativeNode>
@@ -270,7 +276,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!CanBuildOutputAst(noFamilyParameters,null))
+            if(!CanBuildOutputAst(noFamilyParameters))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             return new[] {AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildStringNode((string)Items[SelectedIndex].Item)) };
@@ -393,7 +399,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!CanBuildOutputAst(Properties.Resources.NoFloorTypesAvailable,null))
+            if(!CanBuildOutputAst(Properties.Resources.NoFloorTypesAvailable))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var args = new List<AssociativeNode>
@@ -443,7 +449,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!CanBuildOutputAst(Properties.Resources.NoWallTypesAvailable, null))
+            if(!CanBuildOutputAst(Properties.Resources.NoWallTypesAvailable))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var args = new List<AssociativeNode>
@@ -498,7 +504,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!CanBuildOutputAst(Properties.Resources.NoWallTypesAvailable, null))
+            if(!CanBuildOutputAst(Properties.Resources.NoWallTypesAvailable))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var args = new List<AssociativeNode>
@@ -706,7 +712,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!CanBuildOutputAst(noLevels, null))
+            if(!CanBuildOutputAst(noLevels))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var node = AstFactory.BuildFunctionCall(
@@ -768,7 +774,7 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if(!CanBuildOutputAst(noTypesMessage, null))
+            if(!CanBuildOutputAst(noTypesMessage))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
             
             var node = AstFactory.BuildFunctionCall(

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -62,6 +62,17 @@ namespace DSRevitNodesUI
             DynamoRevitApp.EventHandlerProxy.DocumentOpened -= Controller_RevitDocumentChanged;
             base.Dispose();
         }
+
+        public Boolean IsItemOrSelectedIndexValid(string itemValue = null, string selectedValue = null)
+        {
+            if(Items.Count == 0 || SelectedIndex < 0)
+                return false;
+            if (string.IsNullOrEmpty(itemValue) && Items[0].Name == itemValue) 
+                return false;
+            if (string.IsNullOrEmpty(selectedValue) && Items[SelectedIndex].Name == selectedValue)
+                return false;
+            return true;
+        }
     }
 
     [NodeName("Family Types")]
@@ -110,13 +121,9 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if (Items.Count == 0 ||
-                Items[0].Name == NO_FAMILY_TYPES ||
-                SelectedIndex == -1)
-            {
+            if(!IsItemOrSelectedIndexValid(NO_FAMILY_TYPES,null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
-            }
-
+            
             var args = new List<AssociativeNode>
             {
                 AstFactory.BuildStringNode(((FamilySymbol) Items[SelectedIndex].Item).Family.Name),
@@ -263,13 +270,9 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if (Items.Count == 0 ||
-                Items[0].Name == noFamilyParameters ||
-                SelectedIndex == -1)
-            {
+            if(!IsItemOrSelectedIndexValid(noFamilyParameters,null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
-            }
-
+            
             return new[] {AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildStringNode((string)Items[SelectedIndex].Item)) };
         }
 
@@ -390,13 +393,9 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if (Items.Count == 0 || 
-                Items[0].Name == Properties.Resources.NoFloorTypesAvailable ||
-                SelectedIndex == -1)
-            {
+            if(!IsItemOrSelectedIndexValid(Properties.Resources.NoFloorTypesAvailable,null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
-            }
-
+            
             var args = new List<AssociativeNode>
             {
                 AstFactory.BuildStringNode(((Autodesk.Revit.DB.FloorType) Items[SelectedIndex].Item).Name)
@@ -444,13 +443,9 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if (Items.Count == 0 ||
-                Items[0].Name == Properties.Resources.NoWallTypesAvailable ||
-                SelectedIndex == -1)
-            {
+            if(!IsItemOrSelectedIndexValid(Properties.Resources.NoWallTypesAvailable, null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
-            }
-
+            
             var args = new List<AssociativeNode>
             {
                 AstFactory.BuildStringNode(((Autodesk.Revit.DB.WallType) Items[SelectedIndex].Item).Name)
@@ -503,13 +498,9 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if (Items.Count == 0 ||
-                Items[0].Name == Properties.Resources.NoWallTypesAvailable ||
-                SelectedIndex == -1)
-            {
+            if(!IsItemOrSelectedIndexValid(Properties.Resources.NoWallTypesAvailable, null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
-            }
-
+            
             var args = new List<AssociativeNode>
             {
                 AstFactory.BuildStringNode(((Revit.Elements.PerformanceAdviserRule) Items[SelectedIndex].Item).RuleId.ToString())
@@ -715,13 +706,9 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if (Items.Count == 0 ||
-                Items[0].Name == noLevels ||
-                SelectedIndex == -1)
-            {
+            if(!IsItemOrSelectedIndexValid(noLevels, null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
-            }
-
+            
             var node = AstFactory.BuildFunctionCall(
                 "Revit.Elements.ElementSelector",
                 "ByElementId",
@@ -781,13 +768,9 @@ namespace DSRevitNodesUI
 
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
-            if (Items.Count == 0 ||
-                Items[0].Name == noTypesMessage ||
-                SelectedIndex == -1)
-            {
+            if(!IsItemOrSelectedIndexValid(noTypesMessage, null))
                 return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
-            }
-
+            
             var node = AstFactory.BuildFunctionCall(
                 "Revit.Elements.ElementSelector",
                 "ByElementId",
@@ -913,8 +896,7 @@ namespace DSRevitNodesUI
         public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
         {
             AssociativeNode node;
-
-            if (SelectedIndex == -1)
+            if (!IsItemOrSelectedIndexValid())
             {
                 node = AstFactory.BuildNullNode();
             }


### PR DESCRIPTION
…eturn a null node

### Purpose

The nodes like "Wall Location" which implement abstract class "CustomGenericEnumerationDropDown", run error when they have no selected value. It should return a null value in that case.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 @QilongTang 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
