### PR TITLE
add functionality to dynamically preload internal packages

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -913,15 +913,25 @@ namespace Dynamo.Applications
         }
     }
 
+    /// <summary>
+    /// Defines parameters used for loading internal Dynamo Revit packages
+    /// </summary>
     [Serializable()]
-    public class ExtensionInfo
+    public class InternalPackage
     {
+        /// <summary>
+        /// keeps the path to the node file
+        /// </summary>
         public string NodePath { get; set; }
+
+        /// <summary>
+        /// keeps the path to the layoutSpecs.json file
+        /// </summary>
         public string LayoutSpecsPath { get; set; }
     }
     internal static class DynamoRevitInternalNodes
     {
-        private static IEnumerable<string> GetAllExtensionFiles()
+        private static IEnumerable<string> GetAllInternalPackageFiles()
         {
             string currentAssemblyPath = Assembly.GetExecutingAssembly().Location;
             string currentAssemblyDir = Path.GetDirectoryName(currentAssemblyPath);
@@ -934,63 +944,63 @@ namespace Dynamo.Applications
 
             string[] internalNodesFolders = Directory.GetDirectories(internalNodesDir);
 
-            List<string> extensionFiles = new List<string>();
+            List<string> internalPackageFiles = new List<string>();
             foreach (string dir in internalNodesFolders)
             {
-                string extensionFile = Path.Combine(dir, "extension.xml");
-                if (true == File.Exists(extensionFile))
+                string internalPackageFile = Path.Combine(dir, "internalPackage.xml");
+                if (true == File.Exists(internalPackageFile))
                 {
-                    extensionFiles.Add(extensionFile);
+                    internalPackageFiles.Add(internalPackageFile);
                 }
             }
-            return extensionFiles;
+            return internalPackageFiles;
         }
-        private static IEnumerable<ExtensionInfo> ParseExtensionFiles(IEnumerable<string> extensionFiles)
+        private static IEnumerable<InternalPackage> ParseinternalPackageFiles(IEnumerable<string> internalPackageFiles)
         {
-            List<ExtensionInfo> extensionInfos = new List<ExtensionInfo>();
+            List<InternalPackage> internalPackages = new List<InternalPackage>();
 
-            foreach (string extensionFile in extensionFiles)
+            foreach (string internalPackageFile in internalPackageFiles)
             {
                 try
                 {
-                    string extensionFileDir = Path.GetDirectoryName(extensionFile);
-                    using (StreamReader reader = new StreamReader(extensionFile))
+                    string internalPackageDir = Path.GetDirectoryName(internalPackageFile);
+                    using (StreamReader reader = new StreamReader(internalPackageFile))
                     {
-                        XmlSerializer serializer = new XmlSerializer(typeof(ExtensionInfo));
-                        ExtensionInfo extInfo = serializer.Deserialize(reader) as ExtensionInfo;
+                        XmlSerializer serializer = new XmlSerializer(typeof(InternalPackage));
+                        InternalPackage intPackage = serializer.Deserialize(reader) as InternalPackage;
 
                         // convert to absolute path, if needed
-                        if (false == Path.IsPathRooted(extInfo.NodePath))
+                        if (false == Path.IsPathRooted(intPackage.NodePath))
                         {
-                            extInfo.NodePath = Path.Combine(extensionFileDir, extInfo.NodePath);
+                            intPackage.NodePath = Path.Combine(internalPackageDir, intPackage.NodePath);
                         }
 
                         // convert to absolute path, if needed
-                        if (false == Path.IsPathRooted(extInfo.LayoutSpecsPath))
+                        if (false == Path.IsPathRooted(intPackage.LayoutSpecsPath))
                         {
-                            extInfo.LayoutSpecsPath = Path.Combine(extensionFileDir, extInfo.LayoutSpecsPath);
+                            intPackage.LayoutSpecsPath = Path.Combine(internalPackageDir, intPackage.LayoutSpecsPath);
                         }
 
-                        extensionInfos.Add(extInfo);
+                        internalPackages.Add(intPackage);
                     }
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine(string.Format("Exception while trying to parse extension file {0}", extensionFile));
+                    Console.WriteLine(string.Format("Exception while trying to parse internalPackage file {0}", internalPackageFile));
                 }
             }
 
-            return extensionInfos;
+            return internalPackages;
         }
         internal static IEnumerable<string> GetNodesToPreload()
         {
-            IEnumerable<string> extensionFiles = GetAllExtensionFiles();
-            return ParseExtensionFiles(extensionFiles).Select(info => info.NodePath);
+            IEnumerable<string> internalPackageFiles = GetAllInternalPackageFiles();
+            return ParseinternalPackageFiles(internalPackageFiles).Select(pkg => pkg.NodePath);
         }
         internal static IEnumerable<string> GetLayoutSpecsFiles()
         {
-            IEnumerable<string> extensionFiles = GetAllExtensionFiles();
-            return ParseExtensionFiles(extensionFiles).Select(info => info.LayoutSpecsPath);
+            IEnumerable<string> internalPackageFiles = GetAllInternalPackageFiles();
+            return ParseinternalPackageFiles(internalPackageFiles).Select(pkg => pkg.LayoutSpecsPath);
         }
     }
 }

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -926,7 +926,7 @@ namespace Dynamo.Applications
             string currentAssemblyPath = Assembly.GetExecutingAssembly().Location;
             string currentAssemblyDir = Path.GetDirectoryName(currentAssemblyPath);
 
