### PR TITLE
Implemented Additional Elements for Warning.GetFailingElements

### DIFF
--- a/src/Libraries/RevitNodes/Application/Warning.cs
+++ b/src/Libraries/RevitNodes/Application/Warning.cs
@@ -63,9 +63,11 @@ namespace Revit.Application
         /// <returns>The elements that have caused the failure.</returns>
         public List<Element> GetFailingElements()
         {
-            return this.InternalWarning
-                .GetFailingElements()
-                .Select(x => DocumentManager.Instance.CurrentDBDocument.GetElement(x).ToDSType(true))
+            var doc = DocumentManager.Instance.CurrentDBDocument;
+            List<Autodesk.Revit.DB.ElementId> FailingElements = new List<Autodesk.Revit.DB.ElementId>(this.InternalWarning.GetFailingElements());
+            FailingElements.AddRange(this.InternalWarning.GetAdditionalElements());
+            return FailingElements
+                .Select(x => doc.GetElement(x).ToDSType(true))
                 .ToList();
         }
 


### PR DESCRIPTION
### Purpose
Due to Revit Warning also use “GetAdditionalElements” in HTML Warning Export. So we should implement Additional Elements for Warning nodes.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
