### PR TITLE
Material structural parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix a bug - filter out unavailable Parameters from Material.
+
 ## 0.2.18
 * Add a Category ScheduleOnSheet and its nodes - ScheduleOnSheet.Sheet, ScheduleOnSheet.Schedule, ScheduleOnSheet.BySheetViewLocation, ScheduleOnSheet.Location and ScheduleOnSheet.SetLocation
 * Add some new nodes for Sheet - Sheet.Schedules, Sheet.Viewports, Sheet.TitleBlock, Sheet.SetSheetName, Sheet.SetSheetNumber

--- a/src/Libraries/RevitNodes/Elements/Material.cs
+++ b/src/Libraries/RevitNodes/Elements/Material.cs
@@ -204,13 +204,7 @@ namespace Revit.Elements
                     Autodesk.Revit.DB.AppearanceAssetElement appearance = document.GetElement(this.InternalMaterial.AppearanceAssetId) as Autodesk.Revit.DB.AppearanceAssetElement;
                     if (appearance != null)
                     {
-                        foreach (var parameter in appearance.Parameters)
-                        {
-                            Parameter p = new Parameter(parameter as Autodesk.Revit.DB.Parameter);
-                            if (!appearances.Contains(p) && p.InternalParameter.Definition != null) appearances.Add(p);
-                            if (!invalidAppearances.Contains(p) && p.InternalParameter.Definition == null)
-                                invalidAppearances.Add(p);
-                        }
+                        GetValidParameter(appearance.Parameters, ref appearances, ref invalidAppearances);
                     }
                 }
 #if DEBUG
@@ -243,13 +237,7 @@ namespace Revit.Elements
                     Autodesk.Revit.DB.PropertySetElement thermal = document.GetElement(this.InternalMaterial.ThermalAssetId) as Autodesk.Revit.DB.PropertySetElement;
                     if (thermal != null)
                     {
-                        foreach (var parameter in thermal.Parameters)
-                        {
-                            Parameter p = new Parameter(parameter as Autodesk.Revit.DB.Parameter);
-                            if (!thermals.Contains(p) && p.InternalParameter.Definition != null) thermals.Add(p);
-                            if (!invalidThermals.Contains(p) && p.InternalParameter.Definition == null)
-                                invalidThermals.Add(p);
-                        }
+                        GetValidParameter(thermal.Parameters, ref thermals, ref invalidThermals);
                     }
                 }
 
@@ -284,13 +272,7 @@ namespace Revit.Elements
                     Autodesk.Revit.DB.PropertySetElement structural = document.GetElement(this.InternalMaterial.StructuralAssetId) as Autodesk.Revit.DB.PropertySetElement;
                     if (structural != null)
                     {
-                        foreach (var parameter in structural.Parameters)
-                        {
-                            Parameter p = new Parameter(parameter as Autodesk.Revit.DB.Parameter);
-                            if (!structurals.Contains(p) && p.InternalParameter.Definition != null) structurals.Add(p);
-                            if (!invalidStructurals.Contains(p) && p.InternalParameter.Definition == null)
-                                invalidStructurals.Add(p);
-                        }
+                        GetValidParameter(structural.Parameters, ref structurals, ref invalidStructurals);
                     }
                 }
 #if DEBUG
