### PR TITLE
Add two new ImportInstance nodes because of RevitAPI changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Add CanBuildOutputAst function to RevitDropDownBase for judging whether it have valid Enumeration values to the output in dropdown list
 * Update RevitSystemTestBase to make it more user friendly
+* Add two new nodes to ImportInstance because of RevitAPI changes
 
 ## 0.1.0
 * The version of master branch will be start with 0.1.x, and Revit2020 branch will still be 0.0.xx.

--- a/src/Libraries/RevitNodes/Elements/ImportInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/ImportInstance.cs
@@ -34,7 +34,7 @@ namespace Revit.Elements
         }
 
         #region Private constructor
-      
+
         /// <summary>
         /// Constructor for ImportInstance
         /// </summary>
@@ -56,7 +56,7 @@ namespace Revit.Elements
         }
 
         #endregion
-              
+
         /// <summary>
         /// Initialize an ImportInstance element
         /// </summary>
@@ -153,24 +153,7 @@ namespace Revit.Elements
         /// <returns></returns>
         public static ImportInstance ByGeometries(Autodesk.DesignScript.Geometry.Geometry[] geometries)
         {
-            if (geometries == null)
-            {
-                throw new ArgumentNullException("geometries");
-            }
-
-            // transform geometry from dynamo unit system (m) to revit (ft)
-            var newGeometries = geometries.Select(x => x.InHostUnits()).ToArray();
-
-            var translation = Vector.ByCoordinates(0, 0, 0);
-            Robustify(ref newGeometries, ref translation);
-
-            // Export to temporary file
-            var fn = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".sat";
-            var exported_fn = Autodesk.DesignScript.Geometry.Geometry.ExportToSAT(newGeometries, fn);
-
-            newGeometries.ForEach(x => x.Dispose());
-
-            return new ImportInstance(exported_fn, translation.ToXyz());
+            return ByGeometriesAndView(geometries);
         }
 
         /// <summary>
@@ -180,17 +163,13 @@ namespace Revit.Elements
         /// <param name="geometries">A collection of Geometry</param>
         /// <param name="view">The view into which the ImportInstance will be imported.</param>
         /// <returns></returns>
-        public static ImportInstance ByGeometriesAndView(Autodesk.DesignScript.Geometry.Geometry[] geometries, Revit.Elements.Views.View view)
+        public static ImportInstance ByGeometriesAndView(Autodesk.DesignScript.Geometry.Geometry[] geometries, Revit.Elements.Views.View view = null)
         {
             if (geometries == null)
             {
                 throw new ArgumentNullException("geometries");
             }
-            if (view == null)
-            {
-                throw new ArgumentNullException("view");
-            }
-
+            
             // transform geometry from dynamo unit system (m) to revit (ft)
             var newGeometries = geometries.Select(x => x.InHostUnits()).ToArray();
 

--- a/src/Libraries/RevitNodes/Elements/ImportInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/ImportInstance.cs
@@ -34,24 +34,14 @@ namespace Revit.Elements
         }
 
         #region Private constructor
-
-        /// <summary>
-        /// Constructor for ImportInstance
-        /// </summary>
-        /// <param name="satPath"></param>
-        /// <param name="translation"></param>
-        internal ImportInstance(string satPath, XYZ translation = null)
-        {
-            SafeInit(() => InitImportInstance(satPath, translation));
-        }
-
+      
         /// <summary>
         /// Constructor for ImportInstance
         /// </summary>
         /// <param name="satPath"></param>
         /// <param name="translation"></param>
         /// <param name="view"></param>
-        internal ImportInstance(string satPath, Revit.Elements.Views.View view, XYZ translation = null)
+        internal ImportInstance(string satPath, XYZ translation = null, Revit.Elements.Views.View view = null)
         {
             SafeInit(() => InitImportInstance(satPath, view, translation));
         }
@@ -66,46 +56,7 @@ namespace Revit.Elements
         }
 
         #endregion
