### PR TITLE
Add Get Remove Insert and Set waypoints nodes on a PathOfTravel eleme…

### DIFF
--- a/src/DynamoRevitIcons/RevitNodesImages.resx
+++ b/src/DynamoRevitIcons/RevitNodesImages.resx
@@ -10482,118 +10482,121 @@
     </data>
     <data name="Revit.Elements.PathOfTravel.ByFloorPlanPoints.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
         <value>
-        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAABLBJREFUeF7t
-        mz+O3EUUhDdCvgFngMz3wBdxChmnICKAO5A6tgURCSSwFgcwGSA5AjTupusnfXr07quZNe5m/Er6ZHk9
-        VVtTz/tvpL0plUqlUqlUKlG3t7en4u2hWX3NQorL0ay+ZiHF5WhWXzQ33ezEzt0Ie2pWXzTH4NXs3I2w
-        p2b1RXMMXs3O3Qh7alZfNMfg1ezcjbCnZvVFcwxezc7dCHtqVl80x+DV7NyNsKdm9UVzDF7Nzt0Ie2pW
-        XzTH4NXs3I2wp2b1RXMMXs3O3Qh7alZfNMfg1ezcjbCnZvVFcwxezc7dCHtqVl80x+DV7NyNsKdm9UVz
-        DF7Nzt0Ie2pWXzTH4NXs3I2wp2b1RXMMXs3O3Qh7alZfNMfgGZ9+e3rUeNp43njdOOnP/vf+9kcz3yWc
-        220V7KlZfdEcgyNt3MeNl40++l30f38885/LOd1Wwp6a1RfNMZj0URu/aeSM/rgHH8Htthr21Ky+aI7B
-        B23M/mkn+58f6Y9/0Kcjp9sOsKdm9UVzDD5oQ/bP7bORM57O8lycbjvAnprVF80x+KAN2b/AzgbOeD7L
-        c3G67QB7alZfNMfggzbk8d3Oubye5bk43XaAPTWrL5pj8MFkWBvmnIvTbQfYU7P6ojkGH7Qh6yPgHthT
-        s/qiOQYftCHra8A9sKdm9UVzDD5oQ9Z3QffAnprVF80x+KANWT8H3AN7alZfNMdg0sasn4TvgD01qy+a
-        Y3Ckj9rIPhL6v9drQa5ojsEz2rj1amiAPTWrL5pj8Gp27kbYU7P6ojkGr2bnboQ9NasvmmPwanbuRthT
-        s/qiOQZn6PP/P/Dtb4uHdHuXsKdm9UVzDM6oAwzYU7P6ojkGZ9QBBuypWX3RHIMz6gAD9tSsvmiOwRl1
-        gAF7alZfNMfgjDrAgD01qy+aY3BGHWDAnprVF80xOKMOMGBPzeqL5hicUQcYsKdm9UVzDM6oAwzYU7P6
-        ojkGZ9QBBuypWX3RHIMz6gAD9tSsvmiOwRl1gAF7alZfNMfgjDrAgD01qy+aY3BGHWDAnprVF80xOKMO
-        MGBPzeqL5hicUQcYsKdm9UVzDM6oAwzYU7P6ojkGZ9QBBuypWX3RHIMz6gAD9tSsvmiOwRl1gAF7alZf
-        NMfgjDrAgD01qy+aY3BGHWDAnprVF80xOKMOMGBPzeqL5hicUQcYsKdm9UVzDM6oAwzYU7P6ojkGZ9QB
-        BuypWX3RHIMz/usDrKY9rxeN9HcduKFm9UVzDM54Dw7Qn9vfja8aH84e0+GGmtUXzTE4QwWv/QAHvzc+
-        a3wQH8cNNasvmmNwBsp1TR/zf4bPD/RfwfqEj+OGmtUXzQx1YDG+/Vrg85vwrPFRfxw31Ky+aOY7d2Ah
-        vv1a4PO7gz8bX/z48y/rD/A+8/l3f52++eHV6afbl3WAlXz5/R91gBWMj4Bf3/1HwLUzGzuw9mvAtRPG
-        jvTvgj7uj+OGmtUXzXznxZ0H6D8HPOHjuKFm9UUzQ4t/HWC/n4SvHQ3fXwv6urHfa0HXTht971dDiwE3
-        1Ky+aI7BhQc31Ky+aI7BhQc31Ky+aC4ejmb1NQspLkez+pqFFJejWUulUqlUKpVKTTc3bwDCKTfEjewO
-        BQAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAABLhJREFUeF7tnEFunFUQhL1CuQFngF3uARfJFnacgjUchHUiuIM5BSyyAmT60f1L
+        ldKzu978ZuY5rpI+RRlPFUV1bI+9mDvLsizLsiwLdX9//2Cej5pV1yzEXE7NqmsWYi6nZtWF5tDdTuzc
+        DcGeNasuNHPwrdm5G4I9a1ZdaObgGd/9+vAmeBe8Dz4GD/Xn+Pt4/M3Mdwmr3W4F9qxZdaGZg5kY923w
+        ezBGf4zx8bcz/yor3W4J9qxZdaGZg5ExavBHjdwxnnf6CGq3W4M9a1ZdaObggxhzfNnp/uUz4/mnvhwp
+        3XYAe9asutDMwQcx5PjaPhu5490sT0XptgPYs2bVhWYOPoghxzfY2cAd72d5Kkq3HcCeNasuNHPwQQx5
+        vNpZ5eMsT0XptgPYs2bVhWYOPpgMK4M5qyjddgB71qy60MzBBzGkPwOeAHvWrLrQzMEHMaS/BzwB9qxZ
+        daGZgw9iSL8KegLsWbPqQjMHH8SQ/jngCbBnzaoLzRyMxJj+SfgRsGfNqgvNHMyMUYPuM2F83L8LUoVm
+        Dp4R4/q3oQT2rFl1oZmDb83O3RDsWbPqQjMH35qduyHYs2bVhWYO7qgvP/+Bjz8XZ7pdE+xZs+pCMwd3
+        +AAJ9qxZdaGZgzt8gAR71qy60MzBHT5Agj1rVl1o5uAOHyDBnjWrLjRzcIcPkGDPmlUXmjm4wwdIsGfN
+        qgvNHNzhAyTYs2bVhWYO7vABEuxZs+pCMwd3+AAJ9qxZdaGZgzt8gAR71qy60MzBHT5Agj1rVl1o5uAO
+        HyDBnjWrLjRzcIcPkGDPmlUXmjm4wwdIsGfNqgvNHNzhAyTYs2bVhWYO7vABEuxZs+pCMwd3+AAJ9qxZ
+        daGZgzt8gAR71qy60MzBHT5Agj1rVl1o5uAOHyDBnjWrLjRzcIcPkGDPmlUXmjm4wwdIsGfNqgvNHNzh
+        AyTYs2bVhWYO7vABEuxZs+pCMwd3+AAJ9qxZdaGZgzt8gAR71qy60MzBHT5Agj1rVl1o5uAOHyDBnjWr
+        LjRzcIcPkGDPmlUXmjm4wwdIsGfNqgvNHNzhAyTYs2bVhWYO7vABEuxZs+pCMwd3+AAJ9qxZdaGZgzt8
+        gAR71qy60MzBHT5Agj1rVl1o5uAOHyDBnjWrLjRzcIcPkGDPmlUXmjm4wwdIsGfNqgvNHNzhAyTcc0ls
+        XsEHSLjnkti8wv99AJX4738ITr9BSGRc9D4YvOGS2LxCFdzhAKPDP8FPwZez53SE7+J3guENl8TmFbAc
+        Pn5tsEfwZ/B98MXsuTPiuafeC4k3XBKbV8Bi+Pi1wR7A+Nf6zez5SDzn9LuB8YZLYvMKWAofvzbYY8Iv
+        wVcz3yA+dvr98HjDJbF5BSyEj18b7PEIfwU/PuI9/Y6QvOGS2LzCpNTW/PDb3+PPTw4Rfz/9nqi84ZLY
+        vMKk1IvhOf4fjgzecElsXmFWamc+u8+AXZiMw3ye3wN2YTIOMl4FfT3zDeJjL/dV0C5MxhmM1+rfzp6P
+        xHNe7s8Bu0DjvJ6fhHehhhm/C/o5eD2/C9qFGOV1/jbUJLzhkths1uENl8Rmsw5uWLPqQrM5T82qaxZi
+        Lqdm1TULMZdTs1qWZVmWZVmhu7t/AU8ChBKGCkr+AAAAAElFTkSuQmCC
 </value>
     </data>
     <data name="Revit.Elements.PathOfTravel.ByFloorPlanPoints.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
         <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAALBJREFUWEft
-        kjEOgzAMRXMFzgE3YujMzEmYOFG3DmxVOAMTFwjfVaxalSpChMmALT0hxyL/yYqz4vLehyuJsd+iQ5Q7
-        Qs4/hAmYwK5A/wwNmECI35pnEk0BDmcmnkk0BWT4B55JNAWKb6CmUA6nnmcSNYFU1AVoA7L/xQRMwARM
-        oLhAKrinBQOoqC8h8KC7wAK6t5/TBTQYX2uawFkgNG8DZ4HQvDegxV+BK4mxty/nNpmUck+XLe0+AAAA
-        AElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAALhJREFUWEftlsENgzAMRbMCc9CNOPTccyfpUL1zzQ7skH5X+aqFEpGgGg7Y0hPC
+        JvlPEYcEL1aMMR1Jjv2VNFGhhz1rhE2B5zvdwAxSfo6caSwFGE5mzjSWAjr8C2caS4HTT2CUUIbLO2ca
+        M4FWzAXkBPT7GhdwARdwARdwgdMFCL6bwAsMq37xamchcM8hC3iofvFi0yWwl9p66TcLtIKNbU6gFWxc
+        +weKV7u/C/RSFTiSHHv5CuED8a5ypm2Fz1AAAAAASUVORK5CYII=
 </value>
     </data>
     <data name="Revit.Elements.PathOfTravel.LongestOfShortestExitPaths.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
         <value>
         iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAABA9JREFUeF7tnM1tVEEQhPeEyIAY4EYeEA3ciIIzBMIdQQ5LFpwBwQzulcvFvLfV
