### PR TITLE
Streamline revit system test base

### DIFF
--- a/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
+++ b/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
@@ -151,7 +151,7 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             //assert no adaptive components in the model
-            Assert.AreEqual(0, RevitSystemTestHelper.GetAllFamilyInstances(true).Count);
+            Assert.AreEqual(0, TestUtils.GetAllFamilyInstances(true).Count);
 
         }
 

--- a/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
+++ b/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
@@ -151,7 +151,7 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             //assert no adaptive components in the model
-            Assert.AreEqual(0, TestUtils.GetAllFamilyInstances(true).Count);
+            Assert.AreEqual(0, TestUtils.GetAllFamilyInstances().Count);
 
         }
 

--- a/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
+++ b/test/Libraries/RevitIntegrationTests/AdaptiveComponentTests.cs
@@ -151,7 +151,7 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             //assert no adaptive components in the model
-            Assert.AreEqual(0, GetAllFamilyInstances(true).Count);
+            Assert.AreEqual(0, RevitSystemTestHelper.GetAllFamilyInstances(true).Count);
 
         }
 

--- a/test/Libraries/RevitIntegrationTests/BugTests.cs
+++ b/test/Libraries/RevitIntegrationTests/BugTests.cs
@@ -762,7 +762,7 @@ namespace RevitSystemTests
 
         [Test]
         [Category("RegressionTests")]
