### PR TITLE
Correct spelling mistakes in Select Rule Type Node

### DIFF
--- a/src/Libraries/RevitNodes/Filter/FilterRule.cs
+++ b/src/Libraries/RevitNodes/Filter/FilterRule.cs
@@ -45,7 +45,7 @@ namespace Revit.Filter
             Equals,
             Greater,
             Less,
-            GeaterOrEqual,
+            GreaterOrEqual,
             LessOrEqual,
             NotBeginsWith,
             NotContains,
@@ -94,7 +94,7 @@ namespace Revit.Filter
                 ruletype == RuleType.NotEquals ||
                 ruletype == RuleType.Greater ||
                 ruletype == RuleType.Less ||
-                ruletype == RuleType.GeaterOrEqual ||
+                ruletype == RuleType.GreaterOrEqual ||
                 ruletype == RuleType.LessOrEqual
                 )
             {


### PR DESCRIPTION
### Purpose

https://github.com/DynamoDS/DynamoRevit/issues/2394 There is a misspelled error in Select Rule Type Node.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 

### FYIs

@QilongTang @mjkkirschner @ksobon 
