### PR TITLE
Improve d4r drop down nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Implemented Additional Elements for Warning.GetFailingElements
+* Add a listener for changes in Revit
+
 ## 0.2.13
 * Fix Roof.ByOutlineExtrusionTypeAndLevel bug - the input outline should not be closed.
 * Longest of shortest exit paths node

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -25,6 +25,9 @@ using Parameter = Autodesk.Revit.DB.Parameter;
 using Revit.Application;
 using System.Text.RegularExpressions;
 
+using RevitServices.Elements;
+using RevitServices.Transactions;
+
 namespace DSRevitNodesUI
 {
     public class DropDownItemEqualityComparer : IEqualityComparer<DynamoDropDownItem>
@@ -42,15 +45,16 @@ namespace DSRevitNodesUI
 
     public abstract class RevitDropDownBase : DSDropDownBase
     {
-
         protected RevitDropDownBase(string value) : base(value)
         {
+            RevitServicesUpdater.Instance.ElementsUpdated += Updater_ElementsUpdated;
             DynamoRevitApp.EventHandlerProxy.DocumentOpened += Controller_RevitDocumentChanged;
         }
 
         [JsonConstructor]
         public RevitDropDownBase(string value, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) : base(value, inPorts, outPorts)
         {
+            RevitServicesUpdater.Instance.ElementsUpdated += Updater_ElementsUpdated;
             DynamoRevitApp.EventHandlerProxy.DocumentOpened += Controller_RevitDocumentChanged;
         }
 
@@ -59,8 +63,29 @@ namespace DSRevitNodesUI
             PopulateItems();
         }
 
+        private void Updater_ElementsUpdated(object sender, ElementUpdateEventArgs e)
+        {
+            switch (e.Operation)
+            {
+                case ElementUpdateEventArgs.UpdateType.Added:
+                    break;
+                case ElementUpdateEventArgs.UpdateType.Modified:
+                    bool dynamoTransaction = e.Transactions.Contains(TransactionWrapper.TransactionName);
+                    if (!dynamoTransaction)
+                    {
+                        Updater_ElementsModified(e.GetUniqueIds());
+                    }
+                    break;
+                case ElementUpdateEventArgs.UpdateType.Deleted:
+                    break;
+                default:
+                    break;
+            }
+        }
+
         public override void Dispose()
         {
+            RevitServicesUpdater.Instance.ElementsUpdated -= Updater_ElementsUpdated;
             DynamoRevitApp.EventHandlerProxy.DocumentOpened -= Controller_RevitDocumentChanged;
             base.Dispose();
         }
@@ -80,6 +105,24 @@ namespace DSRevitNodesUI
             if (!string.IsNullOrEmpty(selectedValueToIgnore) && Items[SelectedIndex].Name == selectedValueToIgnore)
                 return false;
             return true;
+        }
+
+        void Updater_ElementsModified(IEnumerable<string> updated)
+        {
+            // If nothing has been updated, then return
+
+            if (!updated.Any())
+                return;
+
+            // If the updated list doesn't include any objects in the current selection
+            // then return;
+            if (!Items.Where(x => ((Element)(x.Item)).IsValidObject).Select(x => ((Element)(x.Item)).UniqueId).Any(updated.Contains))
+            {
+                return;
+            }
+
+            PopulateItems();
+            OnNodeModified(true);
         }
     }
 

--- a/src/Libraries/RevitNodesUI/SiteLocation.cs
+++ b/src/Libraries/RevitNodesUI/SiteLocation.cs
@@ -24,6 +24,7 @@ using Autodesk.Revit.DB.Events;
 using Dynamo.Applications;
 using Dynamo.Graph.Nodes;
 using BuiltinNodeCategories = Revit.Elements.BuiltinNodeCategories;
+using RevitServices.Transactions;
 
 namespace DSRevitNodesUI
 {
@@ -126,7 +127,9 @@ namespace DSRevitNodesUI
         {
             if (e.Operation != ElementUpdateEventArgs.UpdateType.Modified)
                 return;
-
+            bool dynamoTransaction = e.Transactions.Contains(TransactionWrapper.TransactionName);
+            if (dynamoTransaction)
+                return;
             var locUuid = DocumentManager.Instance.CurrentDBDocument.SiteLocation.UniqueId;
 
             if (e.GetUniqueIds().Contains(locUuid))

--- a/src/Libraries/RevitNodesUI/SunPath.cs
+++ b/src/Libraries/RevitNodesUI/SunPath.cs
@@ -13,6 +13,7 @@ using ProtoCore.AST.AssociativeAST;
 using RevitServices.Elements;
 using RevitServices.Persistence;
 using BuiltinNodeCategories = Revit.Elements.BuiltinNodeCategories;
+using RevitServices.Transactions;
 
 namespace DSRevitNodesUI
 {
@@ -67,6 +68,10 @@ namespace DSRevitNodesUI
         private void Updater_ElementsUpdated(object sender, ElementUpdateEventArgs e)
         {
             if (e.Operation != ElementUpdateEventArgs.UpdateType.Modified) return;
+
+            bool dynamoTransaction = e.Transactions.Contains(TransactionWrapper.TransactionName);
+            if (dynamoTransaction)
+                return;
 
             if (e.GetUniqueIds().Contains(settingsID))
             {


### PR DESCRIPTION

### Purpose

For DynamoRevit Dropdown Nodes, a mechanism to monitor Revit Element change is needed so that the nodes can follow the changes of Revit document.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 

### FYIs

@mjkkirschner @QilongTang 