-        8+bPS3/SJ4Ttbmq6hAAfOAVBEARBEATI+Xz+HbbTzqpTWhLWa2fVKS0J67Wz6uBw4rSSK2dDMaedVQeH
-        efFsV86GYk47qw4O49I3X/JPH/5Co93KtrJuSo/Mx794+dgMS9keizKlR2IBM0soZVtdN1uPjALqdbH1
-        SCxgVglb2VbWzd4jo4A6Xew9EguYUcJetpV1ce2RUYBPN9ceiQWMLuFatlV1oTwyCtB1ozwSCxhZgpJt
-        Nd2oj4wCNN2oj8QCRpWgZltJN55HKgWkzz0tfbxGT7ZVdON5JBawV0IrPdlW0Y36yHTwl/ZjFEBiTjur
-        Dg7z4pJYQO8SvNlmiTntrDo4zIu3jAIeijntrDo4zIu3xAJ6llCTbYaY086qg8O8eM8o4F7MaWfVwWFe
-        vCcW0KuE2myjxZx2Vh0c5sXXjALuxJx2Vh0c5sWKPUs4mm2UmNPOqoPDvFgxCphcQLZXCS2yjRBz2ll1
-        cJgXq0YB9zntrDo4zIs99iihVbbeYk47qw4O82KPUcCddlYdHObFXluX0DJbTzGnnVUHh3mx1yhgcgHZ
-        liW0ztZLzGln1cFhXlxjFOAEh3lxra1K6JGth5jTzqqDw7y41ijAAQ7z4iO2KKFXttZiTjurDg7z4iNG
-        ASI4zIuPerSEntlaijntrDo4zIuPGgUI4DAvbuGREnpnayXmtLPq4DAvbmEUcAUc5sWtrC1hRLYWYk47
-        qw4O8+JWYgGeEkZkayHmtLPq4DAvbmkUsAEO8+KWYgFqCaOyHRVz2ll1cJgXtzYKKIDDvLi1WIBSwshs
-        R8ScdlYdHObFPYwCCBzmxT3EAq6VMDpbrZjTzqqDw7y4l1EAgMO8uJdYwF4JM7LViDntrDo4zIt7GgUY
-        OMyLe4oFbJUwK5tXzGln1cFhXtzbKCCBw7y4t1hAqYSZ2TxiTjurDg7z4hFGATDMi0eIBXAJs7OpYk47
-        qw4O8+JRPvYCUDcrPBILwBJWyObVzSqPLBUw25Tlc/Lvf9Gg6mbFArL4uVlall/JD8lnpa9h3axSQNYe
-        vFoBF78n3yaflL6WlVm1gCx+boacx/yWfFX6+osuViogi4/Fj88QsxT8lHxemnOxcgFZ/NxoOUvBH8n3
-        POditQKy9Mjlfff1Z4p9l91NFNDOnN3NigVkSw9c1Zv7HbCKpWOT//wZ4CYK2JaOzea/Bb3gGTdRwLZ0
-        8Iv53wGvS19/0UUUsC0d/vb/Jbyadvj8vaCPSel7QVkXUcC26ej/z3dDb0U3UcBx8YZ2Vh0c5sWhJt7Q
-        zqqDw+Fx7aw6pSVhvXZWndKSsF47axAEQRAEQZA4nf4AHvYjYXlCWgEAAAAASUVORK5CYII=
+        wwAADsMBx2+oZAAABM1JREFUeF7tnEFy1EAMRbOicgPOADvuARfJFnacgjUchDUU3CGcAhasgAKJyOSP
+        Rm2r291qM9GvepWK3ZJ/6zOZGVfhq1QqlUqlUqkU6vb29nfSDxmrX1aTpB0Zq19Wk6QdGatfWEy6OhJH
+        9oagTxmrX1isG8/myN4Q9Clj9QuLsenLT/zr6YWiKXk7MtWyNsnDX1iOzcDy9r/glrVJDGBmCJa3o0Bz
+        uSZuiA/Ed56T/OTf+fi1jHhdpU1KwwzAgGbyjPiCMzLg889kzGWVNqmanZyLouRtJjxU4ivOZgVetx7C
+        2iaxGR6PYs3bDGgO/Gdn61++hteX/xytbVI1Yp2cH82atxnQDPhv+8lMnNzIuM+1tUlshMcj2PIWDc2A
+        32BxsF4+yLjPtbVJ3QzPjWbLWzS0/+XTTi3fZdzn8mwSm+Hx0Xi8RYJzqEXGfS7PJnUzPDcSj7dIaO9z
+        XgEMNsTjI/F6i4L2Hv8esKCb4rlReL1FQfuO/xSEYFM8jtC5a+t4CzXeIuC9EXHfAzSqMctc14sab1HQ
+        vuO+CSPcSH7+u8BybhReb9HwLIitVwKfb78XVEJdhGWu60Gtt0ho72Pvhq4hF3vQAWzhVssmMYCRIbR4
+        OwputW4yA7jH8umWVewBAxgVQqu3aCyfblnFXjKAO9CnjNUvLNaNPYwMYa+3KNCnjNUvLNaNPWQAkwNg
+        RoXQw1sE6FPG6hcW68ZeMoB7nzJWv7BYN65hRAi9vI0GfcpY/cJi3biGDOAOGatfWKwb19I7hJ7eRoI+
+        Zax+YbFuXEsGMDkApmcIvb2NAn3KWP3CYt24hQygUlisG7fSK4QR3kaAPmWsfmGxbtxKBlAhLNaN99Aj
+        hFHeeoM+Zax+YbFuvIcMwCks1o33sjeEkd56gj5lrH5hsW68lwzAISzWjXuwJ4TR3nqBPmWsfmGxbtyD
+        DGBDWKwb96I1hAhvPUCfMla/sFg37gUGUBNChLceoE8Zq19YrBv3JAMoCIt1455gAN4QorztBX3KWP3C
+        Yt24NxmAISzWjXuDAXhCiPS2B/QpY/ULi3XjEWQASlisG48AA9gKIdpbK+hTxuoXFuvGo8gAQFisG48C
+        A1gLYYa3FtCnjNUvLNaNR5IBiLBYNx4JBlAKYZa3WtCnjNUvLNaNR5MBkLBYNx4NBmCFMNNbDehTxuoX
+        FuvGEVxaAHjcpVJxFBiADmG2t724dIRNXmoASFFH2CQGgCEcwVsJ8rn5H7VxfVFH2aRs4CSAUdA1PhJ/
+        H73QAtcSrkcVLDVFHTEABs/1Rq7xi3hLPLbWlKD11Q/r4LqijhIAg+bxeG/wOsQ34hXxyFqL0Jq5j6sZ
+        jTLOMtftRV9H4EE9t9Yv0Pm5D2yKAI3j8Z7gNQzeE08KdfMeWRaFNo/neqGvYfCDeGPUzXtoXyTGBqbw
+        +vNP/vkvCH2+Bhn3uTIAH+LrYbwCGGMT4RivgMt/D4jAGJCm9B5w+Z+CIjAGhPCnoKeFusv+HhCFGhAO
+        6oW1HqE1l/tNOAo1JPc34QVae3n3giKRAfG9oHdE1b2gBaq7rLuhkdBwdt0NbaGohxjADIrKAPaDM5Sx
+        +oXFunHiA2coY/ULi5P9yFj9spok7chY/bKaJO3IWFOpVCqVSqVSpKurPyIdb9aJNcMlAAAAAElFTkSu
+        QmCC
 </value>
     </data>
     <data name="Revit.Elements.PathOfTravel.LongestOfShortestExitPaths.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
         <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAZhJREFUWEftlqFOxEAQhisQSEgQSAQSgUAikMgTOAQIBKg72gocvAFB8QhIHqGi
-        7RGCQJIGiUDAM+zw/9DNbbZb0jbdNTDJl97O3u78mZ2dbPRv2qqqkpDUYRdGJyy6zGSJ3y7oNX1pFYDg
-        y0mhJM5kzbXQZqgA0jC9WVwqSUq5Mv/chhcBCC5xod6YDXOBCy8CCI7hHpzqcRveBMwKtQMBr3rchjcB
-        BLWQxaVMTJ+NZwEySUqVmz6boQK4rg67MNdmOIaXOJdd26/xLgC34YQFafs13gXwKkLE+/lcbdpzxLsA
-        glq4QEHeuuaCCJhmsoJi/EgfZd2eCyKA4BiuXe05mIDpg2wwC3Z7DiaAIAt36VzNTF9QAWkh22zP5nsh
-        qADC9oyjONDj4ALQD/Yh4EmPgwsgyMJzkssefw8VQBrWWUAhx7+1Zxe4wofgBqxqX8O6CmARsj3jKLZc
-        8y4Q+AjwqfcJzuhrWJ90/mz2/XYcBPdoWB8BbM/8dnk3EgQdNwOka3CCoOPVwBgwVh12YXSGpA775y2K
-        vgADJ1YhIB2MPAAAAABJRU5ErkJggg==
+        wwAADsMBx2+oZAAAAc1JREFUWEftlq9Sw0AQxiMQSJhBIBG4IhBIBBJZgUOAQIBqSSpw8AYMikdA8ggR
+        TcowCOqYDhKBgGe45dvO7eRyvSTXlJ6BnflNepvcft/cv170HxKTyYRComWL4CQiuk5phZ8+SJ95qTQA
+        8dUkUxSntOHqaNPWADMTUizOFSU53ZgfVzGvAdTdAWPAGvzsaPnCAL+MM/XBo2F2dtHCgIgLYy1fGJh+
+        mKlHcC7tKloYMMWnaPmygX6m9mDgXdpVLG0EGKyFNM6pa+ZsWhjosKiIc1vLuwxQN8nV0MzZzGvAphSu
+        YpiGt3hI+3ZeaGtA+pXCVQy74YwXpJ0Xlm6AtyJMfF6O1Lb9jlnEgJYtoqoY1sIVFuS9610QA72U1rAY
+        vwbPtGm/C2KAwTTcYsvMHM/BDPSeaItHwT6eFzHAz1I0FcMoPAxGqm/mghoYZLTLx7N5XwhqgOHjGVNx
+        JO3gBnAeHMLAi7TbGhBK4VsMo/CaDOmAf9f1wa45Bndg3cg1X0iaiDM6rTueBRQ/0ULf4ELn/P+Oq+BF
+        aBXxgvu68lre34AvKL6cEWD4eOZn3b0RxV1rwP9C0kSduA8z8dtTUAdradkiOBkSLfvnI4p+ADnpqhpB
+        rlllAAAAAElFTkSuQmCC
 </value>
     </data>
     <data name="Revit.Elements.PathOfTravel.Update.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
         <value>
