### PR TITLE
Exit Dynamo when Revit document lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Exit Dynamo when Revit document lost.
+
 ## 0.1.4
 * Add System tests for Sample files.
 * Refactoring some RevitSystemTestBase codes.

--- a/src/DynamoRevit/ViewModel/DynamoRevitViewModel.cs
+++ b/src/DynamoRevit/ViewModel/DynamoRevitViewModel.cs
@@ -81,6 +81,7 @@ namespace Dynamo.Applications.ViewModel
             hsvm.CurrentNotificationLevel = NotificationLevel.Error;
             hsvm.CurrentNotificationMessage = Resources.DocumentLostWarning;
             CloseHomeWorkspaceCommand.Execute(null);
+            ExitCommand.Execute(null);
         }
 
         private void model_RevitContextUnavailable()


### PR DESCRIPTION
### Purpose

Exit Dynamo when Revit document is lost.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 

### FYIs

@QilongTang @mjkkirschner 
