### PR TITLE
revert public constructor to private

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Views/FloorPlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/FloorPlanView.cs
@@ -22,6 +22,14 @@ namespace Revit.Elements.Views
             SafeInit(() => InitFloorPlanView(level));
         }
 
+        /// <summary>
+        /// Create a Revit Floor Plan from Autodesk View Plan
+        /// </summary>
+        private FloorPlanView(Autodesk.Revit.DB.ViewPlan view)
+        {
+            SafeInit(() => InitFloorPlanView(view));
+        }
+
         #endregion
 
         #region Helpers for private constructors
@@ -48,18 +56,6 @@ namespace Revit.Elements.Views
             TransactionManager.Instance.TransactionTaskDone();
 
             ElementBinder.CleanupAndSetElementForTrace(Document, InternalElement);
-        }
-
-        #endregion
-
-        #region Public constructors
-
-        /// <summary>
-        /// Create a Revit Floor Plan from Autodesk View Plan
-        /// </summary>
-        public  FloorPlanView(Autodesk.Revit.DB.ViewPlan view)
-        {
-           SafeInit(() => InitFloorPlanView(view));
         }
 
         #endregion

--- a/test/Libraries/RevitNodesTests/Elements/PathOfTravelTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/PathOfTravelTests.cs
@@ -73,7 +73,7 @@ namespace RevitNodesTests.Elements
          Autodesk.Revit.DB.ViewPlan defaultView = (Autodesk.Revit.DB.ViewPlan) GetDefaultViewPlan();
 
          var longestOfShortestPaths = PathOfTravel.LongestOfShortestExitPaths(
-               new FloorPlanView(defaultView),
+               defaultView.ToDSType(true) as FloorPlanView,
                new Point[] { Point.ByCoordinates(23.349, 2.508, 3.625),
                              Point.ByCoordinates(12.892, 7.285, 3.625) });
 
@@ -94,7 +94,7 @@ namespace RevitNodesTests.Elements
          Autodesk.Revit.DB.ViewPlan defaultView = (Autodesk.Revit.DB.ViewPlan) GetDefaultViewPlan();
 
          var longestOfShortestPaths = PathOfTravel.LongestOfShortestExitPaths(
-               new FloorPlanView(defaultView),
+               defaultView.ToDSType(true) as FloorPlanView,
                new Point[] { Point.ByCoordinates(12.892, -7.285, 3.625),
                              Point.ByCoordinates(33.806, -7.285, 3.625) });
 


### PR DESCRIPTION

### Purpose

Some code change break Systemtest - TestNonBrowsableClasses. Restore the broken test.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@AndyDu1985 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
