### PR TITLE
Fix Roof.ByOutlineExtrusionTypeAndLevel bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix Roof.ByOutlineExtrusionTypeAndLevel bug - the input outline should not be closed.
+
 ## 0.2.12
 * Fix some tests was deleted by mistake.
 

--- a/src/Libraries/RevitNodes/Elements/Roof.cs
+++ b/src/Libraries/RevitNodes/Elements/Roof.cs
@@ -146,7 +146,7 @@ namespace Revit.Elements
         /// Create a Revit Roof given its curve outline and Level
         /// </summary>
         /// <param name="outline"></param>
-        /// <param name="RoofType"></param>
+        /// <param name="roofType"></param>
         /// <param name="level"></param>
         /// <returns>The Roof</returns>
         public static Roof ByOutlineTypeAndLevel(Curve[] outline, RoofType roofType, Level level)

--- a/src/Libraries/RevitNodes/Elements/Roof.cs
+++ b/src/Libraries/RevitNodes/Elements/Roof.cs
@@ -182,9 +182,9 @@ namespace Revit.Elements
         public static Roof ByOutlineExtrusionTypeAndLevel(PolyCurve outline, RoofType roofType, Level level, ReferencePlane plane, double extrusionStart, double extrusionEnd)
         {
 
-            if (!outline.IsClosed)
+            if (outline.IsClosed)
             {
-                throw new ArgumentException(Properties.Resources.OpenInputPolyCurveError);
+                throw new ArgumentException(Properties.Resources.CloseInputPolyCurveError);
             }
 
             var ca = new CurveArray();

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Revit.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -156,6 +156,15 @@ namespace Revit.Properties {
         internal static string ChildElementsNotSupported {
             get {
                 return ResourceManager.GetString("ChildElementsNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The input PolyCurve is closed..
+        /// </summary>
+        internal static string CloseInputPolyCurveError {
+            get {
+                return ResourceManager.GetString("CloseInputPolyCurveError", resourceCulture);
             }
         }
         
@@ -367,20 +376,20 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot place empty view on sheet..
-        /// </summary>
-        internal static string EmptyView {
-            get {
-                return ResourceManager.GetString("EmptyView", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to There is no ElementType of the given name in the current Document.
         /// </summary>
         internal static string ElementTypeNameNotFound {
             get {
                 return ResourceManager.GetString("ElementTypeNameNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot place empty view on sheet..
+        /// </summary>
+        internal static string EmptyView {
+            get {
+                return ResourceManager.GetString("EmptyView", resourceCulture);
             }
         }
         
@@ -1051,7 +1060,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rooms are required to compute longest Paths of Travel.
+        ///   Looks up a localized string similar to Rooms are required to compute longest Paths of Travel..
         /// </summary>
         internal static string RoomsForLongestPathNotFound {
             get {

--- a/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
@@ -486,4 +486,7 @@
   <data name="RoomsForLongestPathNotFound" xml:space="preserve">
     <value>Rooms are required to compute longest Paths of Travel.</value>
   </data>
+  <data name="CloseInputPolyCurveError" xml:space="preserve">
+    <value>The input PolyCurve is closed.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-    <!-- 
+  <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,458 +59,461 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
-        <xsd:element name="root" msdata:IsDataSet="true">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
             <xsd:complexType>
-                <xsd:choice maxOccurs="unbounded">
-                    <xsd:element name="metadata">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" use="required" type="xsd:string"/>
-                            <xsd:attribute name="type" type="xsd:string"/>
-                            <xsd:attribute name="mimetype" type="xsd:string"/>
-                            <xsd:attribute ref="xml:space"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="assembly">
-                        <xsd:complexType>
-                            <xsd:attribute name="alias" type="xsd:string"/>
-                            <xsd:attribute name="name" type="xsd:string"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="data">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-                            <xsd:attribute ref="xml:space"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="resheader">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                </xsd:choice>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
-        </xsd:element>
-    </xsd:schema>
-    <resheader name="resmimetype">
-        <value>text/microsoft-resx</value>
-    </resheader>
-    <resheader name="version">
-        <value>2.0</value>
-    </resheader>
-    <resheader name="reader">
-        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-    </resheader>
-    <resheader name="writer">
-        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-    </resheader>
-    <data name="Adaptive_Component_Creation_Failed" xml:space="preserve">
-        <value>An adaptive component could not be found or created.</value>
-    </data>
-    <data name="AnalysisResultsDefaultDescription" xml:space="preserve">
-        <value>Analysis Results from Dynamo</value>
-    </data>
-    <data name="AnalysisResultsDefaultName" xml:space="preserve">
-        <value>Dynamo Analysis Results</value>
-    </data>
-    <data name="AreaSchemeArgumentException" xml:space="preserve">
-        <value>You must supply an Area Scheme.</value>
-    </data>
-    <data name="Array_Count_Mismatch" xml:space="preserve">
-        <value>The number of sample locations and samples is not equal.</value>
-    </data>
-    <data name="AttachedGroupLocation" xml:space="preserve">
-        <value>Cannot get location of attached group.</value>
-    </data>
-    <data name="CannotGetBaseOrSurveyPoint" xml:space="preserve">
-        <value>Cannot get base or survey point from document.</value>
-    </data>
-    <data name="CategoryArgumentException" xml:space="preserve">
-        <value>You must supply a Category.</value>
-    </data>
-    <data name="CategoryVisibilityOverrideError" xml:space="preserve">
-        <value>Specified View Template is not valid for this View.</value>
-    </data>
-    <data name="CellForPanelNotFound" xml:space="preserve">
-        <value>Could not find cell for panel</value>
-    </data>
-    <data name="ChildElementsNotSupported" xml:space="preserve">
-        <value>Getting child elements is not supported for this type of Element.</value>
-    </data>
-    <data name="CurtainGridNotFound" xml:space="preserve">
-        <value>Element has no Curtain Grid.</value>
-    </data>
-    <data name="CurtainGridReferenceError" xml:space="preserve">
-        <value>Reference should be to Face of the Element.</value>
-    </data>
-    <data name="CurtainPanelInternalElementError" xml:space="preserve">
-        <value>InternalElement of Curtain Panel is not Panel.</value>
-    </data>
-    <data name="CurtainPanelIsNotPlanar" xml:space="preserve">
-        <value>Curtain Panel is not planar</value>
-    </data>
-    <data name="CurtainPanelIsNotRectangular" xml:space="preserve">
-        <value>Curtain Panel is not rectangular</value>
-    </data>
-    <data name="CurtainPanelShouldRepresentRevitPanel" xml:space="preserve">
-        <value>Curtain Panel should represent Revit panel</value>
-    </data>
-    <data name="CurtainSystemTypeNotFound" xml:space="preserve">
-        <value>Curtain System Type not found.</value>
-    </data>
-    <data name="CurveIsNotPlanar" xml:space="preserve">
-        <value>Curve ist not planar. Please supply a planar curve.</value>
-    </data>
-    <data name="CurveLoopNotClosed" xml:space="preserve">
-        <value>Curves do not form a closed loop.</value>
-    </data>
-    <data name="CurveNeedsTwoPoints" xml:space="preserve">
-        <value>Cannot create Curve By Points with less than two points.</value>
-    </data>
-    <data name="CurveReferenceExtractionDetail" xml:space="preserve">
-        <value>You supplied an {0}, but we could not extract a CurveReference from it!</value>
-    </data>
-    <data name="CurveReferenceExtractionFailure" xml:space="preserve">
-        <value>{0} requires a ElementCurveReference extracted from a Revit Element! </value>
-    </data>
-    <data name="CurveReferenceFailure" xml:space="preserve">
-        <value>A Curve Reference can only be obtained from an Element.</value>
-    </data>
-    <data name="CurveReferenceHint" xml:space="preserve">
-        <value>You can use the {0} or {1} to turn this Curve into a Revit Element.</value>
-    </data>
-    <data name="CurveRequired" xml:space="preserve">
-        <value>Please supply a curve geometry.</value>
-    </data>
-    <data name="DirectShapeInvalidArgument" xml:space="preserve">
-        <value>Can only create DirectShapes from Solids, Surfaces or Meshes.</value>
-    </data>
-    <data name="DocumentDoesNotSupportGlobalParams" xml:space="preserve">
-        <value>Document does not support global parameters.</value>
-    </data>
-    <data name="DocumentNotFamilyDocument" xml:space="preserve">
-        <value>Document is not a valid Family Document.</value>
-    </data>
-    <data name="DocumentNotWorkshared" xml:space="preserve">
-        <value>Current Document is not workshared</value>
-    </data>
-    <data name="DynamoSolidToRevitBRepFailure" xml:space="preserve">
-        <value>An unexpected failure occurred when attempting to convert the solid into a Revit BRep</value>
-    </data>
-    <data name="DynamoSurfaceToRevitBRepFailure" xml:space="preserve">
-        <value>An unexpected failure occurred when attempting to convert the surface into a Revit BRep</value>
-    </data>
-    <data name="Dynamo_AVF_Data_Name" xml:space="preserve">
-        <value>Dynamo Data</value>
-    </data>
-    <data name="ElementCannotBeAnnotatedError" xml:space="preserve">
-        <value>Element cannot be annotated</value>
-    </data>
-    <data name="ElementTypeNameNotFound" xml:space="preserve">
-        <value>There is no ElementType of the given name in the current Document</value>
-    </data>
-    <data name="EmptyView" xml:space="preserve">
-        <value>Cannot place empty view on sheet.</value>
-    </data>
-    <data name="EndPointListEmpty" xml:space="preserve">
-        <value>End point list is empty</value>
-    </data>
-    <data name="EndPointListHasNulls" xml:space="preserve">
-        <value>End point list contains null elements</value>
-    </data>
-    <data name="ExportOptionsArgumentException" xml:space="preserve">
-        <value>Invalid Schedule Export Options.</value>
-    </data>
-    <data name="FaceReferenceExtractionDetail" xml:space="preserve">
-        <value>You supplied an {0}, but we could not extract a ElementFaceReference from it!</value>
-    </data>
-    <data name="FaceReferenceExtractionFailure" xml:space="preserve">
-        <value>{0} requires a ElementFaceReference extracted from a Revit Element! </value>
-    </data>
-    <data name="FaceReferenceFailure" xml:space="preserve">
-        <value>A Face Reference can only be obtained from an Element.</value>
-    </data>
-    <data name="FaceReferenceHint" xml:space="preserve">
-        <value>You can use the {0} to turn this Surface into a Revit Element, then extract a ElementFaceReference from it.</value>
-    </data>
-    <data name="FamilyInstanceCreationFailure" xml:space="preserve">
-        <value>Could not create the FamilyInstance</value>
-    </data>
-    <data name="FamilyNotFound" xml:space="preserve">
-        <value>A family with the specified name, {0}, could not be found in the document.</value>
-    </data>
-    <data name="FamilySymbolNotFound1" xml:space="preserve">
-        <value>A FamilySymbol with the specified name does not exist in the document.</value>
-    </data>
-    <data name="FamilySymbolNotFound2" xml:space="preserve">
-        <value>A FamilySymbol with the specified name, {0}, does not exist in the Family.</value>
-    </data>
-    <data name="FamilySymbolNotFound3" xml:space="preserve">
-        <value>A FamilySymbol with the specified name, {0}, does not exist in the document.</value>
-    </data>
-    <data name="FamilyTypeDoesNotExist" xml:space="preserve">
-        <value>Family type does not exist in the document.</value>
-    </data>
-    <data name="FileNotFound" xml:space="preserve">
-        <value>The file could not be found at: {0}</value>
-    </data>
-    <data name="FloorTypeNotFound" xml:space="preserve">
-        <value>A Revit FloorType with that name could not be located in the document.</value>
-    </data>
-    <data name="GeometryConversionFailure" xml:space="preserve">
-        <value>One or more geometries have failed to convert due to this error: </value>
-    </data>
-    <data name="GeometryObjectReferenceFailure" xml:space="preserve">
-        <value>Could not get a geometry object from the current document using the provided reference</value>
-    </data>
-    <data name="GridCreationFailure" xml:space="preserve">
-        <value>A Grid Element can only be created in a Revit Project.</value>
-    </data>
-    <data name="InputParamsMismatch" xml:space="preserve">
-        <value>The input list of parameters does not have the same number of values required by the adaptive component.</value>
-    </data>
-    <data name="InputPointParamsMismatch" xml:space="preserve">
-        <value>The input list of points does not have the same number of values required by the adaptive component.</value>
-    </data>
-    <data name="InputUVParamsMismatch" xml:space="preserve">
-        <value>The input list of UVs does not have the same number of values required by the adaptive component.</value>
-    </data>
-    <data name="InstanceImportFailure" xml:space="preserve">
-        <value>Could not obtain ImportInstance from imported Element</value>
-    </data>
-    <data name="InvalidCategory" xml:space="preserve">
-        <value>The selected category is not valid in this document.</value>
-    </data>
-    <data name="InvalidColumnBaseLocation" xml:space="preserve">
-        <value>The end of the curve for creating a column should be above the start of the curve.</value>
-    </data>
-    <data name="InvalidElementId" xml:space="preserve">
-        <value>Id is not a valid ElementId, GUID, string or int.</value>
-    </data>
-    <data name="InvalidElementLocation" xml:space="preserve">
-        <value>The location of the structural element is not a valid curve.</value>
-    </data>
-    <data name="InvalidEndPointList" xml:space="preserve">
-        <value>Invalid end point list</value>
-    </data>
-    <data name="InvalidFace" xml:space="preserve">
-        <value>The selected face cannot be used to create a wall. Please use a mass face instead.</value>
-    </data>
-    <data name="InvalidFilterType" xml:space="preserve">
-        <value>FilterType is not valid.</value>
-    </data>
-    <data name="InvalidGroupType" xml:space="preserve">
-        <value>{0} is not a valid GroupType.</value>
-    </data>
-    <data name="InvalidHost" xml:space="preserve">
-        <value>Element does not have a host.</value>
-    </data>
-    <data name="InvalidShapeEditor" xml:space="preserve">
-        <value>Floor Shape cannot be edited.</value>
-    </data>
-    <data name="InvalidStartPointList" xml:space="preserve">
-        <value>Invalid start point list.</value>
-    </data>
-    <data name="InvalidSwitchJoinOrder" xml:space="preserve">
-        <value>Geometry join order can only be switched when the elements are already joined.</value>
-    </data>
-    <data name="InvalidView" xml:space="preserve">
-        <value>Invalid view.</value>
-    </data>
-    <data name="InvalidWallHeight" xml:space="preserve">
-        <value>The height must be greater than 0 and less that 30000 ft.  You provided a height of {0} ft.</value>
-    </data>
-    <data name="MaterialNotFound" xml:space="preserve">
-        <value>A Material with the given name does not exist in the current Document.</value>
-    </data>
-    <data name="ModelTextCreationFailure" xml:space="preserve">
-        <value>ModelText Elements can only be created in a Family Document.</value>
-    </data>
-    <data name="ModelTextTypeNotFound" xml:space="preserve">
-        <value>There is no ModelTextType of the name, {0}, in the current Document.</value>
-    </data>
-    <data name="MullionParseError" xml:space="preserve">
-        <value>Mullion should represent Revit's Mullion.</value>
-    </data>
-    <data name="MultipleCurvesIntroducedAfterConversion" xml:space="preserve">
-        <value>There are multiple curves converted from the input curve element.</value>
-    </data>
-    <data name="MultipleSurfacesIntroducedAfterConversion" xml:space="preserve">
-        <value>There are multiple surfaces converted from the input face.</value>
-    </data>
-    <data name="NameAlreadyInUse" xml:space="preserve">
-        <value>Name already in use.</value>
-    </data>
-    <data name="NameArgumentException" xml:space="preserve">
-        <value>You must supply a Name.</value>
-    </data>
-    <data name="NoChildElements" xml:space="preserve">
-        <value>Element has no child Elements</value>
-    </data>
-    <data name="NoElementsToPurge" xml:space="preserve">
-        <value>No Elements to purge in the current document.</value>
-    </data>
-    <data name="NonIntersectingElements" xml:space="preserve">
-        <value>Elements are not intersecting</value>
-    </data>
-    <data name="NoParentElement" xml:space="preserve">
-        <value>Element has no parent component</value>
-    </data>
-    <data name="NoSharedParameterFileFound" xml:space="preserve">
-        <value>No shared parameter file found.</value>
-    </data>
-    <data name="NoStructuralMaterialAssigned" xml:space="preserve">
-        <value>FloorType has no structural material assigned</value>
-    </data>
-    <data name="NotAdaptiveComponentError" xml:space="preserve">
-        <value>The FamilyInstance is not an adaptive component.</value>
-    </data>
-    <data name="NotBuiltInCategory" xml:space="preserve">
-        <value>Element not valid. Use an element from a BuiltInCategory.</value>
-    </data>
-    <data name="NotEnoughDataError" xml:space="preserve">
-        <value>You need at least two elements for a dimension.</value>
-    </data>
-    <data name="NotHostElement" xml:space="preserve">
-        <value>Element is not a Host Element</value>
-    </data>
-    <data name="NotJoinedElements" xml:space="preserve">
-        <value>Cannot unjoin Elements that are not already joined.</value>
-    </data>
-    <data name="NotPlanView" xml:space="preserve">
-        <value>The provided input view is not a plan view.</value>
-    </data>
-    <data name="NotPositiveIntegerError" xml:space="preserve">
-        <value>{0} must be a positive integer</value>
-    </data>
-    <data name="NullInputCurvesError" xml:space="preserve">
-        <value>Some of the input curves are null.</value>
-    </data>
-    <data name="NumberOfDivisionsMustBeGreaterThan2" xml:space="preserve">
-        <value>The number of divisions must be greater than 2!</value>
-    </data>
-    <data name="OpenInputPolyCurveError" xml:space="preserve">
-        <value>The input PolyCurve is not closed.</value>
-    </data>
-    <data name="ParameterGroupNotFound" xml:space="preserve">
-        <value>Invalid parameter group.</value>
-    </data>
-    <data name="ParameterNotFound" xml:space="preserve">
-        <value>No parameter found by that name.</value>
-    </data>
-    <data name="ParameterStorageNotElement" xml:space="preserve">
-        <value>The parameter's storage type is not an Element.</value>
-    </data>
-    <data name="ParameterStorageNotInteger" xml:space="preserve">
-        <value>The parameter's storage type is not an integer.</value>
-    </data>
-    <data name="ParameterStorageNotNumber" xml:space="preserve">
-        <value>The parameter's storage type is not a number.</value>
-    </data>
-    <data name="ParameterStorageNotString" xml:space="preserve">
-        <value>The parameter's storage type is not a string.</value>
-    </data>
-    <data name="ParameterTypeNotFound" xml:space="preserve">
-        <value>Invalid parameter type.</value>
-    </data>
-    <data name="ParameterWithoutStorageType" xml:space="preserve">
-        <value>Parameter {0} has no storage type.</value>
-    </data>
-    <data name="PointDataObsolete" xml:space="preserve">
-        <value>Use PointAnalysisDisplay.ByViewPointsAndValues instead.</value>
-    </data>
-    <data name="PointRequired" xml:space="preserve">
-        <value>Please supply a point geometry.</value>
-    </data>
-    <data name="PolyCurvesConversionError" xml:space="preserve">
-        <value>Revit does not support turning PolyCurves into ModelCurves. Try exploding your PolyCurve into multiple Curves.</value>
-    </data>
-    <data name="ReferenceCurveCreationFailure" xml:space="preserve">
-        <value>Revit can only create a ReferenceCurve in a Family Document.</value>
-    </data>
-    <data name="ReferencePointCreationFailure" xml:space="preserve">
-        <value>ReferencePoint Elements can only be created in a Family Document.</value>
-    </data>
-    <data name="RoofTypeNotFound" xml:space="preserve">
-        <value>Roof type not found.</value>
-    </data>
-    <data name="RoomsForLongestPathNotFound" xml:space="preserve">
-        <value>Rooms are required to compute longest Paths of Travel.</value>
-    </data>
-    <data name="SamplePointsMismatchError" xml:space="preserve">
-        <value>The number of sample points and number of samples must be the same.</value>
-    </data>
-    <data name="ScheduleExportError" xml:space="preserve">
-        <value>There was an error exporting this schedule.</value>
-    </data>
-    <data name="ScheduleTypeArgumentException" xml:space="preserve">
-        <value>Invalid Schedule Type.</value>
-    </data>
-    <data name="Sheet_NoViewsError" xml:space="preserve">
-        <value>Must supply more than 0 views</value>
-    </data>
-    <data name="StartEndListSizeMismatch" xml:space="preserve">
-        <value>Size of start point array doesn't match size of end point array</value>
-    </data>
-    <data name="StartPointListEmpty" xml:space="preserve">
-        <value>Start points list is empty</value>
-    </data>
-    <data name="StartPointListHasNulls" xml:space="preserve">
-        <value>Start point list contains null elements</value>
-    </data>
-    <data name="SurfaceDataObsolete" xml:space="preserve">
-        <value>Use FaceAnalysisDisplay.ByViewFacePointsAndValues instead.</value>
-    </data>
-    <data name="Tag_Lookup_Error" xml:space="preserve">
-        <value>A Revit face with the corresponding tag could not be found.</value>
-    </data>
-    <data name="TopographyNeedsThreePoints" xml:space="preserve">
-        <value>A minimum of three points is required to create a topography surface.</value>
-    </data>
-    <data name="TypeNotFound" xml:space="preserve">
-        <value>Type not found in document.</value>
-    </data>
-    <data name="VectorDataObsolete" xml:space="preserve">
-        <value>Use VectorAnalysisDisplay.ByViewPointsAndVectorValues instead.</value>
-    </data>
-    <data name="ViewAlreadyPlacedOnSheet" xml:space="preserve">
-        <value>Cannot place view on sheet as it is already on a sheet.</value>
-    </data>
-    <data name="ViewDoesNotSupportAnnotations" xml:space="preserve">
-        <value>View does not support annotations.</value>
-    </data>
-    <data name="ViewExportImageError" xml:space="preserve">
-        <value>There was an error exporting the image.</value>
-    </data>
-    <data name="ViewExportImageLockedError" xml:space="preserve">
-        <value>Attempt to override existing image failed due to file lock. Please make sure that image is not currently open in another application.</value>
-    </data>
-    <data name="ViewPlan_ViewFamilyNotFound" xml:space="preserve">
-        <value>Specified View Type could not be found.</value>
-    </data>
-    <data name="ViewUnsupportedScheduleType" xml:space="preserve">
-        <value>Provided Schedule Type is not supported.</value>
-    </data>
-    <data name="View_ExportAsImage_Path_Invalid" xml:space="preserve">
-        <value>The supplied path is invalid.</value>
-    </data>
-    <data name="WallTypeNotFound" xml:space="preserve">
-        <value>There is no WallType of the given name in the current Document.</value>
-    </data>
-    <data name="WrongStorageType" xml:space="preserve">
-        <value>Input value for this parameter needs to be of type {0}.</value>
-    </data>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Adaptive_Component_Creation_Failed" xml:space="preserve">
+    <value>An adaptive component could not be found or created.</value>
+  </data>
+  <data name="AnalysisResultsDefaultDescription" xml:space="preserve">
+    <value>Analysis Results from Dynamo</value>
+  </data>
+  <data name="AnalysisResultsDefaultName" xml:space="preserve">
+    <value>Dynamo Analysis Results</value>
+  </data>
+  <data name="AreaSchemeArgumentException" xml:space="preserve">
+    <value>You must supply an Area Scheme.</value>
+  </data>
+  <data name="Array_Count_Mismatch" xml:space="preserve">
+    <value>The number of sample locations and samples is not equal.</value>
+  </data>
+  <data name="AttachedGroupLocation" xml:space="preserve">
+    <value>Cannot get location of attached group.</value>
+  </data>
+  <data name="CannotGetBaseOrSurveyPoint" xml:space="preserve">
+    <value>Cannot get base or survey point from document.</value>
+  </data>
+  <data name="CategoryArgumentException" xml:space="preserve">
+    <value>You must supply a Category.</value>
+  </data>
+  <data name="CategoryVisibilityOverrideError" xml:space="preserve">
+    <value>Specified View Template is not valid for this View.</value>
+  </data>
+  <data name="CellForPanelNotFound" xml:space="preserve">
+    <value>Could not find cell for panel</value>
+  </data>
+  <data name="ChildElementsNotSupported" xml:space="preserve">
+    <value>Getting child elements is not supported for this type of Element.</value>
+  </data>
+  <data name="CurtainGridNotFound" xml:space="preserve">
+    <value>Element has no Curtain Grid.</value>
+  </data>
+  <data name="CurtainGridReferenceError" xml:space="preserve">
+    <value>Reference should be to Face of the Element.</value>
+  </data>
+  <data name="CurtainPanelInternalElementError" xml:space="preserve">
+    <value>InternalElement of Curtain Panel is not Panel.</value>
+  </data>
+  <data name="CurtainPanelIsNotPlanar" xml:space="preserve">
+    <value>Curtain Panel is not planar</value>
+  </data>
+  <data name="CurtainPanelIsNotRectangular" xml:space="preserve">
+    <value>Curtain Panel is not rectangular</value>
+  </data>
+  <data name="CurtainPanelShouldRepresentRevitPanel" xml:space="preserve">
+    <value>Curtain Panel should represent Revit panel</value>
+  </data>
+  <data name="CurtainSystemTypeNotFound" xml:space="preserve">
+    <value>Curtain System Type not found.</value>
+  </data>
+  <data name="CurveIsNotPlanar" xml:space="preserve">
+    <value>Curve ist not planar. Please supply a planar curve.</value>
+  </data>
+  <data name="CurveLoopNotClosed" xml:space="preserve">
+    <value>Curves do not form a closed loop.</value>
+  </data>
+  <data name="CurveNeedsTwoPoints" xml:space="preserve">
+    <value>Cannot create Curve By Points with less than two points.</value>
+  </data>
+  <data name="CurveReferenceExtractionDetail" xml:space="preserve">
+    <value>You supplied an {0}, but we could not extract a CurveReference from it!</value>
+  </data>
+  <data name="CurveReferenceExtractionFailure" xml:space="preserve">
+    <value>{0} requires a ElementCurveReference extracted from a Revit Element! </value>
+  </data>
+  <data name="CurveReferenceFailure" xml:space="preserve">
+    <value>A Curve Reference can only be obtained from an Element.</value>
+  </data>
+  <data name="CurveReferenceHint" xml:space="preserve">
+    <value>You can use the {0} or {1} to turn this Curve into a Revit Element.</value>
+  </data>
+  <data name="CurveRequired" xml:space="preserve">
+    <value>Please supply a curve geometry.</value>
+  </data>
+  <data name="DirectShapeInvalidArgument" xml:space="preserve">
+    <value>Can only create DirectShapes from Solids, Surfaces or Meshes.</value>
+  </data>
+  <data name="DocumentDoesNotSupportGlobalParams" xml:space="preserve">
+    <value>Document does not support global parameters.</value>
+  </data>
+  <data name="DocumentNotFamilyDocument" xml:space="preserve">
+    <value>Document is not a valid Family Document.</value>
+  </data>
+  <data name="DocumentNotWorkshared" xml:space="preserve">
+    <value>Current Document is not workshared</value>
+  </data>
+  <data name="DynamoSolidToRevitBRepFailure" xml:space="preserve">
+    <value>An unexpected failure occurred when attempting to convert the solid into a Revit BRep</value>
+  </data>
+  <data name="DynamoSurfaceToRevitBRepFailure" xml:space="preserve">
+    <value>An unexpected failure occurred when attempting to convert the surface into a Revit BRep</value>
+  </data>
+  <data name="Dynamo_AVF_Data_Name" xml:space="preserve">
+    <value>Dynamo Data</value>
+  </data>
+  <data name="ElementCannotBeAnnotatedError" xml:space="preserve">
+    <value>Element cannot be annotated</value>
+  </data>
+  <data name="ElementTypeNameNotFound" xml:space="preserve">
+    <value>There is no ElementType of the given name in the current Document</value>
+  </data>
+  <data name="EmptyView" xml:space="preserve">
+    <value>Cannot place empty view on sheet.</value>
+  </data>
+  <data name="EndPointListEmpty" xml:space="preserve">
+    <value>End point list is empty</value>
+  </data>
+  <data name="EndPointListHasNulls" xml:space="preserve">
+    <value>End point list contains null elements</value>
+  </data>
+  <data name="ExportOptionsArgumentException" xml:space="preserve">
+    <value>Invalid Schedule Export Options.</value>
+  </data>
+  <data name="FaceReferenceExtractionDetail" xml:space="preserve">
+    <value>You supplied an {0}, but we could not extract a ElementFaceReference from it!</value>
+  </data>
+  <data name="FaceReferenceExtractionFailure" xml:space="preserve">
+    <value>{0} requires a ElementFaceReference extracted from a Revit Element! </value>
+  </data>
+  <data name="FaceReferenceFailure" xml:space="preserve">
+    <value>A Face Reference can only be obtained from an Element.</value>
+  </data>
+  <data name="FaceReferenceHint" xml:space="preserve">
+    <value>You can use the {0} to turn this Surface into a Revit Element, then extract a ElementFaceReference from it.</value>
+  </data>
+  <data name="FamilyInstanceCreationFailure" xml:space="preserve">
+    <value>Could not create the FamilyInstance</value>
+  </data>
+  <data name="FamilyNotFound" xml:space="preserve">
+    <value>A family with the specified name, {0}, could not be found in the document.</value>
+  </data>
+  <data name="FamilySymbolNotFound1" xml:space="preserve">
+    <value>A FamilySymbol with the specified name does not exist in the document.</value>
+  </data>
+  <data name="FamilySymbolNotFound2" xml:space="preserve">
+    <value>A FamilySymbol with the specified name, {0}, does not exist in the Family.</value>
+  </data>
+  <data name="FamilySymbolNotFound3" xml:space="preserve">
+    <value>A FamilySymbol with the specified name, {0}, does not exist in the document.</value>
+  </data>
+  <data name="FamilyTypeDoesNotExist" xml:space="preserve">
+    <value>Family type does not exist in the document.</value>
+  </data>
+  <data name="FileNotFound" xml:space="preserve">
+    <value>The file could not be found at: {0}</value>
+  </data>
+  <data name="FloorTypeNotFound" xml:space="preserve">
+    <value>A Revit FloorType with that name could not be located in the document.</value>
+  </data>
+  <data name="GeometryConversionFailure" xml:space="preserve">
+    <value>One or more geometries have failed to convert due to this error: </value>
+  </data>
+  <data name="GeometryObjectReferenceFailure" xml:space="preserve">
+    <value>Could not get a geometry object from the current document using the provided reference</value>
+  </data>
+  <data name="GridCreationFailure" xml:space="preserve">
+    <value>A Grid Element can only be created in a Revit Project.</value>
+  </data>
+  <data name="InputParamsMismatch" xml:space="preserve">
+    <value>The input list of parameters does not have the same number of values required by the adaptive component.</value>
+  </data>
+  <data name="InputPointParamsMismatch" xml:space="preserve">
+    <value>The input list of points does not have the same number of values required by the adaptive component.</value>
+  </data>
+  <data name="InputUVParamsMismatch" xml:space="preserve">
+    <value>The input list of UVs does not have the same number of values required by the adaptive component.</value>
+  </data>
+  <data name="InstanceImportFailure" xml:space="preserve">
+    <value>Could not obtain ImportInstance from imported Element</value>
+  </data>
+  <data name="InvalidCategory" xml:space="preserve">
+    <value>The selected category is not valid in this document.</value>
+  </data>
+  <data name="InvalidColumnBaseLocation" xml:space="preserve">
+    <value>The end of the curve for creating a column should be above the start of the curve.</value>
+  </data>
+  <data name="InvalidElementId" xml:space="preserve">
+    <value>Id is not a valid ElementId, GUID, string or int.</value>
+  </data>
+  <data name="InvalidElementLocation" xml:space="preserve">
+    <value>The location of the structural element is not a valid curve.</value>
+  </data>
+  <data name="InvalidEndPointList" xml:space="preserve">
+    <value>Invalid end point list</value>
+  </data>
+  <data name="InvalidFace" xml:space="preserve">
+    <value>The selected face cannot be used to create a wall. Please use a mass face instead.</value>
+  </data>
+  <data name="InvalidFilterType" xml:space="preserve">
+    <value>FilterType is not valid.</value>
+  </data>
+  <data name="InvalidGroupType" xml:space="preserve">
+    <value>{0} is not a valid GroupType.</value>
+  </data>
+  <data name="InvalidHost" xml:space="preserve">
+    <value>Element does not have a host.</value>
+  </data>
+  <data name="InvalidShapeEditor" xml:space="preserve">
+    <value>Floor Shape cannot be edited.</value>
+  </data>
+  <data name="InvalidStartPointList" xml:space="preserve">
+    <value>Invalid start point list.</value>
+  </data>
+  <data name="InvalidSwitchJoinOrder" xml:space="preserve">
+    <value>Geometry join order can only be switched when the elements are already joined.</value>
+  </data>
+  <data name="InvalidView" xml:space="preserve">
+    <value>Invalid view.</value>
+  </data>
+  <data name="InvalidWallHeight" xml:space="preserve">
+    <value>The height must be greater than 0 and less that 30000 ft.  You provided a height of {0} ft.</value>
+  </data>
+  <data name="MaterialNotFound" xml:space="preserve">
+    <value>A Material with the given name does not exist in the current Document.</value>
+  </data>
+  <data name="ModelTextCreationFailure" xml:space="preserve">
+    <value>ModelText Elements can only be created in a Family Document.</value>
+  </data>
+  <data name="ModelTextTypeNotFound" xml:space="preserve">
+    <value>There is no ModelTextType of the name, {0}, in the current Document.</value>
+  </data>
+  <data name="MullionParseError" xml:space="preserve">
+    <value>Mullion should represent Revit's Mullion.</value>
+  </data>
+  <data name="MultipleCurvesIntroducedAfterConversion" xml:space="preserve">
+    <value>There are multiple curves converted from the input curve element.</value>
+  </data>
+  <data name="MultipleSurfacesIntroducedAfterConversion" xml:space="preserve">
+    <value>There are multiple surfaces converted from the input face.</value>
+  </data>
+  <data name="NameAlreadyInUse" xml:space="preserve">
+    <value>Name already in use.</value>
+  </data>
+  <data name="NameArgumentException" xml:space="preserve">
+    <value>You must supply a Name.</value>
+  </data>
+  <data name="NoChildElements" xml:space="preserve">
+    <value>Element has no child Elements</value>
+  </data>
+  <data name="NoElementsToPurge" xml:space="preserve">
+    <value>No Elements to purge in the current document.</value>
+  </data>
+  <data name="NonIntersectingElements" xml:space="preserve">
+    <value>Elements are not intersecting</value>
+  </data>
+  <data name="NoParentElement" xml:space="preserve">
+    <value>Element has no parent component</value>
+  </data>
+  <data name="NoSharedParameterFileFound" xml:space="preserve">
+    <value>No shared parameter file found.</value>
+  </data>
+  <data name="NoStructuralMaterialAssigned" xml:space="preserve">
+    <value>FloorType has no structural material assigned</value>
+  </data>
+  <data name="NotAdaptiveComponentError" xml:space="preserve">
+    <value>The FamilyInstance is not an adaptive component.</value>
+  </data>
+  <data name="NotBuiltInCategory" xml:space="preserve">
+    <value>Element not valid. Use an element from a BuiltInCategory.</value>
+  </data>
+  <data name="NotEnoughDataError" xml:space="preserve">
+    <value>You need at least two elements for a dimension.</value>
+  </data>
+  <data name="NotHostElement" xml:space="preserve">
+    <value>Element is not a Host Element</value>
+  </data>
+  <data name="NotJoinedElements" xml:space="preserve">
+    <value>Cannot unjoin Elements that are not already joined.</value>
+  </data>
+  <data name="NotPlanView" xml:space="preserve">
+    <value>The provided input view is not a plan view.</value>
+  </data>
+  <data name="NotPositiveIntegerError" xml:space="preserve">
+    <value>{0} must be a positive integer</value>
+  </data>
+  <data name="NullInputCurvesError" xml:space="preserve">
+    <value>Some of the input curves are null.</value>
+  </data>
+  <data name="NumberOfDivisionsMustBeGreaterThan2" xml:space="preserve">
+    <value>The number of divisions must be greater than 2!</value>
+  </data>
+  <data name="OpenInputPolyCurveError" xml:space="preserve">
+    <value>The input PolyCurve is not closed.</value>
+  </data>
+  <data name="ParameterGroupNotFound" xml:space="preserve">
+    <value>Invalid parameter group.</value>
+  </data>
+  <data name="ParameterNotFound" xml:space="preserve">
+    <value>No parameter found by that name.</value>
+  </data>
+  <data name="ParameterStorageNotElement" xml:space="preserve">
+    <value>The parameter's storage type is not an Element.</value>
+  </data>
+  <data name="ParameterStorageNotInteger" xml:space="preserve">
+    <value>The parameter's storage type is not an integer.</value>
+  </data>
+  <data name="ParameterStorageNotNumber" xml:space="preserve">
+    <value>The parameter's storage type is not a number.</value>
+  </data>
+  <data name="ParameterStorageNotString" xml:space="preserve">
+    <value>The parameter's storage type is not a string.</value>
+  </data>
+  <data name="ParameterTypeNotFound" xml:space="preserve">
+    <value>Invalid parameter type.</value>
+  </data>
+  <data name="ParameterWithoutStorageType" xml:space="preserve">
+    <value>Parameter {0} has no storage type.</value>
+  </data>
+  <data name="PointDataObsolete" xml:space="preserve">
+    <value>Use PointAnalysisDisplay.ByViewPointsAndValues instead.</value>
+  </data>
+  <data name="PointRequired" xml:space="preserve">
+    <value>Please supply a point geometry.</value>
+  </data>
+  <data name="PolyCurvesConversionError" xml:space="preserve">
+    <value>Revit does not support turning PolyCurves into ModelCurves. Try exploding your PolyCurve into multiple Curves.</value>
+  </data>
+  <data name="ReferenceCurveCreationFailure" xml:space="preserve">
+    <value>Revit can only create a ReferenceCurve in a Family Document.</value>
+  </data>
+  <data name="ReferencePointCreationFailure" xml:space="preserve">
+    <value>ReferencePoint Elements can only be created in a Family Document.</value>
+  </data>
+  <data name="RoofTypeNotFound" xml:space="preserve">
+    <value>Roof type not found.</value>
+  </data>
+  <data name="RoomsForLongestPathNotFound" xml:space="preserve">
+    <value>Rooms are required to compute longest Paths of Travel.</value>
+  </data>
+  <data name="SamplePointsMismatchError" xml:space="preserve">
+    <value>The number of sample points and number of samples must be the same.</value>
+  </data>
+  <data name="ScheduleExportError" xml:space="preserve">
+    <value>There was an error exporting this schedule.</value>
+  </data>
+  <data name="ScheduleTypeArgumentException" xml:space="preserve">
+    <value>Invalid Schedule Type.</value>
+  </data>
+  <data name="Sheet_NoViewsError" xml:space="preserve">
+    <value>Must supply more than 0 views</value>
+  </data>
+  <data name="StartEndListSizeMismatch" xml:space="preserve">
+    <value>Size of start point array doesn't match size of end point array</value>
+  </data>
+  <data name="StartPointListEmpty" xml:space="preserve">
+    <value>Start points list is empty</value>
+  </data>
+  <data name="StartPointListHasNulls" xml:space="preserve">
+    <value>Start point list contains null elements</value>
+  </data>
+  <data name="SurfaceDataObsolete" xml:space="preserve">
+    <value>Use FaceAnalysisDisplay.ByViewFacePointsAndValues instead.</value>
+  </data>
+  <data name="Tag_Lookup_Error" xml:space="preserve">
+    <value>A Revit face with the corresponding tag could not be found.</value>
+  </data>
+  <data name="TopographyNeedsThreePoints" xml:space="preserve">
+    <value>A minimum of three points is required to create a topography surface.</value>
+  </data>
+  <data name="TypeNotFound" xml:space="preserve">
+    <value>Type not found in document.</value>
+  </data>
+  <data name="VectorDataObsolete" xml:space="preserve">
+    <value>Use VectorAnalysisDisplay.ByViewPointsAndVectorValues instead.</value>
+  </data>
+  <data name="ViewAlreadyPlacedOnSheet" xml:space="preserve">
+    <value>Cannot place view on sheet as it is already on a sheet.</value>
+  </data>
+  <data name="ViewDoesNotSupportAnnotations" xml:space="preserve">
+    <value>View does not support annotations.</value>
+  </data>
+  <data name="ViewExportImageError" xml:space="preserve">
+    <value>There was an error exporting the image.</value>
+  </data>
+  <data name="ViewExportImageLockedError" xml:space="preserve">
+    <value>Attempt to override existing image failed due to file lock. Please make sure that image is not currently open in another application.</value>
+  </data>
+  <data name="ViewPlan_ViewFamilyNotFound" xml:space="preserve">
+    <value>Specified View Type could not be found.</value>
+  </data>
+  <data name="ViewUnsupportedScheduleType" xml:space="preserve">
+    <value>Provided Schedule Type is not supported.</value>
+  </data>
+  <data name="View_ExportAsImage_Path_Invalid" xml:space="preserve">
+    <value>The supplied path is invalid.</value>
+  </data>
+  <data name="WallTypeNotFound" xml:space="preserve">
+    <value>There is no WallType of the given name in the current Document.</value>
+  </data>
+  <data name="WrongStorageType" xml:space="preserve">
+    <value>Input value for this parameter needs to be of type {0}.</value>
+  </data>
+  <data name="CloseInputPolyCurveError" xml:space="preserve">
+    <value>The input PolyCurve is closed.</value>
+  </data>
 </root>

--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="GroupTests.cs" />
     <Compile Include="PathOfTravelTests.cs" />
     <Compile Include="PerformanceAdviserTests.cs" />
+    <Compile Include="RoofTests.cs" />
     <Compile Include="RoofTypeTests.cs" />
     <Compile Include="SerializationTests.cs" />
     <Compile Include="SheetTests.cs" />

--- a/test/Libraries/RevitIntegrationTests/RoofTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RoofTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using NUnit.Framework;
+using RTF.Framework;
+using RevitTestServices;
+
+namespace RevitSystemTests
+{
+    [TestFixture]
+    class RoofTests : RevitSystemTestBase
+    {
+        [Test]
+        [TestModel(@".\empty.rvt")]
+        public void ByOutlineExtrusionTypeAndLevel()
+        {
+            string samplePath = Path.Combine(workingDirectory, @".\Roof\ByOutLineExtrusionTypeAndLevel.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+
+            RunCurrentModel();
+
+
+            var type = GetPreviewValue("9daa9b583bdf4659901779b540fdeecc");
+            Assert.AreEqual(type.GetType(), typeof(Revit.Elements.Roof));
+        }
+    }
+}

--- a/test/Libraries/RevitIntegrationTests/RoofTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RoofTests.cs
@@ -28,5 +28,21 @@ namespace RevitSystemTests
             var type = GetPreviewValue("9daa9b583bdf4659901779b540fdeecc");
             Assert.AreEqual(type.GetType(), typeof(Revit.Elements.Roof));
         }
+
+        [Test]
+        [TestModel(@".\empty.rvt")]
+        public void ByOutlineTypeAndLevel()
+        {
+            string samplePath = Path.Combine(workingDirectory, @".\Roof\ByOutlineTypeAndLevel.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+
+            RunCurrentModel();
+
+
+            var type = GetPreviewValue("c6d16ef7c551467a8d46cd307b2a465b");
+            Assert.AreEqual(type.GetType(), typeof(Revit.Elements.Roof));
+        }
     }
 }

--- a/test/System/Roof/ByOutLineExtrusionTypeAndLevel.dyn
+++ b/test/System/Roof/ByOutLineExtrusionTypeAndLevel.dyn
@@ -1,0 +1,533 @@
+{
+  "Uuid": "dc9882a6-4ef6-4a7f-8965-5c943962c341",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "ByOutLineExtrusionTypeAndLevel",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Autodesk.DesignScript.Geometry.PolyCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],bool",
+      "Id": "3969348aa77a4303a1fbfba21804428a",
+      "Inputs": [
+        {
+          "Id": "0ecf348cb4964f0b82cb77f3945ba207",
+          "Name": "points",
+          "Description": "Points to make polycurve\n\nPoint[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f6365ff0f23c4ec88242960e5c67df0f",
+          "Name": "connectLastToFirst",
+          "Description": "make close or open polycurve\n\nbool\nDefault value : false",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8f59161ac23b4e8ba9617135b0ae29fd",
+          "Name": "PolyCurve",
+          "Description": "PolyCurve",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Make PolyCurve by connecting points. Set the 'connectLastToFirst' input to true to close the PolyCurve.\n\nPolyCurve.ByPoints (points: Point[], connectLastToFirst: bool = false): PolyCurve"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Roof.ByOutlineExtrusionTypeAndLevel@Autodesk.DesignScript.Geometry.PolyCurve,Revit.Elements.RoofType,Revit.Elements.Level,Revit.Elements.ReferencePlane,double,double",
+      "Id": "9daa9b583bdf4659901779b540fdeecc",
+      "Inputs": [
+        {
+          "Id": "9aeb1080fdeb453a8cc2251682118e51",
+          "Name": "outline",
+          "Description": "PolyCurve",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "170bc28042634f299c367415a9ba0068",
+          "Name": "roofType",
+          "Description": "RoofType",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "579cdad1b334497ba9163ae76894c56b",
+          "Name": "level",
+          "Description": "Level",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "21b93114a35b4914a2d1fa428d8efe4a",
+          "Name": "plane",
+          "Description": "ReferencePlane",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "ff6e42df0e1448b68ca8dbbb9a2b0b45",
+          "Name": "extrusionStart",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b7fc932d6fdc4fd9aea5007e5b94f9c7",
+          "Name": "extrusionEnd",
+          "Description": "double",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "d4f6f48de6f242b6ae81cc3ecd8f9fb3",
+          "Name": "Roof",
+          "Description": "Roof",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Extrude Roof by Outline, Referenceplane\n\nRoof.ByOutlineExtrusionTypeAndLevel (outline: PolyCurve, roofType: RoofType, level: Level, plane: ReferencePlane, extrusionStart: double, extrusionEnd: double): Roof"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "Point.ByCoordinates(0,0,0);\nPoint.ByCoordinates(0,100,0);\nPoint.ByCoordinates(0,0,100);\nPoint.ByCoordinates(0,100,100);\ntrue;",
+      "Id": "be43060cdcff4cc0b96af2d9218006bf",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "92a9445c06c14979bb2356aa8cd49f44",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c054e9d8c41341ab8f4525b8de2a738e",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b790e72f83d348e086e038b96fb41170",
+          "Name": "",
+          "Description": "Value of expression at line 3",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b81cda2cf7494780ba0d3b213d019d45",
+          "Name": "",
+          "Description": "Value of expression at line 4",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "4b6f253e4fa04dd985ae26c160c23544",
+          "Name": "",
+          "Description": "Value of expression at line 5",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.CreateList, CoreNodeModels",
+      "VariableInputPorts": true,
+      "NodeType": "ExtensionNode",
+      "Id": "b00af734448b4a4ea516cb4b36c28a12",
+      "Inputs": [
+        {
+          "Id": "67f338006e434c819be8e338ae8394b1",
+          "Name": "item0",
+          "Description": "Item Index #0",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "876c2403fde54d14a141ea466cd4c0da",
+          "Name": "item1",
+          "Description": "Item Index #1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "16452c68701242fa8d3fbf1d82b45e56",
+          "Name": "item2",
+          "Description": "Item Index #2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a46324d790c34f46a1e3e065500de813",
+          "Name": "item3",
+          "Description": "Item Index #3",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "6a38d350ed2643adb7bc05a62a6013ad",
+          "Name": "list",
+          "Description": "A list",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Makes a new list out of the given inputs"
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.RoofTypes, DSRevitNodesUI",
+      "SelectedIndex": 0,
+      "SelectedString": "Roof_Flat-4Felt-150Ins-50Scr-150Conc-12Plr",
+      "NodeType": "ExtensionNode",
+      "Id": "b1e6e7fe4e214598a64a815d4230f80a",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "332b75cb411145cc9adec7f8da7d2572",
+          "Name": "Roof Types",
+          "Description": "The selected Roof Types",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "All roof types in the current document."
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.Levels, DSRevitNodesUI",
+      "SelectedIndex": 0,
+      "SelectedString": "Level 01 - B.O. Footing",
+      "NodeType": "ExtensionNode",
+      "Id": "10073855d30b48aba7bd5264b7811f06",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "23aab56d956345c8901e33478bfd81c1",
+          "Name": "Levels",
+          "Description": "The selected Levels",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Select a level in the active document"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "50.0;\n200.0;",
+      "Id": "b73294689834449a88b9d4be53300011",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "e2424d808078449f9602f53c7c1d3e87",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3adcc493f85b4b08a5e2f48d04d654ed",
+          "Name": "",
+          "Description": "Value of expression at line 2",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.ReferencePlane.ByStartPointEndPoint@Autodesk.DesignScript.Geometry.Point,Autodesk.DesignScript.Geometry.Point",
+      "Id": "da804445d5364561b9bf339ff140fedc",
+      "Inputs": [
+        {
+          "Id": "604ae3ca5ece44ef8f260fa83b9a1d8b",
+          "Name": "start",
+          "Description": "The location where the bubble will be located\n\nPoint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "bbe7e2582c1f46858b505509f330c6b7",
+          "Name": "end",
+          "Description": "The other end\n\nPoint",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "afcc03e2f8c0402ea756a108eab26d78",
+          "Name": "ReferencePlane",
+          "Description": "ReferencePlane",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Form a Refernece plane from two end points in the Active view. The cut vector is the Z Axis.\n\nReferencePlane.ByStartPointEndPoint (start: Point, end: Point): ReferencePlane"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "8f59161ac23b4e8ba9617135b0ae29fd",
+      "End": "9aeb1080fdeb453a8cc2251682118e51",
+      "Id": "8e10151a7b5e4afb984278c054e4006c"
+    },
+    {
+      "Start": "92a9445c06c14979bb2356aa8cd49f44",
+      "End": "67f338006e434c819be8e338ae8394b1",
+      "Id": "9d83d1f45def486f8a60e64f6850140b"
+    },
+    {
+      "Start": "92a9445c06c14979bb2356aa8cd49f44",
+      "End": "604ae3ca5ece44ef8f260fa83b9a1d8b",
+      "Id": "1825c1aa1ee54fbead3f1683d1e1422c"
+    },
+    {
+      "Start": "c054e9d8c41341ab8f4525b8de2a738e",
+      "End": "876c2403fde54d14a141ea466cd4c0da",
+      "Id": "3b4fcfac3de2428ba56f29c90981922f"
+    },
+    {
+      "Start": "c054e9d8c41341ab8f4525b8de2a738e",
+      "End": "bbe7e2582c1f46858b505509f330c6b7",
+      "Id": "2531f5c621584853b557159e9ec11bf6"
+    },
+    {
+      "Start": "b790e72f83d348e086e038b96fb41170",
+      "End": "a46324d790c34f46a1e3e065500de813",
+      "Id": "4956b093a62446cc8db693fd966859e1"
+    },
+    {
+      "Start": "b81cda2cf7494780ba0d3b213d019d45",
+      "End": "16452c68701242fa8d3fbf1d82b45e56",
+      "Id": "66129724728a4cdebf8004ffc97a5f07"
+    },
+    {
+      "Start": "6a38d350ed2643adb7bc05a62a6013ad",
+      "End": "0ecf348cb4964f0b82cb77f3945ba207",
+      "Id": "f0452348207045fcb2aaa2d44b528259"
+    },
+    {
+      "Start": "332b75cb411145cc9adec7f8da7d2572",
+      "End": "170bc28042634f299c367415a9ba0068",
+      "Id": "555feec429ba4305a9610680ff1854fb"
+    },
+    {
+      "Start": "23aab56d956345c8901e33478bfd81c1",
+      "End": "579cdad1b334497ba9163ae76894c56b",
+      "Id": "e9a7ff029c0d454fb8ba29a3c7f83b58"
+    },
+    {
+      "Start": "e2424d808078449f9602f53c7c1d3e87",
+      "End": "ff6e42df0e1448b68ca8dbbb9a2b0b45",
+      "Id": "c6bad52612af41d1adc4154861e84cfd"
+    },
+    {
+      "Start": "3adcc493f85b4b08a5e2f48d04d654ed",
+      "End": "b7fc932d6fdc4fd9aea5007e5b94f9c7",
+      "Id": "ee3ea80adb914ead8e3f31f11026d47c"
+    },
+    {
+      "Start": "afcc03e2f8c0402ea756a108eab26d78",
+      "End": "21b93114a35b4914a2d1fa428d8efe4a",
+      "Id": "d369c5ea3cce49f0a52a36c83718a680"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.5.2.7915",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "PolyCurve.ByPoints",
+        "Id": "3969348aa77a4303a1fbfba21804428a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 589.4302707268223,
+        "Y": 241.38270317308985
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Roof.ByOutlineExtrusionTypeAndLevel",
+        "Id": "9daa9b583bdf4659901779b540fdeecc",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1083.6432433470052,
+        "Y": 247.62270368498173
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "be43060cdcff4cc0b96af2d9218006bf",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 85.0,
+        "Y": 407.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "List Create",
+        "Id": "b00af734448b4a4ea516cb4b36c28a12",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 421.0,
+        "Y": 340.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Roof Types",
+        "Id": "b1e6e7fe4e214598a64a815d4230f80a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 567.0,
+        "Y": 446.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Levels",
+        "Id": "10073855d30b48aba7bd5264b7811f06",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 384.0,
+        "Y": 567.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "b73294689834449a88b9d4be53300011",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 561.0,
+        "Y": 675.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "ReferencePlane.ByStartPointEndPoint",
+        "Id": "da804445d5364561b9bf339ff140fedc",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 779.61405271206718,
+        "Y": 545.45297313207448
+      }
+    ],
+    "Annotations": [],
+    "X": -309.62286940759623,
+    "Y": -35.734858256428168,
+    "Zoom": 0.67900743610005732
+  }
+}

--- a/test/System/Roof/ByOutlineTypeAndLevel.dyn
+++ b/test/System/Roof/ByOutlineTypeAndLevel.dyn
@@ -1,0 +1,220 @@
+{
+  "Uuid": "21bd368f-6bc4-4452-9a37-b35b5d562eb8",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "ByOutlineTypeAndLevel",
+  "ElementResolver": {
+    "ResolutionMap": {
+      "Line": {
+        "Key": "Autodesk.DesignScript.Geometry.Line",
+        "Value": "ProtoGeometry.dll"
+      },
+      "Point": {
+        "Key": "Autodesk.DesignScript.Geometry.Point",
+        "Value": "ProtoGeometry.dll"
+      }
+    }
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Roof.ByOutlineTypeAndLevel@Autodesk.DesignScript.Geometry.Curve[],Revit.Elements.RoofType,Revit.Elements.Level",
+      "Id": "c6d16ef7c551467a8d46cd307b2a465b",
+      "Inputs": [
+        {
+          "Id": "8804e2ed1d3246a3a7937696c4259dca",
+          "Name": "outline",
+          "Description": "Curve[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e05c6c80f7b04cae981a6f8e0aab5164",
+          "Name": "roofType",
+          "Description": "RoofType",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a36803c023ae42bbacecff1843c19068",
+          "Name": "level",
+          "Description": "Level",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "67a929467a4545db9156a876a97ecda2",
+          "Name": "Roof",
+          "Description": "The Roof",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a Revit Roof given its curve outline and Level\n\nRoof.ByOutlineTypeAndLevel (outline: Curve[], roofType: RoofType, level: Level): Roof"
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.RoofTypes, DSRevitNodesUI",
+      "SelectedIndex": 0,
+      "SelectedString": "Generic - 12\"",
+      "NodeType": "ExtensionNode",
+      "Id": "f632a3a086664abeb2ff75560bf699e6",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "8afc41eea73547acba0d9e93fa5283fa",
+          "Name": "Roof Types",
+          "Description": "The selected Roof Types",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "All roof types in the current document."
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.Levels, DSRevitNodesUI",
+      "SelectedIndex": 0,
+      "SelectedString": "Level 1",
+      "NodeType": "ExtensionNode",
+      "Id": "a4078cc43ffe4f91a41ea8fbb2d45151",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "03aeff89305543e5afc92fe91284e409",
+          "Name": "Levels",
+          "Description": "The selected Levels",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Select a level in the active document"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "[Line.ByStartPointEndPoint(Point.ByCoordinates(0, 0, 0), Point.ByCoordinates(100, 0, 0)),\n                Line.ByStartPointEndPoint(Point.ByCoordinates(100, 0, 0), Point.ByCoordinates(100, 100, 0)),\n                Line.ByStartPointEndPoint(Point.ByCoordinates(100, 100, 0), Point.ByCoordinates(0, 100, 0)),\n                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 100, 0), Point.ByCoordinates(0, 0, 0))];",
+      "Id": "6f9423a2874a4de6a25761fb591f65d4",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "fd27a53b392a4d82a32c283b43a7ded4",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "8afc41eea73547acba0d9e93fa5283fa",
+      "End": "e05c6c80f7b04cae981a6f8e0aab5164",
+      "Id": "4ee87c31a6854a6daee1c41a04db7678"
+    },
+    {
+      "Start": "03aeff89305543e5afc92fe91284e409",
+      "End": "a36803c023ae42bbacecff1843c19068",
+      "Id": "537bbf0ecc194103b384e1ec5bf2fefb"
+    },
+    {
+      "Start": "fd27a53b392a4d82a32c283b43a7ded4",
+      "End": "8804e2ed1d3246a3a7937696c4259dca",
+      "Id": "20eb38206ace496d895e22b7570ae55a"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.5.2.7915",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Roof.ByOutlineTypeAndLevel",
+        "Id": "c6d16ef7c551467a8d46cd307b2a465b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 321.481082395398,
+        "Y": 78.990631184027279
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Roof Types",
+        "Id": "f632a3a086664abeb2ff75560bf699e6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -476.518917604602,
+        "Y": 126.99063118402728
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Levels",
+        "Id": "a4078cc43ffe4f91a41ea8fbb2d45151",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -476.518917604602,
+        "Y": 234.99063118402725
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "6f9423a2874a4de6a25761fb591f65d4",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -476.518917604602,
+        "Y": -42.796035482639383
+      }
+    ],
+    "Annotations": [],
+    "X": 273.53185178041542,
+    "Y": 168.21913264094957,
+    "Zoom": 0.97676875
+  }
+}


### PR DESCRIPTION
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

Fix Roof.ByOutlineExtrusionTypeAndLevel bug - the input outline should not be closed.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 

### FYIs

@QilongTang @mjkkirschner 