-
-        /// <summary>
-        /// Initialize an ImportInstance element
-        /// </summary>
-        /// <param name="satPath"></param>
-        /// <param name="translation"></param>
-        private void InitImportInstance(string satPath, XYZ translation = null)
-        {
-            var instance = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.ImportInstance>(Document);
-            if (null != instance)
-                DocumentManager.Instance.DeleteElement(new ElementUUID(instance.UniqueId));
-
-            translation = translation ?? XYZ.Zero;
-
-            TransactionManager.Instance.EnsureInTransaction(Document);
-
-            var options = new SATImportOptions()
-            {
-                Unit = ImportUnit.Foot
-            };
-
-            var id = Document.Import(satPath, options, Document.ActiveView);
-            var element = Document.GetElement(id);
-            var importInstance = element as Autodesk.Revit.DB.ImportInstance;
-
-            if (importInstance == null)
-            {
-                throw new Exception(Properties.Resources.InstanceImportFailure);
-            }
-
-            InternalSetImportInstance(importInstance);
-            InternalUnpinAndTranslateImportInstance(translation);
-
-            this.Path = satPath;
-
-            TransactionManager.Instance.TransactionTaskDone();
-
-            ElementBinder.SetElementForTrace(importInstance);
-        }
-
+              
         /// <summary>
         /// Initialize an ImportInstance element
         /// </summary>
@@ -127,7 +78,7 @@ namespace Revit.Elements
                 Unit = ImportUnit.Foot
             };
 
-            var id = Document.Import(satPath, options, view.InternalView);
+            var id = null != view ? Document.Import(satPath, options, view.InternalView) : Document.Import(satPath, options, Document.ActiveView);
             var element = Document.GetElement(id);
             var importInstance = element as Autodesk.Revit.DB.ImportInstance;
 
@@ -252,7 +203,7 @@ namespace Revit.Elements
 
             newGeometries.ForEach(x => x.Dispose());
 
-            return new ImportInstance(exported_fn, view, translation.ToXyz());
+            return new ImportInstance(exported_fn, translation.ToXyz(), view);
         }
 
         /// <summary>

--- a/test/Libraries/RevitNodesTests/Elements/ImportInstanceTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ImportInstanceTests.cs
@@ -38,5 +38,38 @@ namespace RevitNodesTests.Elements
             cuboid.BoundingBox.MinPoint.ShouldBeApproximately(solidImport.BoundingBox.MinPoint);
             cuboid.BoundingBox.MaxPoint.ShouldBeApproximately(solidImport.BoundingBox.MaxPoint);
         }
+
+        [Test]
+        [TestModel(@".\empty.rfa")]
+        public void ByGeometryAndView_ProviedesExpectedConversion()
+        {
+            // construct the cuboid in meters
+            var c0 = Point.ByCoordinates(-1, -1, -1);
+            var c1 = Point.ByCoordinates(1, 1, 1);
+            var cuboid = Cuboid.ByCorners(c0, c1);
+
+            // set the view into which the ImportInstance will be imported
+            var elevation = 100;
+            var level = Revit.Elements.Level.ByElevation(elevation);
+            Assert.NotNull(level);
+            var view = Revit.Elements.Views.FloorPlanView.ByLevel(level);
+            
+            // import
+            var import = Revit.Elements.ImportInstance.ByGeometryAndView(cuboid,view);
+            // extract geometry
+            var importGeometry = import.Geometry().First();
+
+            Assert.IsAssignableFrom(typeof(Autodesk.DesignScript.Geometry.Solid), importGeometry);
+
+            var solidImport = (Autodesk.DesignScript.Geometry.Solid)importGeometry;
+
+            var c2 = Point.ByCoordinates(-1, -1, -1 + elevation);
+            var c3 = Point.ByCoordinates(1, 1, 1 + elevation);
+            var cuboid2 = Cuboid.ByCorners(c2, c3);
+
+            cuboid2.Volume.ShouldBeApproximately(solidImport.Volume);
+            cuboid2.BoundingBox.MinPoint.ShouldBeApproximately(solidImport.BoundingBox.MinPoint);
+            cuboid2.BoundingBox.MaxPoint.ShouldBeApproximately(solidImport.BoundingBox.MaxPoint);
+      }
     }
 }


### PR DESCRIPTION
### Purpose

Because of Revit API changes, the ImportInstance should have another param to import Geometries into correct position.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 

### FYIs

@QilongTang @mjkkirschner 
