### PR TITLE
memory issue in roof

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Roof.cs
+++ b/src/Libraries/RevitNodes/Elements/Roof.cs
@@ -159,8 +159,11 @@ namespace Revit.Elements
             }
 
             var ca = new CurveArray();
-            polycurve.Curves().ForEach(x => ca.Append(x.ToRevitType()));
-
+            polycurve.Curves().ForEach(x => {
+                ca.Append(x.ToRevitType());
+                x.Dispose();
+                });
+            
             var roof = new Roof(ca, level.InternalLevel,roofType.InternalRoofType);
             DocumentManager.Regenerate();
             return roof;
@@ -185,7 +188,10 @@ namespace Revit.Elements
             }
 
             var ca = new CurveArray();
-            outline.Curves().ForEach(x => ca.Append(x.ToRevitType()));
+            outline.Curves().ForEach(x => {
+                ca.Append(x.ToRevitType());
+                x.Dispose();
+                });
 
             var roof = new Roof(ca, plane.InternalReferencePlane, level.InternalLevel, roofType.InternalRoofType, extrusionStart, extrusionEnd);
             DocumentManager.Regenerate();


### PR DESCRIPTION
### Purpose
reported here:
https://forum.dynamobim.com/t/attempted-to-read-or-write-protected-memory-this-is-often-an-indication-that-other-memory-is-corrupt/42518/6

I took a look and the advice for disposal of intermediate geometry was not followed in this node. This should not be required in Dynamo 2.5 - but it's best to dispose all types which implement `IDisposable` when appropriate.

https://github.com/DynamoDS/Dynamo/wiki/Zero-Touch-Plugin-Development#dispose--using-statement

⚠️ This is untested / unbuilt. Need to do that when I am at my dev machine.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ZiyunShang 

### FYIs

@QilongTang 