-        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAABj1JREFUeF7t
-        mz+MFVUUxpdCA4FEpNAgwUCpDVlqkEBCJERjD50lnWGptIfCxspCzGpBYmxQKyiICUZJiDFio0uIhZUW
-        RkHWf4DP73vM3dx398zMnTln35t39xS/sMzce+453/fevPPm3VkYjUabntdXzu8Ar4G3wefgJ/AvGFXw
-        bx7jOY7h2B1SrK6IBzcLEPEo+Bj8BYLYufwNOPeYFDsX8WDpQLQj4AaQhO0DYx2R1mpDPFgqEGkn+LAS
-        bSNYBjultQnObQcfgX3h2LpBpYKiF8GPQBLOEq5xQFh/P7hVjTkZjk8MKhUUfAKsVsVPgz/A0Wj94+DX
-        6hxZCucmEi0RFEvx/4mKr+MhuAqWwEtgD+Ali/Dvw+As4JgHQIoRQ8OPgXOAseNzyyG/dQmXBAo9AO5H
-        hUvw1XoePCfFkMDY3dUczpViBuqMuhlirQteCiiSr9y2a/6nIFv4FM4Fn1SxukDjtjCGGLgEUCA7Eql4
-        8gjwUjMWQUsVizGlteoYd0JiwHkHxR0C/0XFxlCoU9I8DYh5Olojh3EnJAabd1Bc05estQ7ECsQM/b20
-        Xh3jPBZWVlZGBXAxEoPdilQw+QyYXHYCiBf3910Yd0KlGLB2PwaFXUoKDbAb2hPGWYB4aX/fhXEnVIIB
-        98ATlSDbwJ9RkTEXYvG0IJ7U33dh3AlNGJAuMmu65oaCdgH253dAXCyF2ivN6QviHQTSWl3YV5QBMSgu
-        FuiaNMaKZC1J6DpOFmtADArdJR3fCLBWFzOWNoUBswICt5mx7AZMCYgtmXHTDZgBED6Y8e3cG4AivqmK
-        OSidHzolGBDfduDbe67MKMGA9yvxU+bCjBIMeKMSvImpm4G1slrfEgx4GUii1zEVMxD/Ws5aJRjwPJCE
-        zmFDzEC8vSC9T8S1LoCJd8bcG0BQ1N2qyD5QqHNS3L4gHoWW1uKNwm3x2FIM6LvLjbeSj0sx+4J43EFR
-        txHgUjq+FAPqOqEm+CPKfileXxBvC+CPPtJ65HA6p7MBZ78cbQVnwHWwCkbVv/w/j2+V5vUhNzcUltMJ
-        xfDnw+1SLA2IyR/npfXIDWlOJwMg7iK4DSh6HTy/KM3vSm5uKK5rJ3RaiqMBMU+Bup0R3CBwSJqXXSRF
-        Bb9XIrfBcWoTcnNDcV07ofG2FClWVxCHl522bSlrO+FSsoqEmLzstL3yUzhedTnKyS2AIvt0QtxUpd2Y
-        xc1dUuwAN4fV7pjONYDXdknkNs5I8XLJyS2AIus6obZ9nGFr4m4prgTGUnjOaduayG5o3U7pmFwD+AEr
-        CdzGdSleLjm5BVBo2gmN+3vADbI5O6NpFDfecgNuvDn3qepvHuOlhmNyfoznhuATUq4xuQaEbqcrq1K8
-        XHJyC6DYuBOa6O/xNx9Fanu1WkLDW8UnuQZI4mYRx+lKTm4BFBw6IbG/xzHulJ7WAxrZDUhJ7wB2Qo39
-        Pc7xktK0aVfLB6D2A1ci14DBfwZ0ASIN5yG9nCIh5OC7oD5AtPCYKh85lYRtgo+2cu7ao0h9yDVg8N8D
-        NEBEkwe1kecz6bE2souEmIP9JjxrkN/T4C3wm3S+iU5FUlTQ9k7g+aneC5o1yO9+3zw7FwlxB3c3dNZo
-        8hx0kUPOLUaTpxtggCZPN8AATZ6qydX1f0x83ApNbtNEk6cbYIAmTzfAAE2eboABmjzdAAM0eboBBmjy
-        dAMM0OTpBhigydMNMECTpxtggCZPN8AATZ5ugAGaPN0AAzR5ugEGaPJ0AwzQ5OkGGKDJ0w0wQJOnG2CA
-        Jk83wABNnm6AAZo83QADNHm6AQZo8nQDDNDk6QYYoMnTDTBAk6cbYIAmTzfAAE2egzZg1qCuL0Drsw4a
-        Dd2ABqraHoH3wLPSGKLR0A1oIK4P3AVL4Ml0nEZDN6CBuL4IPoL1SjxOo6Eb0EBcn8AV8ALHaTR0AxqI
-        66vhAXjnux/uzN6AzcybXz0cXb718+j7lduQRdaqDjfAkHe/vgdZZK3qcAMMePwO+GX674DSkcROmO1n
-        QOkkYqewC3qR4zQaugENJIIH+D3g1XicRkM3oIFE+OF9Ey6dSnjeC7oIhncvqHQg+rDvhjqP0WjoBhig
-        0dANMECj4cRkR08qcBtugDGpwG24AcakAjczWvgfVcuhJ2mDEaUAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAABZpJREFUeF7tm7uLVVcUxsciAVGIsUgwomipjWitEQWJSEJ67fwPxLFKei1srFLE
+        MEkhhDSJVqYQC0kECRLT6BWxsDJFCD7yVHPyfcezh333rPNca+5jzyp+cDlnn7XX+r65d9Y9d52FoijW
+        PCdHZzeCj8F5cB08Av+CooKveYznuIZrN0qx+iIeXCtAxEPgG/AXCGJ35W/Aaw9LsbsiHswdiHYQ3ASS
+        sENgrIPSXm2IB3MFIm0CX1WirQZLYJO0N8G5DeBrsCMcW7EoV1D0XvAQSMJZwj32CPvvBHeqNcfC8bFF
+        uYKCj4I/quInwTNwKNr/CPitOkcWw7mxRHMExVL8f6Li63gJvgeL4H2wFfAji/D1AXAacM0LIMWIoeGH
+        wRnA2PG5pZDfioRzAoXuAc+jwiX413oWvCfFkMDaLdU1vFaKGagz6laItSJ4LqBI/uW2feZfBp2FT+G1
+        4LsqVh9o3DrGEAPnAApkRyIVT14BftSUImipYjGmtFcdZSckBpx3UNx+8F9UbAyFOi5dpwExT0R7dKHs
+        hMRg8w6Ka/qStdyBWIGYob+X9qujzGNhNBoVGXAxEoPdilQwuQJMPnYCiBf3930oO6FcDFi+H4PCLiWF
+        BtgNbQ3rLEC8tL/vQ9kJ5WDAU/BGJch68GdUZMy5WDwtiCf1930oO6ExA9JNpk3f3FDQZsD+/AGIi6VQ
+        26RrhoJ4+4C0Vx92ZGVADIqLBbomrbEi2UsSuo5j2RoQg0I3S8dXA+zVx4xFVZGnfyiKQHzcCk1uswAE
+        bjNjyQ2YEBBbMuOWGzAFIHww4+e5NwBF3K6K2Sedn3VyMCC+7cC391yZkYMBX1Tip8yFGTkYcKoSvImJ
+        m4G9OrW+ORjwAZBEr2MiZiD+tS575WDAdiAJ3YVVMQPxtoH0PhH3OgfG3hlzbwBBUU+qIodAoc5IcYeC
+        eBRa2os3CtfHa3MxYOiUG28lH5FiDgXxOEFRNwhwKV2fiwF1nVAT/BFlpxRvKIi3DvBHH2k/ciC9JhcD
+        unRCMfz5cIMUSwNi8sd5aT9yU7omFwP6dkInpDgaEPM4qJuM4IDAfum6XAzo2wmVYylSrL4gDj922sZS
+        lifhUrIwgKDIIZ0Qh6q0g1kc7pJiBzgcVjsxnZMBdZ1Q2xxnGE3cIsWVwFoKz2vaRhPZDa2YlI7JyYC0
+        Eyr7e8AB2S6T0TSKg7ccwI2Hc9+qXvMYP2q4psuP8RwIPirlGpOTAXEnNNbf4zUfRWr7a7WEhreKT3Iy
+        IHRCYn+PY5yUntQDGnvT/evIyQB2Qo39Pc7xI6VpaFfLl6D2H65ENgb0ASLNzkN6miLn1YAARAuPqfKR
+        U0nYJvhoK69dfhRpCGvagABENHlQG3m+kx5rww0wAPm9DT4Fv0vnm3ADDEB+z4fm6QYYoMnTDTBAk6cb
+        YIAmTzfAAE2eboABmjzdAAM0eboBBmjydAMM0OTpBhigydMNMECTpxtggCZPN8AATZ5ugAGaPN0AAzR5
+        ugEGaPJ0AwzQ5OkGGKDJ0w0wQJOnG2CAJk83wABNnm6AAZo83QADNHm6AQZo8nQDDNDk6QYYoMnTDTBA
+        k6cbYIAmTzfAAE2eboABmjzdAAM0eboBBmjynGkDpg3qugFan3jUaOgGNFDV9gp8Dt6V1hCNhm5AA3F9
+        4AlYBG+m6zQaugENxPVF3Acfxus0GroBDcT1CVwFu7hOo6Eb0EBcXw0vwIVf7j2YvgFrmU9+fFl8e+dx
+        cXd0H7LIWtXhBhjy2U9PIYusVR1ugAGv3wG/Tv4dkDuS2AnT/R+QO4nYKeyCdnOdRkM3oIFE8AC/B3wU
+        r9No6AY0kAg/e9+Ec6cSnveCLoLZuxeUOxB9tu+GOq/RaOgGGKDR0A0wQKPh2MWOnlTgNtwAY1KB23AD
+        jEkFbqZY+B//Fp7c7rn8pwAAAABJRU5ErkJggg==
 </value>
     </data>
     <data name="Revit.Elements.PathOfTravel.Update.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
         <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAahJREFUWEft
-        lTFLw1AUhdvZSXAWKTjVLp27C/4FB8GpgovU/gCnbkJB6CRuxf/gLIKIdJOITq5OLi7C85zwDrxck7RN
-        Urtk+Ejevfede/JIbhrOuUo5jkYtcAXegfPwnrGWrU8syoIGffAN1NjCHGs2wC3YSRUqghdWozuwD7Y8
-        vGdM+Q9/PUgVWxYI8dj15BegmVE39TXivBFFkSvJAEJjL8inzGo+BD++TtzEBmzxPOweCHXACPTCeAhy
-        XV/zBmTgsRIDy4LGMjMrbQAiz16sq9gyVGHgAehIeby5ZpDr+ZoO11UYuAYyQPiiDZUPQbwJ9DmOGUuI
-        De7dHpgB569t5UKMgTMvKKbKhSDO5vxEWcNPNp6K1oCai5lyIcYAhwxFNVzIvEHU135rIGweo1yIMbAN
-        OFY5XhcaxdpLSp+ABQ0yf0an0eWurbcG2myq5lwrF5JnIA/se7WxQmIlDOCSjKUGeQLh2lIbqA3UBmoD
-        azewKNA5BGOwyfU6DBxRC3yCk5f4V5CsyTSwCiZPX396pRqoCjQtdgJVgabF3oFVkWngP0kacI1fXFXn
-        oVwy8sQAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAYRJREFUWEftlT9LA0EQxS+1lWAtErBMkzq94FewEFJFsJGYD2CVTjgQrMQu+B2s
+        gyAidrKila2VjY2wvnfMwO56mz93m4hwxY+7nZl98265m8ustUnpm3EbXIA3YAXeM9YO671FXdBgAL6A
+        Ng5hjjUb4AbslApVQYS10S3YA1sC7xnT/Ltc90vFlgVCPHZ98jPQitRNpEY5zYwxtiZDCOUiyKeMNR+B
+        b6lTrgsDYfE8wj0Q6oAx6LlxF+S6UvMK1MB9qYHhlCE/5lLFtAsaq5mn2gYg8ihiXY0tQwoDd0CPlMc7
+        0wxyPanpcJ3CwBVQA4Qv2kjzLoi3gH6OOWMpDJyIoDLRnAvibM5PlDX8ZIupmMIAhwxFdbiQeYNooPtT
+        GNgGHKscrwuNYt1LahsIQYPoz+jYnO+G9ckNzAL7XsLYug3g4scaA42BxkBj4H8aWBToHIAcbHL9FwYO
+        qQU+wNFz8Svwa6IGVsHlw+evXqUGUoGm1U4gFWha7R1YFVED68Q3YLMfhLrpEfxaG+cAAAAASUVORK5C
+        YII=
 </value>
     </data>
     <data name="Revit.Elements.ReferencePlane.ByLine.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -13916,4 +13919,157 @@
         a0r6GhwVvS7crDUlfQ2WW/7fG4hgDVlp2vKwhqw0bUVRHGjtCQDaZXJm6udtAAAAAElFTkSuQmCC
 </value>
     </data>