-            string internalNodesDir = Path.Combine(currentAssemblyDir, "packages");
+            string internalNodesDir = Path.Combine(currentAssemblyDir, "nodes");
             if (false == Directory.Exists(internalNodesDir))
             {
                 return new List<string>();

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -931,12 +931,13 @@ namespace Dynamo.Applications
     }
     internal static class DynamoRevitInternalNodes
     {
+        private const string InternalNodesDir = "nodes";
         private static IEnumerable<string> GetAllInternalPackageFiles()
         {
             string currentAssemblyPath = Assembly.GetExecutingAssembly().Location;
             string currentAssemblyDir = Path.GetDirectoryName(currentAssemblyPath);
 
-            string internalNodesDir = Path.Combine(currentAssemblyDir, "nodes");
+            string internalNodesDir = Path.Combine(currentAssemblyDir, InternalNodesDir);
             if (false == Directory.Exists(internalNodesDir))
             {
                 return new List<string>();

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -10,6 +10,8 @@ using System.Text.RegularExpressions;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Threading;
+using System.Xml;
+using System.Xml.Serialization;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
@@ -586,6 +588,26 @@ namespace Dynamo.Applications
 
             //The revitspec should have only one section, add all its child elements to the customization
             var elements = revitspec.sections.First().childElements;
+
+            // Extend it with the layoutSpecs from internal nodes
+            var internalNodesLayouts = DynamoRevitInternalNodes.GetLayoutSpecsFiles();
+            foreach (var layoutSpecsFile in internalNodesLayouts)
+            {
+                try
+                {
+                    LayoutSpecification spec = LayoutSpecification.FromJSONString(File.ReadAllText(layoutSpecsFile));
+                    var revitSection = spec.sections.First();
+                    var revitCategory = revitSection.childElements.First();
+
+                    var revitCategoryToExtend = elements.First(elem => elem.text == "Revit");
+                    revitCategoryToExtend.childElements.AddRange(revitCategory.childElements);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(string.Format("Exception while trying to load {0}", layoutSpecsFile));
+                }
+            }
+
             customization.AddElements(elements); //add all the elements to default section
         }
 
@@ -888,6 +910,81 @@ namespace Dynamo.Applications
             }
 
             return paths;
+        }
+    }
+
+    [Serializable()]
+    public class ExtensionInfo
+    {
+        public string NodePath { get; set; }
+        public string LayoutSpecsPath { get; set; }
+    }
+    public static class DynamoRevitInternalNodes
+    {
+        private static IEnumerable<string> GetAllExtensionFiles()
+        {
+            string currentAssemblyPath = Assembly.GetExecutingAssembly().Location;
+            string currentAssemblyDir = Path.GetDirectoryName(currentAssemblyPath);
+
+            string internalNodesDir = Path.Combine(currentAssemblyDir, "packages");
+            if (false == Directory.Exists(internalNodesDir))
+                return new List<string>();
+
+            string[] internalNodesFolders = Directory.GetDirectories(internalNodesDir);
+
+            List<string> extensionFiles = new List<string>();
+            foreach (string dir in internalNodesFolders)
+            {
+                string extensionFile = Path.Combine(dir, "extension.xml");
+                if (true == File.Exists(extensionFile))
+                {
+                    extensionFiles.Add(extensionFile);
+                }
+            }
+            return extensionFiles;
+        }
+        private static IEnumerable<ExtensionInfo> ParseExtensionFiles(IEnumerable<string> extensionFiles)
+        {
+            List<ExtensionInfo> extensionInfos = new List<ExtensionInfo>();
+
+            foreach (string extensionFile in extensionFiles)
+            {
+                try
+                {
+                    string extensionFileDir = Path.GetDirectoryName(extensionFile);
+                    using (StreamReader reader = new StreamReader(extensionFile))
+                    {
+                        XmlSerializer serializer = new XmlSerializer(typeof(ExtensionInfo));
+                        ExtensionInfo extInfo = serializer.Deserialize(reader) as ExtensionInfo;
+
+                        // convert to absolute path, if needed
+                        if (false == Path.IsPathRooted(extInfo.NodePath))
+                            extInfo.NodePath = Path.Combine(extensionFileDir, extInfo.NodePath);
+
+                        // convert to absolute path, if needed
+                        if (false == Path.IsPathRooted(extInfo.LayoutSpecsPath))
+                            extInfo.LayoutSpecsPath = Path.Combine(extensionFileDir, extInfo.LayoutSpecsPath);
+
+                        extensionInfos.Add(extInfo);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(string.Format("Exception while trying to parse extension file {0}", extensionFile));
+                }
+            }
+
+            return extensionInfos;
+        }
+        public static IEnumerable<string> GetNodesToPreload()
+        {
+            IEnumerable<string> extensionFiles = GetAllExtensionFiles();
+            return ParseExtensionFiles(extensionFiles).Select(info => info.NodePath);
+        }
+        public static IEnumerable<string> GetLayoutSpecsFiles()
+        {
+            IEnumerable<string> extensionFiles = GetAllExtensionFiles();
+            return ParseExtensionFiles(extensionFiles).Select(info => info.LayoutSpecsPath);
         }
     }
 }

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -919,7 +919,7 @@ namespace Dynamo.Applications
         public string NodePath { get; set; }
         public string LayoutSpecsPath { get; set; }
     }