@@ -321,6 +303,22 @@ namespace Revit.Elements
         private DSCore.Color ToDSColor(Autodesk.Revit.DB.Color color)
         {
             return DSCore.Color.ByARGB(255, color.Red, color.Green, color.Blue);
+        }
+
+        private void GetValidParameter(Autodesk.Revit.DB.ParameterSet parameters, ref List<Parameter> ValidParameters, ref List<Parameter> InvalidParameters)
+        {
+            foreach (var parameter in parameters)
+            {
+                Parameter p = new Parameter(parameter as Autodesk.Revit.DB.Parameter);
+                if (p.InternalParameter.Definition == null)
+                {
+                    if (!InvalidParameters.Contains(p))
+                        InvalidParameters.Add(p);
+                    continue;
+                }
+                if (!ValidParameters.Contains(p))
+                    ValidParameters.Add(p);
+            }                
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/Material.cs
+++ b/src/Libraries/RevitNodes/Elements/Material.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DynamoServices;
 using RevitServices.Persistence;
+using System.Diagnostics;
 
 namespace Revit.Elements
 {
@@ -251,6 +252,7 @@ namespace Revit.Elements
                 Autodesk.Revit.DB.Document document = DocumentManager.Instance.CurrentDBDocument;
 
                 List<Parameter> structurals = new List<Parameter>();
+                List<Parameter> invalidStructurals = new List<Parameter>();
                 if (this.InternalMaterial.StructuralAssetId != Autodesk.Revit.DB.ElementId.InvalidElementId)
                 {
                     Autodesk.Revit.DB.PropertySetElement structural = document.GetElement(this.InternalMaterial.StructuralAssetId) as Autodesk.Revit.DB.PropertySetElement;
@@ -259,11 +261,22 @@ namespace Revit.Elements
                         foreach (var parameter in structural.Parameters)
                         {
                             Parameter p = new Parameter(parameter as Autodesk.Revit.DB.Parameter);
-                            if (!structurals.Contains(p)) structurals.Add(p);
+                            if (!structurals.Contains(p) && p.InternalParameter.Definition != null) structurals.Add(p);
+                            if (!invalidStructurals.Contains(p) && p.InternalParameter.Definition == null)
+                                invalidStructurals.Add(p);
                         }
                     }
                 }
-
+#if DEBUG
+                if(invalidStructurals.Any())
+                {
+                    Debug.WriteLine("There are {0} invalid structural parameters", invalidStructurals.Count);
+                    foreach(var p in invalidStructurals)
+                    {
+                        Debug.WriteLine(string.Format("\t{0}", p.Id));
+                    }
+                }
+#endif
                 return structurals;
             }
         }

--- a/src/Libraries/RevitNodes/Elements/Material.cs
+++ b/src/Libraries/RevitNodes/Elements/Material.cs
@@ -198,6 +198,7 @@ namespace Revit.Elements
                 Autodesk.Revit.DB.Document document = DocumentManager.Instance.CurrentDBDocument;
 
                 List<Parameter> appearances = new List<Parameter>();
+                List<Parameter> invalidAppearances = new List<Parameter>();
                 if (this.InternalMaterial.AppearanceAssetId != Autodesk.Revit.DB.ElementId.InvalidElementId)
                 {
                     Autodesk.Revit.DB.AppearanceAssetElement appearance = document.GetElement(this.InternalMaterial.AppearanceAssetId) as Autodesk.Revit.DB.AppearanceAssetElement;
@@ -206,11 +207,22 @@ namespace Revit.Elements
                         foreach (var parameter in appearance.Parameters)
                         {
                             Parameter p = new Parameter(parameter as Autodesk.Revit.DB.Parameter);
-                            if (!appearances.Contains(p)) appearances.Add(p);
+                            if (!appearances.Contains(p) && p.InternalParameter.Definition != null) appearances.Add(p);
+                            if (!invalidAppearances.Contains(p) && p.InternalParameter.Definition == null)
+                                invalidAppearances.Add(p);
                         }
                     }
                 }
-
+#if DEBUG
+                if (invalidAppearances.Any())
+                {
+                    Debug.WriteLine("There are {0} invalid structural parameters", invalidAppearances.Count);
+                    foreach (var p in invalidAppearances)
+                    {
+                        Debug.WriteLine(string.Format("\t{0}", p.Id));
+                    }
+                }
+#endif
                 return appearances;
             }
         }
@@ -225,6 +237,7 @@ namespace Revit.Elements
                 Autodesk.Revit.DB.Document document = DocumentManager.Instance.CurrentDBDocument;
 
                 List<Parameter> thermals = new List<Parameter>();
+                List<Parameter> invalidThermals = new List<Parameter>();
                 if (this.InternalMaterial.ThermalAssetId != Autodesk.Revit.DB.ElementId.InvalidElementId)
                 {
                     Autodesk.Revit.DB.PropertySetElement thermal = document.GetElement(this.InternalMaterial.ThermalAssetId) as Autodesk.Revit.DB.PropertySetElement;
@@ -233,10 +246,23 @@ namespace Revit.Elements
                         foreach (var parameter in thermal.Parameters)
                         {
                             Parameter p = new Parameter(parameter as Autodesk.Revit.DB.Parameter);
-                            if (!thermals.Contains(p)) thermals.Add(p);
+                            if (!thermals.Contains(p) && p.InternalParameter.Definition != null) thermals.Add(p);
+                            if (!invalidThermals.Contains(p) && p.InternalParameter.Definition == null)
+                                invalidThermals.Add(p);
                         }
                     }
                 }
