### PR TITLE
AGD-1513 Add SelectModelElementByCategory node to D4R to compliment the new SelectElementsByCategory node

### DIFF
--- a/src/DynamoRevitIcons/DSRevitNodesUIImages.resx
+++ b/src/DynamoRevitIcons/DSRevitNodesUIImages.resx
@@ -1067,7 +1067,7 @@
         XdgEcAGav/WlnhMvAaxRtX4IaIgLWvpd8Ap4BZLAreXrq3aEEENKFz3tboU9GTwaAAAAAElFTkSuQmCC
 </value>
     </data>
-    <data name="Dynamo.ComboNodes.DSModelElementByCategorySelection.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <data name="Dynamo.ComboNodes.DSModelElementsByCategorySelection.Large" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
         <value>
         iVBORw0KGgoAAAANSUhEUgAAAGEAAABhCAYAAADGBs+jAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
         YQUAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAcfSURBVHhe7ZxPaxVXGMb9CPkI/QjZCNra1kjA2rSpDS2W
@@ -1104,7 +1104,7 @@
         AABJRU5ErkJggg==
 </value>
     </data>
-    <data name="Dynamo.ComboNodes.DSModelElementByCategorySelection.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <data name="Dynamo.ComboNodes.DSModelElementsByCategorySelection.Small" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
         <value>
         iVBORw0KGgoAAAANSUhEUgAAACEAAAAhCAYAAABX5MJvAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
         YQUAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAJSSURBVFhHzZbNqxJhGMXvn+Cf4J/Qxp3QDfogbOVSo7KV