-        [TestModel(@".\Samples\DynamoSample.rvt")]
+        [TestModel(@".\Samples\DynamoSample_2020.rvt")]
         public void GetParameterValueByNameWorksForSheetNumber()
         {
             string filePath = Path.Combine(workingDirectory, @".\Bugs\MAGN_5870.dyn");

--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -33,17 +33,11 @@ namespace RevitSystemTests
         /// <returns>the model curves</returns>
         private static IList<Autodesk.Revit.DB.ModelCurve> GetAllModelCurves()
         {
-            using (var trans = new Transaction(DocumentManager.Instance.CurrentUIDocument.Document, "FilteringElements"))
-            {
-                trans.Start();
-
-                ElementClassFilter ef = new ElementClassFilter(typeof(Autodesk.Revit.DB.CurveElement));
-                FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-                fec.WherePasses(ef);
-
-                trans.Commit();
-                return fec.ToElements().OfType<Autodesk.Revit.DB.ModelCurve>().ToList();
-            }
+            ElementClassFilter ef = new ElementClassFilter(typeof(Autodesk.Revit.DB.CurveElement));
+            FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
+            fec.WherePasses(ef);
+               
+            return fec.ToElements().OfType<Autodesk.Revit.DB.ModelCurve>().ToList();            
         }
 
         /// <summary>
@@ -51,29 +45,12 @@ namespace RevitSystemTests
         /// </summary>
         /// <param name="startNewTransaction">whether do the filtering in a new transaction</param>
         /// <returns>the reference points</returns>
-        private static IList<Element> GetAllReferencePointElements(bool startNewTransaction)
-        {
-            if (startNewTransaction)
-            {
-                using (var trans = new Transaction(DocumentManager.Instance.CurrentUIDocument.Document, "FilteringElements"))
-                {
-                    trans.Start();
-
-                    ElementClassFilter ef = new ElementClassFilter(typeof(ReferencePoint));
-                    FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-                    fec.WherePasses(ef);
-
-                    trans.Commit();
-                    return fec.ToElements();
-                }
-            }
-            else
-            {
-                ElementClassFilter ef = new ElementClassFilter(typeof(ReferencePoint));
-                FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-                fec.WherePasses(ef);
-                return fec.ToElements();
-            }
+        private static IList<Element> GetAllReferencePointElements()
+        {            
+            ElementClassFilter ef = new ElementClassFilter(typeof(ReferencePoint));
+            FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
+            fec.WherePasses(ef);
+            return fec.ToElements();
         }
 
         /// <summary>
@@ -81,29 +58,12 @@ namespace RevitSystemTests
         /// </summary>
         /// <param name="startNewTransaction">whether do the filtering in a new transaction</param>
         /// <returns>the walls</returns>
-        private static IList<Element> GetAllWallElements(bool startNewTransaction)
+        private static IList<Element> GetAllWallElements()
         {
-            if (startNewTransaction)
-            {
-                using (var trans = new Transaction(DocumentManager.Instance.CurrentUIDocument.Document, "FilteringElements"))
-                {
-                    trans.Start();
-
-                    ElementClassFilter ef = new ElementClassFilter(typeof(Wall));
-                    FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-                    fec.WherePasses(ef);
-
-                    trans.Commit();
-                    return fec.ToElements();
-                }
-            }
-            else
-            {
-                ElementClassFilter ef = new ElementClassFilter(typeof(Wall));
-                FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-                fec.WherePasses(ef);
-                return fec.ToElements();
-            }
+            ElementClassFilter ef = new ElementClassFilter(typeof(Wall));
+            FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
+            fec.WherePasses(ef);
+            return fec.ToElements();
         }
 
         /// <summary>
@@ -183,7 +143,7 @@ namespace RevitSystemTests
 
                 try
                 {
-                    IList<Element> rps = GetAllWallElements(false);
+                    IList<Element> rps = GetAllWallElements();
                     Assert.AreEqual(1, rps.Count);
                     Wall wall = rps.First() as Wall;
                     List<XYZ> ctrlPnts = new List<XYZ>();
@@ -213,7 +173,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
             
-            IList<Element> rps2 = GetAllWallElements(false);
+            IList<Element> rps2 = GetAllWallElements();
             Assert.AreEqual(1, rps2.Count);
         }
 
@@ -295,7 +255,7 @@ namespace RevitSystemTests
             
 
             //Change the position of the reference point
-            var points = GetAllReferencePointElements(true);
+            var points = GetAllReferencePointElements();
             Assert.AreEqual(1, points.Count);
             ReferencePoint pnt = points[0] as ReferencePoint;
             Assert.IsNotNull(pnt);
@@ -310,7 +270,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
             
-            points = GetAllReferencePointElements(true);
+            points = GetAllReferencePointElements();
             Assert.AreEqual(1, points.Count);
             pnt = points[0] as ReferencePoint;
             Assert.IsTrue(pnt.Position.IsAlmostEqualTo(new XYZ(0.0, 0.0, 0.0)));
@@ -337,7 +297,7 @@ namespace RevitSystemTests
             //Run the graph once again
             RunCurrentModel();
 
-            var points = GetAllReferencePointElements(true);
+            var points = GetAllReferencePointElements();
             Assert.AreEqual(2, points.Count);
             var pnt = points[0] as ReferencePoint;
             Assert.IsTrue(pnt.Position.IsAlmostEqualTo(new XYZ(0.0, 0.0, 0.0)));
@@ -371,7 +331,7 @@ namespace RevitSystemTests
             //Run the graph once again
             RunCurrentModel();
 
-            var points = GetAllReferencePointElements(true);
+            var points = GetAllReferencePointElements();
             Assert.AreEqual(1, points.Count);
             var pnt = points[0] as ReferencePoint;
             Assert.IsTrue(pnt.Position.IsAlmostEqualTo(new XYZ(0.0, 0.0, 0.0)));
@@ -405,7 +365,7 @@ namespace RevitSystemTests
             {
                 trans.Start();
 
-                IList<Element> rps = GetAllReferencePointElements(false);
+                IList<Element> rps = GetAllReferencePointElements();
                 var rpIDs = rps.Select(x => x.Id);
                 DocumentManager.Instance.CurrentDBDocument.Delete(rpIDs.ToList());
 
@@ -420,7 +380,7 @@ namespace RevitSystemTests
 
             //Check the number of reference points
             //This also verifies MAGN-2317
-            IList<Element> newRps = GetAllReferencePointElements(true);
+            IList<Element> newRps = GetAllReferencePointElements();
             Assert.AreEqual(1, newRps.Count());
 
             //Ensure the binding elements are different
@@ -589,7 +549,7 @@ namespace RevitSystemTests
             
 
             //Check the number of the refrence points
-            var points = GetAllReferencePointElements(true);
+            var points = GetAllReferencePointElements();
             Assert.AreEqual(8, points.Count);
 
             var model = ViewModel.Model;
@@ -607,7 +567,7 @@ namespace RevitSystemTests
             
 
             //Check the number of the refrence points
-            points = GetAllReferencePointElements(true);
+            points = GetAllReferencePointElements();
             Assert.AreEqual(6, points.Count);
         }
 
@@ -673,7 +633,7 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             //Check the number of the family instances
-            var instances = TestUtils.GetAllFamilyInstances(true);
+            var instances = TestUtils.GetAllFamilyInstances();
             Assert.AreEqual(8, instances.Count);
 
             var model = ViewModel.Model;
@@ -695,7 +655,7 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             //Check the number of family instances
-            instances = TestUtils.GetAllFamilyInstances(true);
+            instances = TestUtils.GetAllFamilyInstances();
             Assert.AreEqual(8, instances.Count);
         }
 
@@ -849,7 +809,7 @@ namespace RevitSystemTests
 
             ViewModel.OpenCommand.Execute(testPath);
 
-            var initialNumber = TestUtils.GetAllFamilyInstances(false).Count;
+            var initialNumber = TestUtils.GetAllFamilyInstances().Count;
 
             // The current Revit file already has a family placed at UV param location 0.50
             // We update placement location of family instance to 0.75 param location
@@ -861,7 +821,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            var finalNumber = TestUtils.GetAllFamilyInstances(false).Count;
+            var finalNumber = TestUtils.GetAllFamilyInstances().Count;
             var famInst = GetPreviewValue("56cf69ec-d4ca-4add-810d-aee64d003c76") as Revit.Elements.FamilyInstance;
             Assert.IsNotNull(famInst);
 

--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -151,6 +151,17 @@ namespace RevitSystemTests
             return new ElementId(id.IntID);
         }
 