+  <data name="Revit.Elements.PathOfTravel.GetWayPoints.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAABRZJREFUeF7t2LFvHGUQBfAUKBUlEk1qJOj4C2goQaKhuKO0S7qkQEokQhshxcZ3
+        lyJIaVJTIQWloUBJkyhJkSLO2aKlRZSAlu/tZJ1v997cPt+H13e+KX6K/G7nPDsT7+7dpaqqwjmiYRgO
+        DcNqdg8OPtidTmc7s9mj9O8fu7NZ1diZTo9S9nDnzp2v85rWG4TVpQH/lA98qen0BZaFOvpm4fTooJeo
+        /yLSEuibhdNjQ+6TlnCfvhkcHh5WYbl8Xq3BzmZ/4TJTX5Zwuclea0n3idbQc+wXhrZ8Xs1A09Bv5Xn9
+        2mQyqpfSXUDSOjDHfmFoy+eVhv+wubEy3k2aHgzeL1oH69ybB9f7WMA5Sgs46g4fnxfowVByklcfVVUj
+        z/8vJb2dh3R5mnWHXy8gfSijBVBykrGAt9zhp3sCXqdFUHKSsQBT35jJ8JE3xywUNUpOMhbgP/XgZpwf
+        1yrKlZzkti8A13Zn+AufEVo/5EpOcusXwP73p3sBO3YhaJSc5LYvIA279fUDPgWz44CGUHKSsYDO9z/p
+        Z3Yc0BBKTnLbF0AvQc7XFAtBo+Qkt30Bp0FDKDnJWICOhlByktu+AFxucBk6+Qoa94TJZMSOXQgaJSe5
+        9Qsgn4DrZZD7QOuHXMlJbv0COsM/QT4LtH7IlZxkLIAMH2IBw2CPoXEJGlDchDcIDaHkJGMBOhpCyUnG
+        AnQ0hJKTjAUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLs
+        iQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8a
+        glLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUY
+        pU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLs
+        iQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8a
+        glLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLsiQUYpU8aglLM7L/+6sqNp0+q757/XN14+qz6/tXo
+        PXZciVV7G5rSJw1BKc79cDz+dH8+/n3/aFwtGs33jsefsbqLTJkhDUEphm9//eSdvfnoNh/8goPJyy/f
+        Ze+zrt5cSv9N7ibvs2M8ygxpCEoxnGL4tXT8PfY+6+rNAhp/JteSy+zYLmWGNASluL7skCH32aTLUTb8
+        3Ouk9xyUGdIQlGL/mt9nNGfvt446g+/6JfmQ1YEyQxpCXzGedvhwNWfxdHQWOgNn/k72WW3fDIGG0Fd8
+        ez76gg1WhUfUzolstOuP/8G/rUX0zRBoCH3Fe8ejb9hgVTefP1g4iYuimVHfDIGG0FccfwFtg/8FxD3g
+        xPncAyCeguqnoI9YHSgzpCEoxXie5wNe7oJ8DvicHZ9TZkhDUIohDfSgO+Bl4pNwGw1BKQZ8t4OhsmF3
+        4bgN/i7ox2T9vgtq1JejC/htaBr6b8nH7LU+ygxpCEoxg6ej+hF1Pr6GoW/K085ZUGZIQ1CKw3LKDGkI
+        SnFYTpkhDSEvDuW6823QENibhNV159ugIbA3CavrzrdBwzAcGobh0DAMh4ZhODQMw6FhGEp16T8DCnml
+        KMZI9QAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="Revit.Elements.PathOfTravel.GetWayPoints.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAARtJREFUWEftlDEOgjAUhrmCN3LwFHRwgMXEgcQLOLsYTAoHwDuYuDvrStTdwTvU
+        99DXFCgIGNrBDl9o/we8j7bBE0JYRRuORcj5MUwSQQRpupTFPM/FmGCPgPM99QOZB1ISoHFXhjxDFAKw
+        CjIwKQDNL8UWwIrIUPey1QmjcqYyRACbUnOcy4JpAZrLgimBKnJgegXgusG5LJgSoH+BNYEqcmBSQH1O
+        GxJOwAk4ASfw3wLbK5uuzwexu/szNVcZTSC++RkgFDKq9QFWkAExMFHzVgH88krzAszp3q5A4zluI/AE
+        FpS3CsQ3FukEcDs+L/sJtRdSE8A91wm0nYUmoGH/FUCgob0zQLzPAouGfPk3GgVMUhOwhTY0h/Be9wQZ
+        viHYh90AAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="Revit.Elements.PathOfTravel.InsertWayPoint.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAABExJREFUeF7t3LGO1AYUBVAKlIoSKU1+ADq+gCZlIqWh8PAZUCCBlKSPxExANCDx
+        E0jQUSBoQCBFKbKYVfILqZPI8Z2Hkddz3/hiezyzyy2OIl3mzb55V7uYLXKuqirbIxrafGhomtVxcX31
+        YVG1LcvFA/baDA1N4wL2zAXs2U4LODo6qr5U3VtkXMCOdG+RcQE70r1FZrYCun+2b4eymwvY824HW8CN
+        l1XVaOdTGbObCofsHncq7ZI2vnBjzId0Adu5AIEL2GLMbioXsMWY3VSrsri9/LB4uVVZ/LZ53OIv+toW
+        vHfzdTa+cGPMhzwLBSj8FDRgtym5gAG7TckFDNhtSi5gwG5TcgEDdpuSCxiw25RcwIDdpuQCBuw2JRcw
+        YLdDQ0MY8yFdgI6GMOZDuoCg7ElDUIYzLiAoe9IQlOGMCwjKnjQEZTjjAoKyJw1BGc64gKDsSUNQhjMu
+        ICh70hCU4YwLCMqeNARlOOMCgrInDUEZzriAoOxJQ1CGMy4gKHvSEJThjAsIyp40BGU44wKCsicNQRnO
+        uICg7ElDUIYzLiAoe9IQlOGMCwjKnjQEZTjjAoKyJw1BGc64gKDsSUNQhjMuICh70hCU4YwLCMqeNARl
+        OOMCgrInDUEZzriAoOxJQ1CGMy4gKHvSEJThjAsIyp40BGU44wKCsicNQRnOuICg7ElDUIYzLiAoe9IQ
+        lOGMCwjKnjQEZTjjAoKyJw1BGc64gKDsSUNQhjMuICh70hCU4YwLCMqeNARlOOMCgrInDUEZzriAoOxJ
+        Q1CGMy4gKHvSEJThjAsIyp40BGU44wKCsicNQRnOuICg7ElDUIYzLiAoe9IQlOGMCwjKnjQEZTjjAoKy
+        Jw1BGc64gKDsSUNQhpnV++vf3Hnzuvr53ZPqzpu31S9/FBfZ68YYutvclD1pCMpw26/Hi29X5eLP7v+8
+        IhTl8njxHZs7dPV38YvaFfZnfZQb0hCUYfjx+dXzy7K4yw+/4d79369dYO9zqD7+KP2v9rD2NXtNRrkh
+        DUEZhs84/lr9+sfsfQ7VxwIaf9du1r5ir+1SbkhDUIbXP3bIkfucph9HreO3va/1fgblhjQEZTj/md+n
+        KNn7HaLO4bue1S6xOVBuSEPoG8bTDj+uZhdPR7vQOTjzT23FZvtuCDSEvuG7ZfEDO6wKj6idD3Kq3X71
+        L/57ooi+GwINoW94eVzcYodV/fTu6caHOCuaG/XdEGgIfcP+Djhp9u8A/x3wyX7+DgA/Ba2fgi6zOVBu
+        SENQhvE8zw+83Rn5d8D37PVtyg1pCMow1Ae91z3wNv6X8Ek0BGUY8LsdHJUduwuvO8W/C3pUO7zfBTXW
+        P47829ATlBvSEJRhBk9H60fUcnETRz8tTzu7oNyQhqAM23bKDWkIyrBtp9yQhtAetvG6923QENib2HDd
+        +zZoCOxNbLjufRs0tPnQ0OZDQ5sPDW0+NLT50NDmUp37HywvjQt2mZtnAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="Revit.Elements.PathOfTravel.InsertWayPoint.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAPBJREFUWEftlbENwjAQRbMCqzABBVPEBTVdJBZgAsAULJAhmICa2krYgB2OO+Ci
+        wzHBCVacwsWTrO/Y9+JzlAwAouIMQ7Or1FzXORyq/GTPNQNjDISG9/YW4LEvvmuiCHDRb7BMs8C12eZC
+        0WcmmbSAZHALkkAoARu5zhkySWDyAkNJAkkgCSQBL4F9pRbb6xmOt3wp8xD8FMBfZ0m/T0HJc33AE1SI
+        RmYy7xSgN7eKP6Gcn/UFC6+ojcgdWXPeKaBrVbgEqB3vzf5C1iJaAtRzl8CQu4AF+58AgQXj3QHmdRdU
+        MepXMCYtgVg4w/GA7AEXZxErWUHKVwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="Revit.Elements.PathOfTravel.RemoveWayPoint.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAABb5JREFUeF7t3LFvHFUQBvAUiIoSiYaOCjr+AigoQaIh0h11dE5NikhEgjSpkGJj
+        OpDSUyOZjsKChggXSSScw6JMjVIGtLxv59Z+u/vN7he/+M7em+KnxHNvTvNmdm/31pKvVVUVNogGw/rQ
+        YDjzZLF49mRnp+pZLJ6z9bm07mYvb5X76MaNd7CGJoYzqWH3eg08c4/lNFKjlyQH9ps1vaTQlxp5RJqI
+        I/kZWw/pdT64NJR8XSspcKlx/KPE0LMAwyFr4Wa+rpWUOz4+rrZd3o/UuINOI03niF6t9T62DrtrWz/k
+        WEHbJu/Ho8Xiw9Ts56Sp0Dqq6dGPC296j3wdtH7IsYK2TbcnqZEPeo215h5la7yj/0H+Xo1eoDFUyKZt
+        qjbcOrpnwWJxHWuco9+9WNMgbGqTik3WlhrqHeG4RtDXHu/s3GbvBTQIJZv84teqauTxV6WktlchHdH9
+        +3s7Mw5J/PTjiaFBKNnk5AcwfFvawi68ORqEkk1OfQCQmts/2vvohTdHg1CyyW0YQH1byptusuc9Q2gQ
+        Sja5DQNIDb5OG99w7vu7aBBKNrklA+DPh9p633y7aBBKNjn1AaTG9m83ve8HnW/JXTQIJZuc8gAGvowd
+        0PjAlzCgQSjZ5JQHUDe622SDW1PvNfduiAahZJNTHUBqpPcbrvrLlntnNHBH1As0SjY52QEIz/jT/72z
+        4CB/r0Yv0CjZ5BQHkBo4+iQUBh/YkQty64dcySanNoD6o+Ulmppi3rB6v7xp/ZAr2eTUBoCj3GkofdA2
+        chac/kIeWom5kk1OaQB4lEyaaFa/A2DS695Z0Log9xIbJZucygBWR7J34aUX1cbIWXCa20tslGxyKgNI
+        DfyRNK+mPOdJ6/hZYOprB02Ekk1OZQDrQINQsskYgI4GoWSTMQCj1EmDoCR7YgBGqZMGQUn2xACMUicN
+        gpLsiQEYpU4aBCXZEwMwSp00CEqyJwZglDppEJRkTwzAKHXSICjJnhiAUeqkQVCSPTEAo9RJg6Ake2IA
+        RqmTBkFJ9sQAjFInDYKS7IkBGKVOGgQl2RMDMEqdNAhKsicGYJQ6aRCUZE8MwCh10iAoyZ4YgFHqpEFQ
+        kj0xAKPUSYOgJHtiAEapkwZBSfbEAIxSJw2CkuyJARilThoEJdkTAzBKnTQISrInBmCUOmkQlGRPDMAo
+        ddIgKMmeGIBR6qRBUJI9MQCj1EmDoCR7YgBGqZMGQUn2xACMUicNgpLsiQEYpU4aBCXZEwMwSp00CEqy
+        JwZglDppEJRkTwzAKHXSICjJnhiAUeqkQVCSPTEAo9RJg6Ake2IARqmTBkFJ9sQAjFInDYKS7IkBGKVO
+        GgQl2RMDMEqdNAhKsicGYJQ6aRCUZGbv6edv33n4e3X36KfqzsM/qm/+nL3J1pU4b23rptRJg6Ak5749
+        mX+0t5z/vffXvOqbLXdP5h+zvMsuncWHyfvstTFKD2kQlGT46pcPXttdzu7zxvfsf/f4szfY+1xWq4/S
+        /5Lvk7fYGo/SQxoEJRleovm1tH70r8leJqsBNP5JbiWvs7VdSg9pEJTk+mOHNHnMVfo4ypqfe5qM7kHp
+        IQ2Ckux/5o+Z9f5y1GXVaXzXz8m7LA+UHtIgjCXjboc3V3MRd0cXodNw5kWyx3LHegg0CGPJ95ezT1lj
+        VbhF7WzkSvvyt3/xb2sQYz0EGoSx5N2T2W3WWNXXRwe9TUxF06OxHgINwlhynAFtaz8D4hpwajPXAIi7
+        oPou6D2WB0oPaRCUZNzP8wYPm8j3gE/Y+pzSQxoEJRlSQ/e7DR4S34TbaBCUZMCzHTSVNbsL667ws6Af
+        ksv3LKhRfxzF09AWpYc0CEoyg7uj+hZ1Ob+Fpl+Vu52LoPSQBkFJDsOUHtIgKMlhmNJDGoQ8OZTr9rdB
+        g8DeJJxft78NGgT2JuH8uv1t0GBYHxoM60ODYX1oMKwPDYb1ocGwLtW1/wGkgzNCx1LCmwAAAABJRU5E
+        rkJggg==
+</value>
+  </data>
+  <data name="Revit.Elements.PathOfTravel.RemoveWayPoint.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAS9JREFUWEftlj0OgkAQRr2CN7LwFFJYLnYmXsDK1uAFLDiEJ7CmMBRErW28wzof
+        7mxGWRCUn5hs8cIyO+w8ZpeEkdZ6UJzBNknD8EBoXEUM9zQUAlmW6bbhtVOlbih4UmoCESOwwNyLAI/r
+        UvcZKrYxRQvdsEldCgDqQmKK553guE1wLbY6IvQak/yNABXlLdjnV5LhOZvUsQCK3sy4/iFsQ4C/AGKD
+        e/Ml2K2wiV12oAo76FNAPucMMl7AC3gBL+AFBhXYnoPJOjno3XU2lXFJZwLRZRYTWhDzXBOogwEREWMZ
+        rxTAm78Vz0Gcc+tChefYRuJO5D8goFIgugRLlwC2wyz2E7IWKAhgz10CVWehDCrYvAOACg53BpjnWQiW
+        37z5J0oF+qQgMBTOYH/o0QPxXBAZeSGNRgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="Revit.Elements.PathOfTravel.SetWayPoint.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAABTdJREFUeF7t2LGLHGUYBvAUQSwsLAQb/4BoZy/YpFSwSCAzV8Q/wOLACEICxiKk
+        SOB2L+kUUkj+A0HBwkK0MSSNhXe7x5UWqcQyyvg9894ks1+ed+fZ3eS72fAWPxKem2d573v35ub2TNM0
+        4RTRMJRDw1AODUM5NAzl0DCUQ0M4ODhowouTn2+HhsBeJKwvP98ODYG9SFhffr4dGoJSPi1jnq1PmZOG
+        oJRPy5hn61PmpCEoZc/nvzZNp5+/KJvMVpIyJw1BKXtiAUaZk4aglD2xAKPMSUNQyp5YgFHmpCEoZU8s
+        wChz0hCUsicWYJQ5aQhK2RMLMMqcNASl7IkFGGVOGoJS9sQCjDInDUEpe2IBRpmThqCUPbEAo8xJQ1DK
+        nliAUeakIShlTyzAKHPSEJSyJxZglDlpCErZEwswypw0BKXsiQUYZU4aglL2xAKMMicNQSl7YgFGmZOG
+        oJQ9sQCjzElDUMqeWIBR5qQhKGVPLMAoc9IQlLInFmCUOWkIStkTCzDKnDQEpeyJBRhlThqCUvbEAowy
+        Jw1BKXtiAUaZk4aglD2xAKPMSUNQyp5YgFHmpCEoZU8swChz0hCUsicWYJQ5aQhK2RMLMMqcNASl7IkF
+        GGVOGoJS9sQCjDInDUEpe2IBRpmThqCUPbEAo8xJQ1DKnliAUeakIShlTyzAKHPSEJSyJxZglDlpCErZ
+        Ewswypw0BKXsiQUYZU4aglL2xAKMMicNQSl7YgFGmZOGoJQ9sQCjzElDUMqeWIBR5qQhKGVPLMAoc9IQ
+        lLInFmCUOWkIStkTCzDKnDQEpeyJBRhlThqCUvasuoDprLrO1Tf35/X9u39cfLt//SazlaTMSUNQyp6V
+        FzCvG2rW/X/nfv/6TWYrSZmThqCUPSsvIHvn788v3ZrOq7+eLaK60b9+k9lKUuakIShlz6oL6Ns/rs6l
+        d/6xHf7JEtJS+tdsMltJypw0BKXsWXcBk6Pqg3Tgj3Hok1n10/SwuhELWFL2rLOA6eHOhcm8/sfe+fV3
+        X/384dn2lhQLePkLSO/2z9JBP7HDrm92eSxgoOxZZQE48PaQ0wKwiMWvxQLW+iaVBbS3mHSrwQG3t550
+        C8qvSY+fu7acnd1+vslsJSlz0hCUMpMO8p1rD35vvn70fXPtwcPm9p/VW/2vpz+q3rh3fPn19pesvfMf
+        45dv/5rO3vHlN9MfYp+i08/Xna00ZU4aglLu2z+qzz97fMxVs8lR/RGum8yrS3i3t3m6Ho+d+WuNSfop
+        /iV5n31tiHKGNASlDLiVpHfz3vOHTt3BxwrplvNF6uzmPx1jdHIr/S/5Jln4SGSIcoY0BKUMKxx+K11/
+        j73OWJ0soPN3ciV5jV2bU86QhqCU29sOOeQh3e1oG/QOv+8wGfwelDOkIShl/54/pJqx1xuj7OBzPybv
+        sh4oZ0hDGCrjaYcfrmYb7v+QHTjzJJmy7tAZAg1hqLw3qz5hB6vCI2r2jWy1q7/9i38XFjF0hkBDGCqn
+        Z/cv2cGqrj/64blv4lXRndHQGQINYagcPwGLiv8ExO+Ap07ndwDEU1D7FPQe64FyhjQEpYzneX7Ay70i
+        fwd8zK7vU86QhqCUIR3onfyAl4m/hBfREJQy4JNKHCo77Byuyz/ZHLuTg8dnQd8m4/ssqNPejoRPQ7dN
+        OvRxfxqaw9NR+4g6q6/g0LflaedlUM6QhqCUw3LKGdIQlHJYTjlDGkK/HDaXn2+HhsBeJKwvP98ODYG9
+        SFhffr4dGoZyaBjKoWEoh4ahHBqGcmgYSmnO/A8D9+aPqiSbYwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="Revit.Elements.PathOfTravel.SetWayPoint.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAPRJREFUWEftkjEOgjAUhhldvY+Dg5eADsxuJF7AG0i9gAOH8ATOzgSIo4t3qO8X
+        nqlSETC0MenwJe0r9P/avkAp5RRj0SbPQZ7nyiZGAR73Zcw/4H8ENieUXms6XsALeAEv4AW8gHUBWUaK
+        wdy6QFqFC1mGhRMBhKdFdK0lLAscLvEMJ0c4r4FJBXaFWG7PR7WvohXmkNDXwWQCdMUZN1tDxmtDoBsU
+        hCTmer1TACd/C3+AOn/bFwqO8YzEjVhzvVNAliIxCeA5ms1+Qs8CLQG8uUmAe2EIFDj8BgAFuusBpu4F
+        kYw5+Tc+CtikJeAKY9EeKrgDWjQnMgYyPM0AAAAASUVORK5CYII=
+</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/Elements/PathOfTravel.cs
+++ b/src/Libraries/RevitNodes/Elements/PathOfTravel.cs
@@ -15,7 +15,7 @@ using RvtAnalysis = Autodesk.Revit.DB.Analysis;
 namespace Revit.Elements
 {
    /// <summary>
-   /// Revit Path of Travel Element
+   /// PathOfTravel Element.
    /// </summary>
    [DynamoServices.RegisterForTrace]
    public class PathOfTravel : Element
@@ -23,12 +23,12 @@ namespace Revit.Elements
       #region Internal properties
 
       /// <summary>
-      /// An internal handle on the Revit path of travel
+      /// An internal handle on the Revit PathOfTravel element.
       /// </summary>
       RvtAnalysis.PathOfTravel m_rvtPathOfTravel = null;
 
       /// <summary>
-      /// Reference to the Element
+      /// Reference to Revit PathOfTravel Element.
       /// </summary>
       [SupressImportIntoVM]
       public override Rvt.Element InternalElement
@@ -54,11 +54,11 @@ namespace Revit.Elements
       #region Public constructors
 
       /// <summary>
-      /// Calculates the longest PathofTravel(s) of all shortest paths from rooms in the floor plan to the specified exit points.
+      /// Calculates the longest PathOfTravel(s) of all shortest paths from rooms in the floor plan to the specified exit points.
       /// </summary>
       /// <param name="floorPlan">Floor plan view for which rooms will be used to retrieve longest paths to the specified exit points.</param>
       /// <param name="endPtsList">List of end (exit) points.</param>
-      /// <returns>List of PathofTravel elements corresponding to the longest of shortest exit paths from rooms.</returns>
+      /// <returns>List of PathOfTravel elements corresponding to the longest of shortest exit paths from rooms.</returns>
       [NodeCategory("Create")]
       [AllowRankReduction]
       public static PathOfTravel[] LongestOfShortestExitPaths(Revit.Elements.Views.FloorPlanView floorPlan, Autodesk.DesignScript.Geometry.Point[] endPtsList)
@@ -96,13 +96,13 @@ namespace Revit.Elements
       }
 
       /// <summary>