+
+#if DEBUG
+                if (invalidThermals.Any())
+                {
+                    Debug.WriteLine("There are {0} invalid structural parameters", invalidThermals.Count);
+                    foreach (var p in invalidThermals)
+                    {
+                        Debug.WriteLine(string.Format("\t{0}", p.Id));
+                    }
+                }
+#endif
 
                 return thermals;
             }

--- a/src/Libraries/RevitNodes/Elements/Material.cs
+++ b/src/Libraries/RevitNodes/Elements/Material.cs
@@ -204,7 +204,7 @@ namespace Revit.Elements
                     Autodesk.Revit.DB.AppearanceAssetElement appearance = document.GetElement(this.InternalMaterial.AppearanceAssetId) as Autodesk.Revit.DB.AppearanceAssetElement;
                     if (appearance != null)
                     {
-                        GetValidParameter(appearance.Parameters, ref appearances, ref invalidAppearances);
+                        FilterParameters(appearance.Parameters, ref appearances, ref invalidAppearances);
                     }
                 }
 #if DEBUG
@@ -237,7 +237,7 @@ namespace Revit.Elements
                     Autodesk.Revit.DB.PropertySetElement thermal = document.GetElement(this.InternalMaterial.ThermalAssetId) as Autodesk.Revit.DB.PropertySetElement;
                     if (thermal != null)
                     {
-                        GetValidParameter(thermal.Parameters, ref thermals, ref invalidThermals);
+                        FilterParameters(thermal.Parameters, ref thermals, ref invalidThermals);
                     }
                 }
 
@@ -272,7 +272,7 @@ namespace Revit.Elements
                     Autodesk.Revit.DB.PropertySetElement structural = document.GetElement(this.InternalMaterial.StructuralAssetId) as Autodesk.Revit.DB.PropertySetElement;
                     if (structural != null)
                     {
-                        GetValidParameter(structural.Parameters, ref structurals, ref invalidStructurals);
+                        FilterParameters(structural.Parameters, ref structurals, ref invalidStructurals);
                     }
                 }
 #if DEBUG
@@ -305,7 +305,7 @@ namespace Revit.Elements
             return DSCore.Color.ByARGB(255, color.Red, color.Green, color.Blue);
         }
 
-        private void GetValidParameters(Autodesk.Revit.DB.ParameterSet parameters, ref List<Parameter> ValidParameters, ref List<Parameter> InvalidParameters)
+        private void FilterParameters(Autodesk.Revit.DB.ParameterSet parameters, ref List<Parameter> ValidParameters, ref List<Parameter> InvalidParameters)
         {
             foreach (var parameter in parameters)
             {

--- a/src/Libraries/RevitNodes/Elements/Material.cs
+++ b/src/Libraries/RevitNodes/Elements/Material.cs
@@ -305,7 +305,7 @@ namespace Revit.Elements
             return DSCore.Color.ByARGB(255, color.Red, color.Green, color.Blue);
         }
 
-        private void GetValidParameter(Autodesk.Revit.DB.ParameterSet parameters, ref List<Parameter> ValidParameters, ref List<Parameter> InvalidParameters)
+        private void GetValidParameters(Autodesk.Revit.DB.ParameterSet parameters, ref List<Parameter> ValidParameters, ref List<Parameter> InvalidParameters)
         {
             foreach (var parameter in parameters)
             {


### PR DESCRIPTION

### Purpose

When use Material.StructuralParameters node to get StructuralParameters from a Material, there are some invalid parameters which just have ID, no name, no type, and can't get access to theirs StorageType and value. So I think it is reasonable to filter out these unavailable Parameters.

https://github.com/DynamoDS/DynamoRevit/issues/2598

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 @wangyangshi @QilongTang @mjkkirschner 

### FYIs

@Amoursol 