--- a/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
@@ -691,6 +691,15 @@ namespace DSRevitNodesUI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Select a model element from the Revit document filtered by Category..
+        /// </summary>
+        internal static string SelectModelElementByCategoryDescription {
+            get {
+                return ResourceManager.GetString("SelectModelElementByCategoryDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select a model element from the document..
         /// </summary>
         internal static string SelectModelElementDescription {

--- a/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
@@ -432,4 +432,8 @@
     <value>All view family types in the current document.</value>
     <comment>Description for View Family Types</comment>
   </data>
+  <data name="SelectModelElementByCategoryDescription" xml:space="preserve">
+    <value>Select a model element from the Revit document filtered by Category.</value>
+    <comment>Description for Select Model Element By Category</comment>
+  </data>
 </root>

--- a/src/Libraries/RevitNodesUI/Properties/Resources.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.resx
@@ -363,6 +363,10 @@
   <data name="SelectionIsDisabledDescription" xml:space="preserve">
     <value>Selection is disabled when Dynamo run is disabled.</value>
   </data>
+  <data name="SelectModelElementByCategoryDescription" xml:space="preserve">
+    <value>Select a model element from the Revit document filtered by Category.</value>
+    <comment>Description for Select Model Element By Category</comment>
+  </data>
   <data name="SelectModelElementDescription" xml:space="preserve">
     <value>Select a model element from the document.</value>
     <comment>Description for Select Model Element</comment>

--- a/src/Libraries/RevitNodesUI/SelectionCombo.cs
+++ b/src/Libraries/RevitNodesUI/SelectionCombo.cs
@@ -33,7 +33,7 @@ namespace Dynamo.ComboNodes
     NodeCategory(Revit.Elements.BuiltinNodeCategories.REVIT_SELECTION),
     NodeDescription("SelectModelElementsByCategoryDescription", typeof(DSRevitNodesUI.Properties.Resources)),
     IsDesignScriptCompatible]
-    public class DSModelElementByCategorySelection : ElementFilterSelection<Element>
+    public class DSModelElementsByCategorySelection : ElementFilterSelection<Element>
     {
         private const string message = "Select Model Elements";
         private const string prefix = "Element";
@@ -58,7 +58,7 @@ namespace Dynamo.ComboNodes
             }
         }
 
-        public DSModelElementByCategorySelection()
+        public DSModelElementsByCategorySelection()
             : base(
                 SelectionType.Many,
                 SelectionObjectType.None,
@@ -72,7 +72,7 @@ namespace Dynamo.ComboNodes
         }
 
         [JsonConstructor]
-        public DSModelElementByCategorySelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts,
+        public DSModelElementsByCategorySelection(IEnumerable<string> selectionIdentifier, IEnumerable<PortModel> inPorts,
             IEnumerable<PortModel> outPorts)
             : base(
                 SelectionType.Many,
@@ -98,12 +98,12 @@ namespace Dynamo.ComboNodes
 
     #region Node View Customization
 
-    public class DSModelElementByCategorySelectionNodeViewCustomization : INodeViewCustomization<DSModelElementByCategorySelection>
+    public class DSModelElementsByCategorySelectionNodeViewCustomization : INodeViewCustomization<DSModelElementsByCategorySelection>
     {
-        public DSModelElementByCategorySelection Model { get; set; }
+        public DSModelElementsByCategorySelection Model { get; set; }
         public DelegateCommand SelectCommand { get; set; }
 
-        public void CustomizeView(DSModelElementByCategorySelection model, NodeView nodeView)
+        public void CustomizeView(DSModelElementsByCategorySelection model, NodeView nodeView)
         {
             Model = model;
             SelectCommand = new DelegateCommand(() => Model.Select(null), Model.CanBeginSelect);

--- a/test/Libraries/RevitIntegrationTests/SelectionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/SelectionTests.cs
@@ -620,6 +620,14 @@ namespace RevitSystemTests
             OpenAndAssertNoDummyNodes(Path.Combine(workingDirectory, @".\Selection\SelectModelElementsByCategory.dyn"));
             TestMultipleCategorySelection<Element, Element>();
         }
+
+        [Test]
+        [TestModel(@".\Selection\DynamoSample.rvt")]
+        public void SelectModelElementByCategory()
+        {
+            OpenAndAssertNoDummyNodes(Path.Combine(workingDirectory, @".\Selection\SelectModelElementByCategory.dyn"));
+            TestMultipleCategorySelection<Element, Element>();
+        }
  
         [Test]
         [TestModel(@".\SampleModel.rvt")]

--- a/test/System/Selection/SelectModelElementByCategory.dyn
+++ b/test/System/Selection/SelectModelElementByCategory.dyn
@@ -1,0 +1,76 @@
+{
+  "Uuid": "1d5146c5-fb96-4581-9213-894aaef18cff",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "SelectModelElementByCategory",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.ComboNodes.DSModelElementByCategorySelection, DSRevitNodesUI",
+      "NodeType": "ExtensionNode",
+      "InstanceId": [
+        "ef57b02a-5e81-49e7-93bb-ae5f002d921c-00030826"
+      ],
+      "Id": "25141fda2c244924845cfe500289447d",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "92367b3f6ed043538c183496e31924fb",
+          "Name": "Element",
+          "Description": "The selected elements.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.6.0.7733",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Select Model Element By Category",
+        "Id": "25141fda2c244924845cfe500289447d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 145.33333333333331,
+        "Y": 241.33333333333331
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}

--- a/test/System/Selection/SelectModelElementsByCategory.dyn
+++ b/test/System/Selection/SelectModelElementsByCategory.dyn
@@ -10,7 +10,7 @@
   "Outputs": [],
   "Nodes": [
     {
-      "ConcreteType": "Dynamo.ComboNodes.DSModelElementByCategorySelection, DSRevitNodesUI",
+      "ConcreteType": "Dynamo.ComboNodes.DSModelElementsByCategorySelection, DSRevitNodesUI",
       "NodeType": "ExtensionNode",
       "InstanceId": [
         "ef57b02a-5e81-49e7-93bb-ae5f002d921c-00030826",


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/AGD-1526

SelectModelElementByCategoryNode exists in DynamoRevit that works similar to the plural version but follows the singular selection UX.

![Screen Shot 2020-05-21 at 3 28 13 PM](https://user-images.githubusercontent.com/2145751/82598439-ad0e5580-9b78-11ea-973b-430c5ef6c125.png)
### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@SHKnudsen @AndyDu1985 @ZiyunShang 

### FYIs

@radumg @mjkkirschner 