-      /// Constructs a list of PathofTravel elements in a floor plan view between the specified start points and end points.
+      /// Constructs a list of PathOfTravel elements in a floor plan view between the specified start points and end points.
       /// </summary>
       /// <param name="floorPlan">Floor plan view to place paths of travel on</param>
       /// <param name="startPtsList">List of start points</param>
       /// <param name="endPtsList">List of end points</param>
       /// <param name="manyToMany">If true, paths are created from every point in the start point list to all points in the end point list. If false, a path is created from every point in the start point list to a corresponding point in the end point list with the same index. The two lists must have the same size when not creating many-to-many paths.</param>
-      /// <returns>List of PathofTravel elements; can contain null elements if there is no path between some points.</returns>
+      /// <returns>List of PathOfTravel elements; can contain null elements if there is no path between some points.</returns>
       [NodeCategory("Create")]
       [AllowRankReduction]
       public static PathOfTravel[] ByFloorPlanPoints(Revit.Elements.Views.FloorPlanView floorPlan, Autodesk.DesignScript.Geometry.Point[] startPtsList, Autodesk.DesignScript.Geometry.Point[] endPtsList, bool manyToMany)
@@ -163,9 +163,9 @@ namespace Revit.Elements
       #region Public methods
 
       /// <summary>
-      /// Returns the WayPoints set from PathofTravel element.
+      /// Returns the WayPoints set from PathOfTravel element.
       /// </summary>
-      /// <returns>List of WayPoints for the given PathofTravel element.</returns>
+      /// <returns>List of WayPoints for the given PathOfTravel element.</returns>
       [NodeCategory("Query")]
       [AllowRankReduction]
       public IList<XYZ> GetWayPoints()
@@ -177,10 +177,10 @@ namespace Revit.Elements
       }
 
       /// <summary>
-      /// Removes WayPoint at the specified index from PathofTravel element.
+      /// Removes WayPoint at the specified index from PathOfTravel element.
       /// </summary>
-      /// <param name="index">Index of the WayPoint to be removed from the PathofTravel element.</param>
-      /// <returns>The PathofTravel element after the WayPoint was rmnoved.</returns>
+      /// <param name="index">Index of the WayPoint to be removed from the PathOfTravel element.</param>
+      /// <returns>The PathOfTravel element after the WayPoint was rmnoved.</returns>
       [NodeCategory("Action")]
       [AllowRankReduction]
       public PathOfTravel RemoveWayPoint(int index)
@@ -198,11 +198,11 @@ namespace Revit.Elements
       }
 
       /// <summary>
-      /// Inserts a WayPoint to PathofTravel element at the specified index.
+      /// Inserts a WayPoint to PathOfTravel element at the specified index.
       /// </summary>
       /// <param name="wayPoint">The waypoint to insert.</param>
       /// <param name="index">The index to insert the waypoint at.</param>
-      /// <returns>The PathofTravel element after the WayPoint was inserted.</returns>
+      /// <returns>The PathOfTravel element after the WayPoint was inserted.</returns>
       [NodeCategory("Action")]
       [AllowRankReduction]
       public PathOfTravel InsertWayPoint(Autodesk.DesignScript.Geometry.Point wayPoint, int index)
@@ -227,7 +227,7 @@ namespace Revit.Elements
       /// </summary>
       /// <param name="newPosition">The position to which WayPoint will be set.</param>
       /// <param name="index">The index of WayPoint to update.</param>
-      /// <returns>The PathofTravel element after the WayPoint was set.</returns>
+      /// <returns>The PathOfTravel element after the WayPoint was set.</returns>
       [NodeCategory("Action")]
       [AllowRankReduction]
       public PathOfTravel SetWayPoint(Autodesk.DesignScript.Geometry.Point newPosition, int index)
@@ -296,11 +296,11 @@ namespace Revit.Elements
       }
 
       /// <summary>
-      /// [INTERNAL]: Calculates the longest Path of Travel of all shortest paths from rooms in the floor plan to given exit points.
+      /// [INTERNAL]: Calculates the longest PathOfTravel of all shortest paths from rooms in the floor plan to given exit points.
       /// </summary>
       /// <param name="rvtView">Floor plan view for which rooms will be used to retrieve longest paths to the given exit points.</param>
       /// <param name="endPoints">List of end (exit) points.</param>
-      /// <returns>List of Path of Travel elements corresponding to the longest of shortest exit paths from rooms.</returns>
+      /// <returns>List of PathOfTravel elements corresponding to the longest of shortest exit paths from rooms.</returnsO
       /// 
       private static PathOfTravel[] InternalLongestOfShortestExitPaths(Rvt.View rvtView, IEnumerable<XYZ> endPoints)
       {
@@ -523,7 +523,7 @@ namespace Revit.Elements
       }
 
       /// <summary>