+        /// <summary>
+        /// Get all the wall from current document
+        /// </summary>
+        /// <returns>the list of walls</returns>
+        private IList<Wall> GetAllWalls()
+        {
+            var fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
+            fec.OfClass(typeof(Wall));
+            return fec.ToElements().Cast<Wall>().ToList();
+        }
+
         [Test]
         [TestModel(@".\ElementBinding\CreateWallInDynamo.rvt")]
         public void CreateInDynamoModifyInRevitToCauseFailure()
@@ -662,7 +673,7 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             //Check the number of the family instances
-            var instances = GetAllFamilyInstances(true);
+            var instances = RevitSystemTestHelper.GetAllFamilyInstances(true);
             Assert.AreEqual(8, instances.Count);
 
             var model = ViewModel.Model;
@@ -684,7 +695,7 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             //Check the number of family instances
-            instances = GetAllFamilyInstances(true);
+            instances = RevitSystemTestHelper.GetAllFamilyInstances(true);
             Assert.AreEqual(8, instances.Count);
         }
 
@@ -838,7 +849,7 @@ namespace RevitSystemTests
 
             ViewModel.OpenCommand.Execute(testPath);
 
-            var initialNumber = GetAllFamilyInstances(false).Count;
+            var initialNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
 
             // The current Revit file already has a family placed at UV param location 0.50
             // We update placement location of family instance to 0.75 param location
@@ -850,7 +861,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            var finalNumber = GetAllFamilyInstances(false).Count;
+            var finalNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
             var famInst = GetPreviewValue("56cf69ec-d4ca-4add-810d-aee64d003c76") as Revit.Elements.FamilyInstance;
             Assert.IsNotNull(famInst);
 

--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -673,7 +673,7 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             //Check the number of the family instances
-            var instances = RevitSystemTestHelper.GetAllFamilyInstances(true);
+            var instances = TestUtils.GetAllFamilyInstances(true);
             Assert.AreEqual(8, instances.Count);
 
             var model = ViewModel.Model;
