### PR TITLE
Element.Geometry should provide geometry for FamilySymbols with no instances

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -532,6 +532,19 @@ namespace Revit.Elements
                 }
             }
 
+            // FamilySymbol is a special case: the symbol must be activated before geometry is available, unless an instance is already present in the model
+            else if ((thisElement is FamilySymbol) && (geomElement == null || !geomElement.Any()))
+            {
+                var fs = (FamilySymbol)thisElement;
+                if (!fs.IsActive)
+                {
+                    fs.Activate();
+                    DocumentManager.Regenerate();
+                    geomElement = fs.get_Geometry(goptions0);
+                }
+
+            }
+
             return CollectConcreteGeometry(geomElement, useSymbolGeometry);
         }
 


### PR DESCRIPTION
### Purpose

Element.Geometry node returns no result for FamilySymbol elements if the FamilySymbol is not considered "activated" (generally, when it has no instances in the document.) Graph authors have to implement workarounds with temporary elements to guarantee they can get geometry. 

The [Revit API guidance on this issue](https://www.revitapidocs.com/2015/69706e35-87cc-a6d9-68fe-90a41c1c48db.htm) is fairly straightforward, and Element.Geometry already triggers a document regen, so this is something that likely can be safely handled without the user becoming aware of it. (However, there will likely be performance impacts when activating large numbers of unplaced FamilySymbols.)

Before:
![d4r-familysymbol-before](https://user-images.githubusercontent.com/712405/68435004-5a46f080-0188-11ea-86d9-9c26df9964cf.PNG)

After:
![d4r-familysymbol-after](https://user-images.githubusercontent.com/712405/68435014-60d56800-0188-11ea-9525-85052c5a3455.PNG)

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [X] Snapshot of UI changes, if any.