-      /// Initialize a Path of Travel element from existing Revit element
+      /// Initialize a PathOfTravel element from existing Revit element.
       /// </summary>
       private void InitPathOfTravel(RvtAnalysis.PathOfTravel rvtPathOfTravel)
       {

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -664,6 +664,15 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid PathOfTravel element..
+        /// </summary>
+        internal static string InvalidPathOfTravel {
+            get {
+                return ResourceManager.GetString("InvalidPathOfTravel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Floor Shape cannot be edited..
         /// </summary>
         internal static string InvalidShapeEditor {
@@ -1051,7 +1060,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rooms are required to compute longest Paths of Travel.
+        ///   Looks up a localized string similar to Rooms are required to compute longest Paths of Travel..
         /// </summary>
         internal static string RoomsForLongestPathNotFound {
             get {

--- a/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
@@ -486,4 +486,7 @@
   <data name="RoomsForLongestPathNotFound" xml:space="preserve">
     <value>Rooms are required to compute longest Paths of Travel.</value>
   </data>
+  <data name="InvalidPathOfTravel" xml:space="preserve">
+    <value>Invalid PathOfTravel element.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -513,4 +513,7 @@
     <data name="WrongStorageType" xml:space="preserve">
         <value>Input value for this parameter needs to be of type {0}.</value>
     </data>
+    <data name="InvalidPathOfTravel" xml:space="preserve">
+      <value>Invalid PathOfTravel element.</value>
+    </data>
 </root>

--- a/test/Libraries/RevitIntegrationTests/PathOfTravelTests.cs
+++ b/test/Libraries/RevitIntegrationTests/PathOfTravelTests.cs
@@ -32,5 +32,49 @@ namespace RevitSystemTests
          // Two longest paths of travel are created in this test
          Assert.AreEqual(2, collector.ToElements().Count());
       }
+
+      [Test]
+      [TestModel(@".\PathOfTravel\PathOfTravelsAndWayPoints.rvt")]
+      public void WayPointsGetInsertSetRemove()
+      {
+         string samplePath = Path.Combine(workingDirectory, @".\PathOfTravel\GetInsertSetRemoveWayPoints.dyn");
+         string testPath = Path.GetFullPath(samplePath);
+
+         ViewModel.OpenCommand.Execute(testPath);
+
+         RunCurrentModel();
+
+         // Node "Left WayPoints After insertion"
+         var wayPointsAfterinsertion = GetFlattenedPreviewValues("f128cb04b2f74fb2ac27232963885af4");
+         Assert.IsNotNull(wayPointsAfterinsertion);
+         Assert.AreEqual(1, wayPointsAfterinsertion.Count);
+         Assert.IsNotNull(wayPointsAfterinsertion[0]);
+         Assert.AreEqual("(-3.669000000, 15.000000000, 0.000000000)", wayPointsAfterinsertion[0].ToString());
+
+         // Node "Right initial WayPoints"
+         var rightinitialWayPoints = GetFlattenedPreviewValues("185cdb48e36c435abb08847df842ac9c");
+         Assert.IsNotNull(rightinitialWayPoints);
+         Assert.AreEqual(2, rightinitialWayPoints.Count);
+         Assert.IsNotNull(rightinitialWayPoints[0]);
+         Assert.IsNotNull(rightinitialWayPoints[1]);
+         Assert.AreEqual("(51.764361580, 16.711799679, 0.000000000)", rightinitialWayPoints[0].ToString());
+         Assert.AreEqual("(42.646072483, 3.614468449, 0.000000000)", rightinitialWayPoints[1].ToString());
+
+         // Nodes "Right WayPoints after set",
+         var rightWayPointsAfterSet = GetFlattenedPreviewValues("fa775bfa31034b429aaa8ac49e4b3738");
+         Assert.IsNotNull(rightWayPointsAfterSet);
+         Assert.AreEqual(2, rightWayPointsAfterSet.Count);
+         Assert.IsNotNull(rightWayPointsAfterSet[0]);
+         Assert.IsNotNull(rightWayPointsAfterSet[1]);
+         Assert.AreEqual("(56.372000000, 23.331000000, 0.000000000)", rightWayPointsAfterSet[0].ToString());
+         Assert.AreEqual("(42.646072483, 3.614468449, 0.000000000)", rightWayPointsAfterSet[1].ToString());
+
+         // Node "Right WayPoints after removal",
+         var wayPointsAfterRemoval = GetFlattenedPreviewValues("b0d8c3f4aefd412db29a2ee6aed80cd6");
+         Assert.IsNotNull(wayPointsAfterRemoval);
+         Assert.AreEqual(1, wayPointsAfterRemoval.Count);
+         Assert.IsNotNull(wayPointsAfterRemoval[0]);
+         Assert.AreEqual("(56.372000000, 23.331000000, 0.000000000)", wayPointsAfterRemoval[0].ToString());
+      }
    }
 }

--- a/test/Libraries/RevitNodesTests/Elements/PathOfTravelTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/PathOfTravelTests.cs
@@ -275,15 +275,15 @@ namespace RevitNodesTests.Elements
             new Point[] { Point.ByCoordinates(100, 100, 0) },
             false);
 
-         // Assert created Path of Travel is valid.
+         // Assert created PathOfTravel element is valid.
          Assert.NotNull(pathOfTravelOneToOne);
          Assert.AreEqual(1, pathOfTravelOneToOne.GetLength(0));
          Assert.NotNull(pathOfTravelOneToOne[0]);
 
-         // Current Path of Travel.
+         // Current PathOfTravel element.
          var pathOfTravel = pathOfTravelOneToOne[0];
 
-         // Assert there is no way points on current Path of Travel.
+         // Assert there is no way points on current PathOfTravel element.
          var listWayPointsEmpty = pathOfTravel.GetWayPoints();
          Assert.NotNull(listWayPointsEmpty);
          Assert.AreEqual(0, listWayPointsEmpty.Count);
@@ -334,12 +334,12 @@ namespace RevitNodesTests.Elements
             new Point[] { Point.ByCoordinates(100, 100, 0) },
             false);
 
-         // Assert created Path of Travel is valid.
+         // Assert created PathOfTravel element is valid.
          Assert.NotNull(pathOfTravelOneToOne);
          Assert.AreEqual(1, pathOfTravelOneToOne.GetLength(0));
          Assert.NotNull(pathOfTravelOneToOne[0]);
 
-         // Current Path of Travel.
+         // Current PathOfTravel element.
          var pathOfTravel = pathOfTravelOneToOne[0];
 
          // Assert we can insert a way point at valid index
@@ -382,12 +382,12 @@ namespace RevitNodesTests.Elements
             new Point[] { Point.ByCoordinates(100, 100, 0) },
             false);
 
-         // Assert created Path of Travel is valid.
+         // Assert created PathOfTravel element is valid.
          Assert.NotNull(pathOfTravelOneToOne);
          Assert.AreEqual(1, pathOfTravelOneToOne.GetLength(0));
          Assert.NotNull(pathOfTravelOneToOne[0]);
 
-         // Current Path of Travel.
+         // Current PathOfTravel element.
          var pathOfTravel = pathOfTravelOneToOne[0];
 
          // Assert we can insert a way point at valid index

--- a/test/Libraries/RevitNodesTests/Elements/PathOfTravelTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/PathOfTravelTests.cs
@@ -265,10 +265,149 @@ namespace RevitNodesTests.Elements
          Assert.Null(pathOfTravelManyToMany[0]);
       }
 