@@ -695,7 +695,7 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             //Check the number of family instances
-            instances = RevitSystemTestHelper.GetAllFamilyInstances(true);
+            instances = TestUtils.GetAllFamilyInstances(true);
             Assert.AreEqual(8, instances.Count);
         }
 
@@ -849,7 +849,7 @@ namespace RevitSystemTests
 
             ViewModel.OpenCommand.Execute(testPath);
 
-            var initialNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
+            var initialNumber = TestUtils.GetAllFamilyInstances(false).Count;
 
             // The current Revit file already has a family placed at UV param location 0.50
             // We update placement location of family instance to 0.75 param location
@@ -861,7 +861,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            var finalNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
+            var finalNumber = TestUtils.GetAllFamilyInstances(false).Count;
             var famInst = GetPreviewValue("56cf69ec-d4ca-4add-810d-aee64d003c76") as Revit.Elements.FamilyInstance;
             Assert.IsNotNull(famInst);
 

--- a/test/Libraries/RevitIntegrationTests/FamilyTests.cs
+++ b/test/Libraries/RevitIntegrationTests/FamilyTests.cs
@@ -194,7 +194,7 @@ namespace RevitSystemTests
             ViewModel.OpenCommand.Execute(testPath);
             RunCurrentModel();
 
-            var initialNumber = TestUtils.GetAllFamilyInstances(false).Count;
+            var initialNumber = TestUtils.GetAllFamilyInstances().Count;
             var famInst1 = GetPreviewValue("e8dbd9fa-c0fd-4a5c-9cd8-2616f98285c8") as FamilyInstance;
             Assert.IsNotNull(famInst1);
 
@@ -207,7 +207,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            var finalNumber = TestUtils.GetAllFamilyInstances(false).Count;
+            var finalNumber = TestUtils.GetAllFamilyInstances().Count;
             var famInst2 = GetPreviewValue("e8dbd9fa-c0fd-4a5c-9cd8-2616f98285c8") as FamilyInstance;
             Assert.IsNotNull(famInst2);
 
@@ -291,7 +291,7 @@ namespace RevitSystemTests
             ViewModel.OpenCommand.Execute(testPath);
             RunCurrentModel();
 
-            var initialNumber = TestUtils.GetAllFamilyInstances(false).Count;
+            var initialNumber = TestUtils.GetAllFamilyInstances().Count;
 
             // Update input line used to create family instance
             // connect Surface.PointAtParameter node to endPoint of Line.StartPointEndPoint node
@@ -305,7 +305,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            var finalNumber = TestUtils.GetAllFamilyInstances(false).Count;
+            var finalNumber = TestUtils.GetAllFamilyInstances().Count;
 
             // FamilyInstance.ByFace (with Line overload) node
             var famInst = GetPreviewValue("f8a4485d-6bfa-413c-a547-60a8df5022cf") as FamilyInstance;

--- a/test/Libraries/RevitIntegrationTests/FamilyTests.cs
+++ b/test/Libraries/RevitIntegrationTests/FamilyTests.cs
@@ -194,7 +194,7 @@ namespace RevitSystemTests
             ViewModel.OpenCommand.Execute(testPath);
             RunCurrentModel();
 
-            var initialNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
+            var initialNumber = TestUtils.GetAllFamilyInstances(false).Count;
             var famInst1 = GetPreviewValue("e8dbd9fa-c0fd-4a5c-9cd8-2616f98285c8") as FamilyInstance;
             Assert.IsNotNull(famInst1);
 
@@ -207,7 +207,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            var finalNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
+            var finalNumber = TestUtils.GetAllFamilyInstances(false).Count;
             var famInst2 = GetPreviewValue("e8dbd9fa-c0fd-4a5c-9cd8-2616f98285c8") as FamilyInstance;
             Assert.IsNotNull(famInst2);
 
