### PR TITLE
Remove transient elements in Revit doc when Dynamo shutdown

### DIFF
--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -374,14 +374,14 @@ namespace Dynamo.Applications.ViewModel
    
             // Never access the current document with an invalid keeperId
             // See comment at the beginning of this method.
-            var dbDoc = DocumentManager.Instance.CurrentDBDocument;
+            var dbDoc = DocumentManager.Instance.CurrentUIApplication.ActiveUIDocument.Document;
             if (null == dbDoc)
             {
                 return;
             }
 
             TransactionManager.Instance.EnsureInTransaction(dbDoc);
-            DocumentManager.Instance.CurrentUIDocument.Document.Delete(keeperId);
+            dbDoc.Delete(keeperId);
             TransactionManager.Instance.ForceCloseTransaction();
         }
 


### PR DESCRIPTION
### Purpose

Remove transient elements in Revit doc when Dynamo shutdown.
Jira issue: https://jira.autodesk.com/browse/REVIT-153026 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 

### FYIs

@mjkkirschner @QilongTang 