+      [Test]
+      [TestModel(@".\Empty.rvt")]
+      public void WayPointInsertGet_ValidArgs()
+      {
+         var pathOfTravelOneToOne = PathOfTravel.ByFloorPlanPoints(
+            GetFloorPlan(),
+            new Point[] { Point.ByCoordinates(0, 0, 0) },
+            new Point[] { Point.ByCoordinates(100, 100, 0) },
+            false);
+
+         // Assert created Path of Travel is valid.
+         Assert.NotNull(pathOfTravelOneToOne);
+         Assert.AreEqual(1, pathOfTravelOneToOne.GetLength(0));
+         Assert.NotNull(pathOfTravelOneToOne[0]);
+
+         // Current Path of Travel.
+         var pathOfTravel = pathOfTravelOneToOne[0];
+
+         // Assert there is no way points on current Path of Travel.
+         var listWayPointsEmpty = pathOfTravel.GetWayPoints();
+         Assert.NotNull(listWayPointsEmpty);
+         Assert.AreEqual(0, listWayPointsEmpty.Count);
+
+         // Assert only 0 index can be used to insert a way point.
+         Assert.Throws(
+            typeof(Autodesk.Revit.Exceptions.InvalidOperationException),
+            () => pathOfTravel.InsertWayPoint( Point.ByCoordinates(50, 50, 0), -1));
+         Assert.Throws(
+            typeof(Autodesk.Revit.Exceptions.InvalidOperationException),
+            () => pathOfTravel.InsertWayPoint( Point.ByCoordinates(50, 50, 0), 1));
+
+         // Assert we can insert a way point at valid index
+         pathOfTravel.InsertWayPoint(Point.ByCoordinates(50, 50, 0), 0);
+         var listWayPointsOneElem = pathOfTravel.GetWayPoints();
+         Assert.NotNull(listWayPointsOneElem);
+         Assert.AreEqual(1, listWayPointsOneElem.Count);
+         Assert.NotNull(listWayPointsOneElem[0]);
+         Assert.AreEqual("(50.000000000, 50.000000000, 0.000000000)", listWayPointsOneElem[0].ToString());
+
+         // Assert valid indices to insert way points are 0 and 1.
+         Assert.Throws(
+            typeof(Autodesk.Revit.Exceptions.InvalidOperationException),
+            () => pathOfTravel.InsertWayPoint( Point.ByCoordinates(25, 25, 0), -1));
+         Assert.Throws(
+            typeof(Autodesk.Revit.Exceptions.InvalidOperationException),
+            () => pathOfTravel.InsertWayPoint( Point.ByCoordinates(25, 25, 0), 2));
+
+         // Assert way point is inserted at index 0.
+         // inserting at index 1 is tested in WayPointSetGet_ValidArgs.
+         pathOfTravel.InsertWayPoint( Point.ByCoordinates(25, 25, 0), 0);
+         var listWayPointsTwoElems = pathOfTravel.GetWayPoints();
+         Assert.NotNull(listWayPointsTwoElems);
+         Assert.AreEqual(2, listWayPointsTwoElems.Count);
+         Assert.NotNull(listWayPointsTwoElems[0]);
+         Assert.NotNull(listWayPointsTwoElems[1]);
+         Assert.AreEqual("(25.000000000, 25.000000000, 0.000000000)", listWayPointsTwoElems[0].ToString());
+         Assert.AreEqual("(50.000000000, 50.000000000, 0.000000000)", listWayPointsTwoElems[1].ToString());
+      }
+
+      [Test]
+      [TestModel(@".\Empty.rvt")]
+      public void WayPointSetGet_ValidArgs()
+      {
+         var pathOfTravelOneToOne = PathOfTravel.ByFloorPlanPoints(
+            GetFloorPlan(),
+            new Point[] { Point.ByCoordinates(0, 0, 0) },
+            new Point[] { Point.ByCoordinates(100, 100, 0) },
+            false);
+
+         // Assert created Path of Travel is valid.
+         Assert.NotNull(pathOfTravelOneToOne);
+         Assert.AreEqual(1, pathOfTravelOneToOne.GetLength(0));
+         Assert.NotNull(pathOfTravelOneToOne[0]);
+
+         // Current Path of Travel.
+         var pathOfTravel = pathOfTravelOneToOne[0];
+
+         // Assert we can insert a way point at valid index
+         pathOfTravel.InsertWayPoint(Point.ByCoordinates(50, 50, 0), 0);
+         var listWayPointsOneElem = pathOfTravel.GetWayPoints();
+         Assert.NotNull(listWayPointsOneElem);
+         Assert.AreEqual(1, listWayPointsOneElem.Count);
+         Assert.NotNull(listWayPointsOneElem[0]);
+         Assert.AreEqual("(50.000000000, 50.000000000, 0.000000000)", listWayPointsOneElem[0].ToString());
+
+         // Assert way point is inserted at index 1
+         // inserting at index 0 is tested in WayPointInsertGet_ValidArgs.
+         pathOfTravel.InsertWayPoint(Point.ByCoordinates(75, 75, 0), 1);
+         var listWayPointsTwoElems = pathOfTravel.GetWayPoints();
+         Assert.NotNull(listWayPointsTwoElems);
+         Assert.AreEqual(2, listWayPointsTwoElems.Count);
+         Assert.NotNull(listWayPointsTwoElems[0]);
+         Assert.NotNull(listWayPointsTwoElems[1]);
+         Assert.AreEqual("(50.000000000, 50.000000000, 0.000000000)", listWayPointsTwoElems[0].ToString());
+         Assert.AreEqual("(75.000000000, 75.000000000, 0.000000000)", listWayPointsTwoElems[1].ToString());
+
+         //Assert we can modify a way point
+         pathOfTravel.SetWayPoint(Point.ByCoordinates(90, 90, 0), 1);
+         var listWayPointsTwoElemsAfterSet = pathOfTravel.GetWayPoints();
+         Assert.NotNull(listWayPointsTwoElemsAfterSet);
+         Assert.AreEqual(2, listWayPointsTwoElemsAfterSet.Count);
+         Assert.NotNull(listWayPointsTwoElemsAfterSet[0]);
+         Assert.NotNull(listWayPointsTwoElemsAfterSet[1]);
+         Assert.AreEqual("(50.000000000, 50.000000000, 0.000000000)", listWayPointsTwoElemsAfterSet[0].ToString());
+         Assert.AreEqual("(90.000000000, 90.000000000, 0.000000000)", listWayPointsTwoElemsAfterSet[1].ToString());
+      }
+
+      [Test]
+      [TestModel(@".\Empty.rvt")]
+      public void WayPointRemoveGet_ValidArgs()
+      {
+         var pathOfTravelOneToOne = PathOfTravel.ByFloorPlanPoints(
+            GetFloorPlan(),
+            new Point[] { Point.ByCoordinates(0, 0, 0) },
+            new Point[] { Point.ByCoordinates(100, 100, 0) },
+            false);
+
+         // Assert created Path of Travel is valid.
+         Assert.NotNull(pathOfTravelOneToOne);
+         Assert.AreEqual(1, pathOfTravelOneToOne.GetLength(0));
+         Assert.NotNull(pathOfTravelOneToOne[0]);
+
+         // Current Path of Travel.
+         var pathOfTravel = pathOfTravelOneToOne[0];
+
+         // Assert we can insert a way point at valid index
+         pathOfTravel.InsertWayPoint(Point.ByCoordinates(50, 50, 0), 0);
+         var listWayPointsOneElem = pathOfTravel.GetWayPoints();
+         Assert.NotNull(listWayPointsOneElem);
+         Assert.AreEqual(1, listWayPointsOneElem.Count);
+         Assert.NotNull(listWayPointsOneElem[0]);
+         Assert.AreEqual("(50.000000000, 50.000000000, 0.000000000)", listWayPointsOneElem[0].ToString());
+
+         // Assert way point is removed
+         pathOfTravel.RemoveWayPoint(0);
+         var listWayPointsEmpty = pathOfTravel.GetWayPoints();
+         Assert.NotNull(listWayPointsEmpty);
+         Assert.AreEqual(0, listWayPointsEmpty.Count);
+      }
+
       FloorPlanView GetFloorPlan()
       {
-         var elevation = 0;
-         var level = Level.ByElevation(elevation);
+         var level = Level.ByElevation(0);
          Assert.NotNull(level);
 
          var view = FloorPlanView.ByLevel(level);

--- a/test/System/PathOfTravel/GetInsertSetRemoveWayPoints.dyn
+++ b/test/System/PathOfTravel/GetInsertSetRemoveWayPoints.dyn
@@ -1,0 +1,866 @@
+{
+  "Uuid": "164e64fc-37b1-447d-8d4d-0f0bab3a3a30",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "GetInsertSetRemoveWayPoints",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Nodes.DSModelElementSelection, DSRevitNodesUI",
+      "NodeType": "ExtensionNode",
+      "InstanceId": [
+        "2c6f96a1-883e-4521-ba7b-5fd40e77ed84-00057895"
+      ],
+      "Id": "c1f268b4fa544edc973d664fcb736579",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "ee8bc110f36b4dcdbb691db77e0cd59f",
+          "Name": "Element",
+          "Description": "The selected elements.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0;",
+      "Id": "740e7811bdb448b39320ae998a07d9e4",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "bba4518a39a34d9e8bc5d28e17b74a28",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.PathOfTravel.RemoveWayPoint@int",
+      "Id": "ff9407b77dd44958ad1bf5da993bd9ff",
+      "Inputs": [
+        {
+          "Id": "20c0e419a0a947069f743990a8d1766d",
+          "Name": "pathOfTravel",
+          "Description": "Revit.Elements.PathOfTravel",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "fca868dd84284851b532af7412bdc061",
+          "Name": "index",
+          "Description": "Index of the WayPoint to be removed from the PathofTravel element.\n\nint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "171c272178fd462d82cd274eee308b21",
+          "Name": "PathOfTravel",
+          "Description": "The PathofTravel element after the WayPoint was rmnoved.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Removes WayPoint at the specified index from PathofTravel element.\n\nPathOfTravel.RemoveWayPoint (index: int): PathOfTravel"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1;",
+      "Id": "84e5c7812ab14bb287fa1c768905331b",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "802079e30e7a4f2786a54bf25ab70d24",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.PathOfTravel.GetWayPoints",
+      "Id": "f128cb04b2f74fb2ac27232963885af4",
+      "Inputs": [
+        {
+          "Id": "07ef332d6bc94ae09285888b513e7d21",
+          "Name": "pathOfTravel",
+          "Description": "Revit.Elements.PathOfTravel",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b4b1020136bc4cc9a9495352422d7829",
+          "Name": "var[]..[]",
+          "Description": "List of WayPoints for the given PathofTravel element.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Returns the WayPoints set from PathofTravel element.\n\nPathOfTravel.GetWayPoints ( ): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.PathOfTravel.InsertWayPoint@Autodesk.DesignScript.Geometry.Point,int",
+      "Id": "4b2035dc49d24732912fb1541083ab7f",
+      "Inputs": [
+        {
+          "Id": "1dc0ee45972c4972b16e5b7718e8f049",
+          "Name": "pathOfTravel",
+          "Description": "Revit.Elements.PathOfTravel",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "caaa62e42daa40b8a37626f0ab5d45c7",
+          "Name": "wayPoint",
+          "Description": "The waypoint to insert.\n\nPoint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d0ed72f58de7446da1eaa8e6dd0bd1f2",
+          "Name": "index",
+          "Description": "The index to insert the waypoint at.\n\nint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "cd4f339624cc42398ca3f88b46f263e4",
+          "Name": "PathOfTravel",
+          "Description": "The PathofTravel element after the WayPoint was inserted.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Inserts a WayPoint to PathofTravel element at the specified index.\n\nPathOfTravel.InsertWayPoint (wayPoint: Point, index: int): PathOfTravel"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.PathOfTravel.SetWayPoint@Autodesk.DesignScript.Geometry.Point,int",
+      "Id": "288d6104ebe1424d9f82c8b2c9453c5f",
+      "Inputs": [
+        {
+          "Id": "f6c9d67fb7be488f9a15c37ea3e6d8b4",
+          "Name": "pathOfTravel",
+          "Description": "Revit.Elements.PathOfTravel",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cb5a1e2b29b2458684bb57712f76d864",
+          "Name": "newPosition",
+          "Description": "The position to which WayPoint will be set.\n\nPoint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9bcb1b60786b423eb42a041e98ac1335",
+          "Name": "index",
+          "Description": "The index of WayPoint to update.\n\nint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "17962317f715464cbd01a1af28db8c6e",
+          "Name": "PathOfTravel",
+          "Description": "The PathofTravel element after the WayPoint was set.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Updates WayPoint at the specified index to the new specified position.\n\nPathOfTravel.SetWayPoint (newPosition: Point, index: int): PathOfTravel"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "0;",
+      "Id": "660358a1e6f94b31811e54c0e5a7ba47",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "7acd3b13c5f842b8a7400c6361c3485a",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.PathOfTravel.GetWayPoints",
+      "Id": "b0d8c3f4aefd412db29a2ee6aed80cd6",
+      "Inputs": [
+        {
+          "Id": "1400939561d949a6b5f4b15824cc16ee",
+          "Name": "pathOfTravel",
+          "Description": "Revit.Elements.PathOfTravel",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "eb2c80fa5b4e41909dbc577041880af0",
+          "Name": "var[]..[]",
+          "Description": "List of WayPoints for the given PathofTravel element.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Returns the WayPoints set from PathofTravel element.\n\nPathOfTravel.GetWayPoints ( ): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Nodes.DSModelElementSelection, DSRevitNodesUI",
+      "NodeType": "ExtensionNode",
+      "InstanceId": [
+        "2c6f96a1-883e-4521-ba7b-5fd40e77ed84-000578d1"
+      ],
+      "Id": "c6cb704ed7b9409e808d80adf392bb75",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "f55d33b4909e48a1b42ff709e43958a5",
+          "Name": "Element",
+          "Description": "The selected elements.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double",
+      "Id": "9aa42a7537c14b90b07ea2ba1f28b98a",
+      "Inputs": [
+        {
+          "Id": "93202f7e086f49dab8b42ccd124b6ef9",
+          "Name": "x",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "97b72e9ea8a14e3f9b64be8ec5bfaec7",
+          "Name": "y",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "789650cf2f384131bccfc11dafd9adc3",
+          "Name": "Point",
+          "Description": "Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Point in the XY plane given two 2 cartesian coordinates. The Z component is 0.\n\nPoint.ByCoordinates (x: double = 0, y: double = 0): Point"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "InputValue": 15.0,
+      "Id": "77e3e2b250284fbe8e5489eede11a80e",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "5d76faa422554a9f99e15a6a73b6a098",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "InputValue": -3.669,
+      "Id": "03cb6e15964b4ca8afba6ca85a99d8c6",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "53ed205339e0467e9d33ff8dfd2bbc1f",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "InputValue": 56.372,
+      "Id": "f4832915a8504cd8a4c1e1536f13bfc4",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "b0e082fac1664a228731a750d7457b80",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.DoubleInput, CoreNodeModels",
+      "NodeType": "NumberInputNode",
+      "NumberType": "Double",
+      "InputValue": 23.331,
+      "Id": "b8e180f880c347de8d6e8c40beeb89f4",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "a7c8c6a9411242c1936704338c8c5d66",
+          "Name": "",
+          "Description": "Double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a number."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double",
+      "Id": "210f3e48a3ad4b138283949b579a7b51",
+      "Inputs": [
+        {
+          "Id": "98aee49bbff04847b8414df0ec4501f8",
+          "Name": "x",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "41a4ed4d904343b485abfe3846c66245",
+          "Name": "y",
+          "Description": "double\nDefault value : 0",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "dfe3363f301d4d6188d627c642ff945a",
+          "Name": "Point",
+          "Description": "Point",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Point in the XY plane given two 2 cartesian coordinates. The Z component is 0.\n\nPoint.ByCoordinates (x: double = 0, y: double = 0): Point"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.PathOfTravel.GetWayPoints",
+      "Id": "fa775bfa31034b429aaa8ac49e4b3738",
+      "Inputs": [
+        {
+          "Id": "690022f9f30e444f85261c01ae9deaed",
+          "Name": "pathOfTravel",
+          "Description": "Revit.Elements.PathOfTravel",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "02fdf6617bda40fca9cbb4652c929ead",
+          "Name": "var[]..[]",
+          "Description": "List of WayPoints for the given PathofTravel element.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Returns the WayPoints set from PathofTravel element.\n\nPathOfTravel.GetWayPoints ( ): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.PathOfTravel.GetWayPoints",
+      "Id": "185cdb48e36c435abb08847df842ac9c",
+      "Inputs": [
+        {
+          "Id": "16cf29679677437a9bcb4342993afe52",
+          "Name": "pathOfTravel",
+          "Description": "Revit.Elements.PathOfTravel",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "71249abaa1d64afe927cfb97e91f7e55",
+          "Name": "var[]..[]",
+          "Description": "List of WayPoints for the given PathofTravel element.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Returns the WayPoints set from PathofTravel element.\n\nPathOfTravel.GetWayPoints ( ): var[]..[]"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "ee8bc110f36b4dcdbb691db77e0cd59f",
+      "End": "1dc0ee45972c4972b16e5b7718e8f049",
+      "Id": "c3909b4e281b4a76915404c6a3e4c73b"
+    },
+    {
+      "Start": "bba4518a39a34d9e8bc5d28e17b74a28",
+      "End": "d0ed72f58de7446da1eaa8e6dd0bd1f2",
+      "Id": "6ffc1eecd2534c96954e20e27dd956d1"
+    },
+    {
+      "Start": "171c272178fd462d82cd274eee308b21",
+      "End": "1400939561d949a6b5f4b15824cc16ee",
+      "Id": "979389d07ddb47dcbc34b294bfc0481b"
+    },
+    {
+      "Start": "802079e30e7a4f2786a54bf25ab70d24",
+      "End": "fca868dd84284851b532af7412bdc061",
+      "Id": "675f466da8f042c0afbba9562678abf5"
+    },
+    {
+      "Start": "cd4f339624cc42398ca3f88b46f263e4",
+      "End": "07ef332d6bc94ae09285888b513e7d21",
+      "Id": "d09bd63f81984fef8db87ed855489de7"
+    },
+    {
+      "Start": "17962317f715464cbd01a1af28db8c6e",
+      "End": "20c0e419a0a947069f743990a8d1766d",
+      "Id": "c01bc1a129be4198bc81d09c2edca5eb"
+    },
+    {
+      "Start": "17962317f715464cbd01a1af28db8c6e",
+      "End": "690022f9f30e444f85261c01ae9deaed",
+      "Id": "cd54a3d120f5466fbc80daa1ed390457"
+    },
+    {
+      "Start": "7acd3b13c5f842b8a7400c6361c3485a",
+      "End": "9bcb1b60786b423eb42a041e98ac1335",
+      "Id": "55ce8cb5dc8e451bb8f0d00e87698cf3"
+    },
+    {
+      "Start": "f55d33b4909e48a1b42ff709e43958a5",
+      "End": "f6c9d67fb7be488f9a15c37ea3e6d8b4",
+      "Id": "052794bc7e2944e39ff337d0e3b5e37e"
+    },
+    {
+      "Start": "f55d33b4909e48a1b42ff709e43958a5",
+      "End": "16cf29679677437a9bcb4342993afe52",
+      "Id": "003d5fe81900439286c8fc87957c7190"
+    },
+    {
+      "Start": "789650cf2f384131bccfc11dafd9adc3",
+      "End": "caaa62e42daa40b8a37626f0ab5d45c7",
+      "Id": "1d1565664bd24dbf8b3cd5ab24d022f5"
+    },
+    {
+      "Start": "5d76faa422554a9f99e15a6a73b6a098",
+      "End": "97b72e9ea8a14e3f9b64be8ec5bfaec7",
+      "Id": "8a32996372204a7eada5c32e32dad0e8"
+    },
+    {
+      "Start": "53ed205339e0467e9d33ff8dfd2bbc1f",
+      "End": "93202f7e086f49dab8b42ccd124b6ef9",
+      "Id": "c9f02ece176f41f49c87b76bb55c10db"
+    },
+    {
+      "Start": "b0e082fac1664a228731a750d7457b80",
+      "End": "98aee49bbff04847b8414df0ec4501f8",
+      "Id": "8ef455d3e5f7415fb75e190a7e0589ae"
+    },
+    {
+      "Start": "a7c8c6a9411242c1936704338c8c5d66",
+      "End": "41a4ed4d904343b485abfe3846c66245",
+      "Id": "c28667cc752446de9db44e21d81404ae"
+    },
+    {
+      "Start": "dfe3363f301d4d6188d627c642ff945a",
+      "End": "cb5a1e2b29b2458684bb57712f76d864",
+      "Id": "f4498ebfc3cf4a049985e433f1ff890c"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.7.0.8206",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -9.2752397737917764,
+      "EyeY": 8.5723746748222158,
+      "EyeZ": 31.800249308860344,
+      "LookX": 7.5980142767650278,
+      "LookY": -8.2311821331621129,
+      "LookZ": -36.723735671030944,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Select Path of Travel",
+        "Id": "c1f268b4fa544edc973d664fcb736579",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4900.080627458683,
+        "Y": 770.867918593041
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Index",
+        "Id": "740e7811bdb448b39320ae998a07d9e4",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4899.6874160797688,
+        "Y": 1028.8464682103904
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "PathOfTravel.RemoveWayPoint",
+        "Id": "ff9407b77dd44958ad1bf5da993bd9ff",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4199.8392694729127,
+        "Y": 1594.7135018462939
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Index",
+        "Id": "84e5c7812ab14bb287fa1c768905331b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4334.8069335347136,
+        "Y": 1752.6481522002648
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Left WayPoints After insertion",
+        "Id": "f128cb04b2f74fb2ac27232963885af4",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4202.9373257481911,
+        "Y": 901.06589796453966
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "PathOfTravel.InsertWayPoint",
+        "Id": "4b2035dc49d24732912fb1541083ab7f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4558.0600347572745,
+        "Y": 895.73512754659737
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "PathOfTravel.SetWayPoint",
+        "Id": "288d6104ebe1424d9f82c8b2c9453c5f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4557.0145500817089,
+        "Y": 1596.5098176137631
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Index",
+        "Id": "660358a1e6f94b31811e54c0e5a7ba47",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4901.5076423809969,
+        "Y": 1704.8685927021374
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Right WayPoints after removal",
+        "Id": "b0d8c3f4aefd412db29a2ee6aed80cd6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -3862.0916150788448,
+        "Y": 1332.79405884654
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Select Path of Travel",
+        "Id": "c6cb704ed7b9409e808d80adf392bb75",
+        "IsSetAsInput": true,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4899.7372410105254,
+        "Y": 1450.387836220438
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Point.ByCoordinates",
+        "Id": "9aa42a7537c14b90b07ea2ba1f28b98a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4795.5419619481017,
+        "Y": 908.55098962282307
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Number",
+        "Id": "77e3e2b250284fbe8e5489eede11a80e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4897.7592350502309,
+        "Y": 960.21186502848229
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Number",
+        "Id": "03cb6e15964b4ca8afba6ca85a99d8c6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4898.1579409657743,
+        "Y": 893.54732973477871
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Number",
+        "Id": "f4832915a8504cd8a4c1e1536f13bfc4",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4898.4067294334982,
+        "Y": 1577.4262980625533
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Number",
+        "Id": "b8e180f880c347de8d6e8c40beeb89f4",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4901.4019379003776,
+        "Y": 1642.234374213708
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Point.ByCoordinates",
+        "Id": "210f3e48a3ad4b138283949b579a7b51",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4774.604051200261,
+        "Y": 1583.4410194001575
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Right WayPoints after update",
+        "Id": "fa775bfa31034b429aaa8ac49e4b3738",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4199.0045576877083,
+        "Y": 1334.3882716150292
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Right initial WayPoints",
+        "Id": "185cdb48e36c435abb08847df842ac9c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -4535.8405997169311,
+        "Y": 1331.1998460780515
+      }
+    ],
+    "Annotations": [
+      {
+        "Id": "5c10a0eb1504439cbd289db667678d30",
+        "Title": "Select existing PathOfTravel element and set new WayPoint to insert.",
+        "Nodes": [
+          "c1f268b4fa544edc973d664fcb736579",
+          "740e7811bdb448b39320ae998a07d9e4",
+          "9aa42a7537c14b90b07ea2ba1f28b98a",
+          "77e3e2b250284fbe8e5489eede11a80e",
+          "03cb6e15964b4ca8afba6ca85a99d8c6"
+        ],
+        "Left": -4910.080627458683,
+        "Top": 544.867918593041,
+        "Width": 281.53866551058127,
+        "Height": 576.97854961734936,
+        "FontSize": 36.0,
+        "InitialTop": 770.867918593041,
+        "InitialHeight": 402.97854961734936,
+        "TextblockHeight": 216.0,
+        "Background": "#FFC1D676"
+      },
+      {
+        "Id": "3801f8e069894c1d9733abe651fbcac8",
+        "Title": "Select  existing PathOfTravel element with some WayPoints on it.",
+        "Nodes": [
+          "660358a1e6f94b31811e54c0e5a7ba47",
+          "c6cb704ed7b9409e808d80adf392bb75",
+          "f4832915a8504cd8a4c1e1536f13bfc4",
+          "b8e180f880c347de8d6e8c40beeb89f4",
+          "210f3e48a3ad4b138283949b579a7b51"
+        ],
+        "Left": -4911.5076423809969,
+        "Top": 1267.387836220438,
+        "Width": 303.90359118073593,
+        "Height": 530.48075648169947,
+        "FontSize": 36.0,
+        "InitialTop": 1450.387836220438,
+        "InitialHeight": 399.48075648169947,
+        "TextblockHeight": 173.0,
+        "Background": "#FFC1D676"
+      }
+    ],
+    "X": 2991.2597766325011,
+    "Y": -643.59304069537234,
+    "Zoom": 0.59735380659680293
+  }
+}


### PR DESCRIPTION
…nt. Rework PathOfTravel nodes icons.


### Purpose

As a major user story of Revit Recombinant team (https://jira.autodesk.com/browse/REVIT-146364), the aim of this PR is to create a  set of four new Dynamo nodes to handle and manage WayPoints on a PathOfTravel element. These nodes are named InsertWayPoint, RemoveWayPoint, SetWayPoint and GetWayPoints.
Existing icons of ByFloorPlanPoints, LongestOfShortestExitPaths and Update nodes are slightly modified to keep PathOfTravel icons based on same graphical representations.
![image](https://user-images.githubusercontent.com/62023888/79461617-68fdc300-7fc4-11ea-9199-a90d80760191.png)
![image](https://user-images.githubusercontent.com/62023888/79461715-8a5eaf00-7fc4-11ea-8fd4-fc5b90dfaf7e.png)
![image](https://user-images.githubusercontent.com/62023888/79461779-a2cec980-7fc4-11ea-96eb-d78352bc0b20.png)
![image](https://user-images.githubusercontent.com/62023888/79461825-af532200-7fc4-11ea-8c19-2e36f4d3dc55.png)
![image](https://user-images.githubusercontent.com/62023888/79461861-bbd77a80-7fc4-11ea-8bac-0a883cd7d8e0.png)

## Description:
The new four nodes are being added to the Dynamo Library under the Revit.Analyze.RouteAnanlysis.PathOfTravel group.
InsertWayPoint, RemoveWayPoint and SetWayPoint nodes return the same updated PathOfTravel element used as input. This allows to chain node operations ob the same PathOfTravel element.
* InsertWayPoint node inserts a WayPoint to PathOfTravel element at the specified index. It takes the pathOfTravel, the wayPoint and the index as input and returns the updated PathOfTravel element.
* RemoveWayPoint node removes the WayPoint at the specified index from PathOfTravel element. It takes the pathOfTravel and the index as input and returns the updated PathOfTravel element.
* SetWayPoint node updates WayPoint at the specified index to the new specified position. It takes the pathOfTravel, the newPosition point and the index as input and returns the updated PathOfTravel element.
* GetWayPoints node returns the WayPoints set from PathOfTravel element. It takes the pathOfTravel as input and returns a list of wayPoints on the PathofTravel.

## Preliminary conditions:
* Input elements (PathOfTravel, Point used to set or to insert) must not be null.
* Indices used to insert, remove or set a WayPoint must be in a valid range.
* For code robustness, an internal validity/integrity check of the input PathOfTravel is performed. If this happens, for some reason, a new warning "Invalid PathOfTravel element." will be shown. There is no explicit case where we can reproduce this particular case.

### Impact assessment

- [ ] Changes the way 3rd party nodes work (Add ikeough to the reviewer list)
- [ ] Includes migrations (Add ikeough to the reviewer list)
- [ ] Adds or changes a public interface (Add lukechurch to the reviewer list)
- [ ] API change is added to the [API Changes document](https://github.com/DynamoDS/Dynamo/wiki/API-Changes).
- [ ] Affects which components of the system depends on which other components (Add pboyer to the reviewer list)
- [x] Introduces new components (Add lukechurch to the reviewer list)
- [ ] Has a performance impact (Add keyu to the reviewer list)
- [ ] Changes the installer (Add sharadkjaiswal to the reviewer list)
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x ] All tests pass using the self-service CI.
- [ x] Snapshot of UI changes, if any.

### Unit tests
The following unit tests have been added to RevitNodesTests assembly and they pass OK (I used RevitTestFrameworkConsole):
WayPointInsertGet_ValidArgs
WayPointSetGet_ValidArgs
WayPointRemoveGet_ValidArgs

### Integration test
New Revit 2021 model is added test\System\PathOfTravel\PathOfTravelsAndWayPoints.rvt with a scenario file GetInsertSetRemoveWayPoints.dyn.
WayPointsGetInsertSetRemove test has been added to RevitSystemTests assembly and it passes OK (I used RevitTestFrameworkConsole).
![image](https://user-images.githubusercontent.com/62023888/79485145-b9841900-7fe2-11ea-9bf7-1f4ebb96e2a7.png)
![image](https://user-images.githubusercontent.com/62023888/79485308-ffd97800-7fe2-11ea-954a-499219a034a3.png)
![image](https://user-images.githubusercontent.com/62023888/79485347-1089ee00-7fe3-11ea-95c7-094bbd1f230a.png)

### Resource localization
New warning exception message "Invalid PathOfTravel element." is added when the PathOfTravel element do not have a valid internal representation.

### Reviewers
@lukechurch 
@awbushnell 
@bykovsm
@aan.du@autodesk.com
@ziyun.shang@autodesk

### FYIs
@awbushnell 
@shafirb
@wangmin