@@ -291,7 +291,7 @@ namespace RevitSystemTests
             ViewModel.OpenCommand.Execute(testPath);
             RunCurrentModel();
 
-            var initialNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
+            var initialNumber = TestUtils.GetAllFamilyInstances(false).Count;
 
             // Update input line used to create family instance
             // connect Surface.PointAtParameter node to endPoint of Line.StartPointEndPoint node
@@ -305,7 +305,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            var finalNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
+            var finalNumber = TestUtils.GetAllFamilyInstances(false).Count;
 
             // FamilyInstance.ByFace (with Line overload) node
             var famInst = GetPreviewValue("f8a4485d-6bfa-413c-a547-60a8df5022cf") as FamilyInstance;

--- a/test/Libraries/RevitIntegrationTests/FamilyTests.cs
+++ b/test/Libraries/RevitIntegrationTests/FamilyTests.cs
@@ -194,7 +194,7 @@ namespace RevitSystemTests
             ViewModel.OpenCommand.Execute(testPath);
             RunCurrentModel();
 
-            var initialNumber = GetAllFamilyInstances(false).Count;
+            var initialNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
             var famInst1 = GetPreviewValue("e8dbd9fa-c0fd-4a5c-9cd8-2616f98285c8") as FamilyInstance;
             Assert.IsNotNull(famInst1);
 
@@ -207,7 +207,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            var finalNumber = GetAllFamilyInstances(false).Count;
+            var finalNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
             var famInst2 = GetPreviewValue("e8dbd9fa-c0fd-4a5c-9cd8-2616f98285c8") as FamilyInstance;
             Assert.IsNotNull(famInst2);
 
@@ -291,7 +291,7 @@ namespace RevitSystemTests
             ViewModel.OpenCommand.Execute(testPath);
             RunCurrentModel();
 
-            var initialNumber = GetAllFamilyInstances(false).Count;
+            var initialNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
 
             // Update input line used to create family instance
             // connect Surface.PointAtParameter node to endPoint of Line.StartPointEndPoint node
@@ -305,7 +305,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            var finalNumber = GetAllFamilyInstances(false).Count;
+            var finalNumber = RevitSystemTestHelper.GetAllFamilyInstances(false).Count;
 
             // FamilyInstance.ByFace (with Line overload) node
             var famInst = GetPreviewValue("f8a4485d-6bfa-413c-a547-60a8df5022cf") as FamilyInstance;

--- a/test/Libraries/RevitIntegrationTests/ImportInstanceTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ImportInstanceTests.cs
@@ -99,17 +99,10 @@ namespace RevitSystemTests
         /// <returns>the import instances</returns>
         protected static IList<Element> GetAllImportInstances()
         {
-            using (var trans = new Transaction(DocumentManager.Instance.CurrentUIDocument.Document, "FilteringElements"))
-            {
-                trans.Start();
-
-                ElementClassFilter ef = new ElementClassFilter(typeof(Autodesk.Revit.DB.ImportInstance));
-                FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-                fec.WherePasses(ef);
-
-                trans.Commit();
-                return fec.ToElements();
-            }
+            ElementClassFilter ef = new ElementClassFilter(typeof(Autodesk.Revit.DB.ImportInstance));
+            FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
+            fec.WherePasses(ef);
+            return fec.ToElements();
         }
     }
 }

