### PR TITLE
2496 GetChildElements bug fix

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -780,12 +780,12 @@ namespace Revit.Elements
         private IEnumerable<Element> GetElementChildren(Autodesk.Revit.DB.Element element)
         {
             List<Element> components = new List<Element>();
-            string categoryId = element.Category.Id.ToString();
+            int categoryId = element.Category.Id.IntegerValue;
             if (!Enum.IsDefined(typeof(BuiltInCategory), categoryId))
                 throw new InvalidOperationException(Properties.Resources.NotBuiltInCategory);
-                
+
             BuiltInCategory builtInCategory = (BuiltInCategory)System.Enum.Parse(typeof(BuiltInCategory),
-                                                                                 categoryId);
+                                                                                 categoryId.ToString());
 
 
             // By default we use the GetSubComponentIds() on the elements FamilyInstance, 
@@ -891,8 +891,12 @@ namespace Revit.Elements
         private Element GetParentElementFromElement(Autodesk.Revit.DB.Element element)
         {
             Autodesk.Revit.DB.Element parent;
+            int categoryId = element.Category.Id.IntegerValue;
+            if (!Enum.IsDefined(typeof(BuiltInCategory), categoryId))
+                throw new InvalidOperationException(Properties.Resources.NotBuiltInCategory);
+
             BuiltInCategory builtInCategory = (BuiltInCategory)System.Enum.Parse(typeof(BuiltInCategory),
-                                                                                 element.Category.Id.ToString());
+                                                                                 categoryId.ToString());
 
             // By default we use the SuperComponent on the elements FamilyInstance to get the Parent Element, 
             // for now the node also handles special cases including Stairs, StructuralFramingSystems and Railings 


### PR DESCRIPTION
### Purpose

this PR fix the small bug in `Element.GetChildElements`. The issue was that i was checking if the elements category existed in the `BuiltInCategory` enum with a string instead of int.

closes #2496 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 

### FYIs