-    public static class DynamoRevitInternalNodes
+    internal static class DynamoRevitInternalNodes
     {
         private static IEnumerable<string> GetAllExtensionFiles()
         {
@@ -928,7 +928,9 @@ namespace Dynamo.Applications
 
             string internalNodesDir = Path.Combine(currentAssemblyDir, "packages");
             if (false == Directory.Exists(internalNodesDir))
+            {
                 return new List<string>();
+            }
 
             string[] internalNodesFolders = Directory.GetDirectories(internalNodesDir);
 
@@ -959,11 +961,15 @@ namespace Dynamo.Applications
 
                         // convert to absolute path, if needed
                         if (false == Path.IsPathRooted(extInfo.NodePath))
+                        {
                             extInfo.NodePath = Path.Combine(extensionFileDir, extInfo.NodePath);
+                        }
 
                         // convert to absolute path, if needed
                         if (false == Path.IsPathRooted(extInfo.LayoutSpecsPath))
+                        {
                             extInfo.LayoutSpecsPath = Path.Combine(extensionFileDir, extInfo.LayoutSpecsPath);
+                        }
 
                         extensionInfos.Add(extInfo);
                     }
@@ -976,12 +982,12 @@ namespace Dynamo.Applications
 
             return extensionInfos;
         }
-        public static IEnumerable<string> GetNodesToPreload()
+        internal static IEnumerable<string> GetNodesToPreload()
         {
             IEnumerable<string> extensionFiles = GetAllExtensionFiles();
             return ParseExtensionFiles(extensionFiles).Select(info => info.NodePath);
         }
-        public static IEnumerable<string> GetLayoutSpecsFiles()
+        internal static IEnumerable<string> GetLayoutSpecsFiles()
         {
             IEnumerable<string> extensionFiles = GetAllExtensionFiles();
             return ParseExtensionFiles(extensionFiles).Select(info => info.LayoutSpecsPath);

--- a/src/DynamoRevit/RevitPathResolver.cs
+++ b/src/DynamoRevit/RevitPathResolver.cs
@@ -55,6 +55,17 @@ namespace Dynamo.Applications
             // Add the Revit_20xx folder for assembly resolution
             additionalResolutionPaths = new List<string> { currentAssemblyDir };
 
+            // Add other internal nodes to preload list
+            var internalNodes = DynamoRevitInternalNodes.GetNodesToPreload();
+            foreach (var assemblyPath in internalNodes)
+            {
+                if (File.Exists(assemblyPath))
+                {
+                    preloadLibraryPaths.Add(assemblyPath);
+                    additionalNodeDirectories.Add(Path.GetDirectoryName(assemblyPath));
+                }
+            }
+
             this.userDataRootFolder = userDataFolder;
             this.commonDataRootFolder = commonDataFolder;
         }


### PR DESCRIPTION
### Purpose

We need to preload Steel Connections for Dynamo package from Revit. This new functionality will load all internal nodes placed in subfolders from [RevitInstallerfolder]\Addins\DynamoForRevit\Revit\packages\. 

Every internal package needs to create an extension.xml file where it will specify the path to the node and the path to the layoutspecs.json file.

Here is a sample of extension.xml:
```xml
<ExtensionInfo>
  <NodePath>.\bin\AdvanceSteelConnAutoNodes.dll</NodePath>
  <LayoutSpecsPath>.\LayoutSpecs.json</LayoutSpecsPath>
</ExtensionInfo>
```

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985
@QilongTang