--- a/test/Libraries/RevitIntegrationTests/TestUtils.cs
+++ b/test/Libraries/RevitIntegrationTests/TestUtils.cs
@@ -10,45 +10,16 @@ namespace RevitSystemTests
     class TestUtils
     {
         /// <summary>
-        /// Retrieves all family instances of the named type from the active document.
-        /// </summary>
-        /// <param name="typeName"></param>
-        /// <returns></returns>
-        public static IEnumerable<FamilyInstance> GetAllFamilyInstancesWithTypeName(string typeName)
-        {
-            FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-            fec.OfClass(typeof(FamilyInstance));
-            return fec.ToElements().Where(x => ((FamilyInstance)x).Symbol.Name == typeName).Cast<FamilyInstance>();
-        }
-
-        /// <summary>
         /// This function gets all the family instances in the current Revit document
         /// </summary>
         /// <param name="startNewTransaction">whether do the filtering in a new transaction</param>
         /// <returns>the family instances</returns>
-        public static IList<Element> GetAllFamilyInstances(bool startNewTransaction)
+        public static IList<Element> GetAllFamilyInstances()
         {
-            if (startNewTransaction)
-            {
-                using (var trans = new Transaction(DocumentManager.Instance.CurrentUIDocument.Document, "FilteringElements"))
-                {
-                    trans.Start();
-
-                    ElementClassFilter ef = new ElementClassFilter(typeof(FamilyInstance));
-                    FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-                    fec.WherePasses(ef);
-
-                    trans.Commit();
-                    return fec.ToElements();
-                }
-            }
-            else
-            {
-                ElementClassFilter ef = new ElementClassFilter(typeof(FamilyInstance));
-                FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-                fec.WherePasses(ef);
-                return fec.ToElements();
-            }
+            ElementClassFilter ef = new ElementClassFilter(typeof(FamilyInstance));
+            FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
+            fec.WherePasses(ef);
+            return fec.ToElements();            
         }
     }
 }

--- a/test/Libraries/RevitIntegrationTests/TestUtils.cs
+++ b/test/Libraries/RevitIntegrationTests/TestUtils.cs
@@ -20,5 +20,35 @@ namespace RevitSystemTests
             fec.OfClass(typeof(FamilyInstance));
             return fec.ToElements().Where(x => ((FamilyInstance)x).Symbol.Name == typeName).Cast<FamilyInstance>();
         }
+
+        /// <summary>
+        /// This function gets all the family instances in the current Revit document
+        /// </summary>
+        /// <param name="startNewTransaction">whether do the filtering in a new transaction</param>
+        /// <returns>the family instances</returns>
+        public static IList<Element> GetAllFamilyInstances(bool startNewTransaction)
+        {
+            if (startNewTransaction)
+            {
+                using (var trans = new Transaction(DocumentManager.Instance.CurrentUIDocument.Document, "FilteringElements"))
+                {
+                    trans.Start();
+
+                    ElementClassFilter ef = new ElementClassFilter(typeof(FamilyInstance));
+                    FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
+                    fec.WherePasses(ef);
+
+                    trans.Commit();
+                    return fec.ToElements();
+                }
+            }
+            else
+            {
+                ElementClassFilter ef = new ElementClassFilter(typeof(FamilyInstance));
+                FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
+                fec.WherePasses(ef);
+                return fec.ToElements();
+            }
+        }
     }
 }

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -216,7 +216,7 @@ namespace RevitTestServices
            return false;
         }
 
-      protected override void StartDynamo(TestSessionConfiguration testConfig)
+        protected override void StartDynamo(TestSessionConfiguration testConfig)
         {
             try
             {
@@ -391,9 +391,8 @@ namespace RevitTestServices
                     EnvironmentVariableTarget.Process) + ";" + corePath;
             Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Process);
         }
-    }
+    }   
 
-    
     public class RevitSystemTestHelper
     {
         /// <summary>

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -363,12 +363,45 @@ namespace RevitTestServices
             initialDoc.Close(false);
         }
 
+        #endregion
+
+        protected void MakeConnector(NodeModel start, NodeModel end, int portStart, int portEnd)
+        {
+            var cmdStart = new DynamoModel.MakeConnectionCommand(start.GUID, portStart, PortType.Output,
+                DynamoModel.MakeConnectionCommand.Mode.Begin);
+            this.Model.ExecuteCommand(cmdStart);
+
+            var cmdend = new DynamoModel.MakeConnectionCommand(end.GUID, portEnd, PortType.Input,
+                DynamoModel.MakeConnectionCommand.Mode.End);
+            this.Model.ExecuteCommand(cmdend);
+        }
+      
+        private static void UpdateSystemPathForProcess()
+        {
+            var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+            var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
+            var parentDirectory = Directory.GetParent(assemblyDirectory);
+            var corePath = parentDirectory.FullName;
+
+            // Add the main exec path to the system PATH
+            // This is required to pickup certain dlls.
+            var path =
+                Environment.GetEnvironmentVariable(
+                    "Path",
+                    EnvironmentVariableTarget.Process) + ";" + corePath;
+            Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Process);
+        }
+    }
+
+    
+    public class RevitSystemTestHelper
+    {
         /// <summary>
         /// This function gets all the family instances in the current Revit document
         /// </summary>
         /// <param name="startNewTransaction">whether do the filtering in a new transaction</param>
         /// <returns>the family instances</returns>
-        protected static IList<Element> GetAllFamilyInstances(bool startNewTransaction)
+        public static IList<Element> GetAllFamilyInstances(bool startNewTransaction)
         {
             if (startNewTransaction)
             {
@@ -391,42 +424,6 @@ namespace RevitTestServices
                 fec.WherePasses(ef);
                 return fec.ToElements();
             }
-        }
-
-        #endregion
-
-        protected void MakeConnector(NodeModel start, NodeModel end, int portStart, int portEnd)
-        {
-            var cmdStart = new DynamoModel.MakeConnectionCommand(start.GUID, portStart, PortType.Output,
-                DynamoModel.MakeConnectionCommand.Mode.Begin);
-            this.Model.ExecuteCommand(cmdStart);
-
-            var cmdend = new DynamoModel.MakeConnectionCommand(end.GUID, portEnd, PortType.Input,
-                DynamoModel.MakeConnectionCommand.Mode.End);
-            this.Model.ExecuteCommand(cmdend);
-        }
-
-        protected static IList<Wall> GetAllWalls()
-        {
-            var fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-            fec.OfClass(typeof(Wall));
-            return fec.ToElements().Cast<Wall>().ToList();
-        }
-
-        private static void UpdateSystemPathForProcess()
-        {
-            var assemblyLocation = Assembly.GetExecutingAssembly().Location;
-            var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
-            var parentDirectory = Directory.GetParent(assemblyDirectory);
-            var corePath = parentDirectory.FullName;
-
-            // Add the main exec path to the system PATH
-            // This is required to pickup certain dlls.
-            var path =
-                Environment.GetEnvironmentVariable(
-                    "Path",
-                    EnvironmentVariableTarget.Process) + ";" + corePath;
-            Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Process);
         }
     }
 }

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -391,38 +391,5 @@ namespace RevitTestServices
                     EnvironmentVariableTarget.Process) + ";" + corePath;
             Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Process);
         }
-    }   
-
-    public class RevitSystemTestHelper
-    {
-        /// <summary>
-        /// This function gets all the family instances in the current Revit document
-        /// </summary>
-        /// <param name="startNewTransaction">whether do the filtering in a new transaction</param>
-        /// <returns>the family instances</returns>
-        public static IList<Element> GetAllFamilyInstances(bool startNewTransaction)
-        {
-            if (startNewTransaction)
-            {
-                using (var trans = new Transaction(DocumentManager.Instance.CurrentUIDocument.Document, "FilteringElements"))
-                {
-                    trans.Start();
-
-                    ElementClassFilter ef = new ElementClassFilter(typeof(FamilyInstance));
-                    FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-                    fec.WherePasses(ef);
-
-                    trans.Commit();
-                    return fec.ToElements();
-                }
-            }
-            else
-            {
-                ElementClassFilter ef = new ElementClassFilter(typeof(FamilyInstance));
-                FilteredElementCollector fec = new FilteredElementCollector(DocumentManager.Instance.CurrentUIDocument.Document);
-                fec.WherePasses(ef);
-                return fec.ToElements();
-            }
-        }
     }
 }


### PR DESCRIPTION
### Purpose

Remove GetAllFamilyInstances and GetAllWalls from RevitSystemTestBase class.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 

### FYIs

@mjkkirschner @QilongTang 
