### PR TITLE
Add view part visibility property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 * Fix a bug - filter out unavailable Parameters from Material.
 * Add some view 3d properties - View.Outline, View.Origin, View.Scale, View.CropBox, View.SetCropBox, View.CropBoxActive, View.SetCropBoxActive, View.CropBoxVisible, View.SetCropBoxVisible, View.ViewDirection, View.RightDirection.
 * Add some view properties - View.Discipline, View.SetDiscipline, View.DisplayStyle, View.SetDisplayStyle, View.SketchPlane, View.SetSketchPlane.
+* Add some view properties - View.CanViewBeDuplicated, View.Partsvisibility, View.SetPartsVisibility
 
 ## 0.2.18
 * Add a Category ScheduleOnSheet and its nodes - ScheduleOnSheet.Sheet, ScheduleOnSheet.Schedule, ScheduleOnSheet.BySheetViewLocation, ScheduleOnSheet.Location and ScheduleOnSheet.SetLocation

--- a/src/Libraries/RevitNodes/Elements/Views/View.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View.cs
@@ -426,6 +426,32 @@ namespace Revit.Elements.Views
         #region Duplicate
 
         /// <summary>
+        /// Identifies if this view can be duplicated with specified viewDuplicateOption
+        /// </summary>
+        /// <param name="viewDuplicateOption">Enter View Duplicate Option: 0 = Duplicate. 1 = AsDependent. 2 = WithDetailing.</param>
+        /// <returns></returns>
+        public Boolean CanViewBeDuplicated(int viewDuplicateOption = 0)
+        {
+            ViewDuplicateOption Option = 0;
+            switch (viewDuplicateOption)
+            {
+                case 0:
+                    Option = ViewDuplicateOption.Duplicate;
+                    break;
+                case 1:
+                    Option = ViewDuplicateOption.AsDependent;
+                    break;
+                case 2:
+                    Option = ViewDuplicateOption.WithDetailing;
+                    break;
+                default:
+                    throw new ArgumentException(Properties.Resources.ViewDuplicateOptionOutofRange);
+            }
+
+            return InternalView.CanViewBeDuplicated(Option);
+        }
+
+        /// <summary>
         /// Duplicates A view. 
         /// </summary>
         /// <param name="view">The View to be Duplicated</param>
@@ -696,6 +722,34 @@ namespace Revit.Elements.Views
         {
             RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
             InternalView.SketchPlane = sketchPlane.InternalSketchPlane;
+            RevitServices.Transactions.TransactionManager.Instance.TransactionTaskDone();
+
+            return this;
+        }
+
+        #endregion
+
+        #region PartsVisibility
+        
+        /// <summary>
+        /// The visibility setting for parts in this view. 
+        /// </summary>
+        public string Partsvisibility
+        {
+            get
+            {
+                return InternalView.PartsVisibility.ToString();
+            }
+        }
+
+        public View SetPartsVisibility(string partsVisibility)
+        {
+            PartsVisibility parts;
+            parts = (PartsVisibility)Enum.Parse(typeof(PartsVisibility), partsVisibility);
+
+            RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
+            var param = InternalView.get_Parameter(BuiltInParameter.VIEW_PARTS_VISIBILITY);
+            param.Set((int)parts);
             RevitServices.Transactions.TransactionManager.Instance.TransactionTaskDone();
 
             return this;

--- a/src/Libraries/RevitNodes/Elements/Views/View.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View.cs
@@ -742,6 +742,11 @@ namespace Revit.Elements.Views
             }
         }
 
+        /// <summary>
+        ///  Set PartsVisibility of view
+        /// </summary>
+        /// <param name="partsVisibility"></param>
+        /// <returns></returns>
         public View SetPartsVisibility(string partsVisibility)
         {
             PartsVisibility parts;

--- a/test/Libraries/RevitIntegrationTests/ViewTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ViewTests.cs
@@ -231,5 +231,22 @@ namespace RevitSystemTests
             Assert.AreEqual(0.000, plane.Origin.Y, Tolerance);
             Assert.AreEqual(2.000, plane.Origin.Z, Tolerance);
         }
+
+        [Test]
+        [TestModel(@".\SampleModel.rvt")]
+        public void CanGetSetPartsVisibility()
+        {
+            // Arrange
+            string samplePath = Path.Combine(workingDirectory, @".\View\CanGetSetPartsVisibility.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            // Act
+            ViewModel.OpenCommand.Execute(testPath);
+            RunCurrentModel();
+
+            // Assert
+            var partsVisibility = GetPreviewValue("22843a82efe942b2b89437e4a115e69a");
+            Assert.AreEqual("ShowPartsAndOriginal", partsVisibility);
+        }
     }
 }

--- a/test/System/View/CanGetSetPartsVisibility.dyn
+++ b/test/System/View/CanGetSetPartsVisibility.dyn
@@ -1,0 +1,211 @@
+{
+  "Uuid": "048e1b9a-11fd-46fb-afa8-3e7b42fe12eb",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "CanGetSetPartsVisibility",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "DSRevitNodesUI.Views, DSRevitNodesUI",
+      "SelectedIndex": 0,
+      "SelectedString": "{3D}",
+      "NodeType": "ExtensionNode",
+      "Id": "04188a1ceed54897bb03090427bd42d5",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "2fdee38f4827408a9f178d0a72e43fa2",
+          "Name": "Views",
+          "Description": "The selected Views",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "All views available in the current document."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Views.View.Partsvisibility",
+      "Id": "22843a82efe942b2b89437e4a115e69a",
+      "Inputs": [
+        {
+          "Id": "726bc2d7e4db424692ac0d71cdc8840b",
+          "Name": "view",
+          "Description": "Revit.Elements.Views.View",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "f841b74a636944318202506f11b828d7",
+          "Name": "string",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "The visibility setting for parts in this view.\n\nView.Partsvisibility: string"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Views.View.SetPartsVisibility@string",
+      "Id": "dae4646a32f54e9580d717bf03415fa8",
+      "Inputs": [
+        {
+          "Id": "160e86a714c44075bfabaf9ab93351ea",
+          "Name": "view",
+          "Description": "Revit.Elements.Views.View",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0b91b5c81cc441ecbc111d0021fbc5f1",
+          "Name": "partsVisibility",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "0f19c6b704c346f993047aae82130d87",
+          "Name": "View",
+          "Description": "View",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "View.SetPartsVisibility (partsVisibility: string): View"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.StringInput, CoreNodeModels",
+      "NodeType": "StringInputNode",
+      "InputValue": "ShowPartsAndOriginal",
+      "Id": "ec5c1c1e02b54545b4ba2dd5f7723d4e",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "ef617e85660a48b295253bdd3e1c3a96",
+          "Name": "",
+          "Description": "String",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a string."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "2fdee38f4827408a9f178d0a72e43fa2",
+      "End": "160e86a714c44075bfabaf9ab93351ea",
+      "Id": "d7b7135c0a8941c4b1699aa4c4ab06d8"
+    },
+    {
+      "Start": "0f19c6b704c346f993047aae82130d87",
+      "End": "726bc2d7e4db424692ac0d71cdc8840b",
+      "Id": "2272c908601a4200aad9e198696b1072"
+    },
+    {
+      "Start": "ef617e85660a48b295253bdd3e1c3a96",
+      "End": "0b91b5c81cc441ecbc111d0021fbc5f1",
+      "Id": "7382a19e56374271a9f9b60d2e7de5f9"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.6.1.9130",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Views",
+        "Id": "04188a1ceed54897bb03090427bd42d5",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 35.0,
+        "Y": 137.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "View.Partsvisibility",
+        "Id": "22843a82efe942b2b89437e4a115e69a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 620.0,
+        "Y": 178.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "View.SetPartsVisibility",
+        "Id": "dae4646a32f54e9580d717bf03415fa8",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 292.0,
+        "Y": 178.5
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "String",
+        "Id": "ec5c1c1e02b54545b4ba2dd5f7723d4e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 35.0,
+        "Y": 245.50000000000003
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION

### Purpose

This PR has added 3 nodes of View properties
![NewViewPartsVisibilityNodes](https://user-images.githubusercontent.com/33445445/89276242-fe0cf080-d675-11ea-9173-2c415ec99832.png)

#### SystemTests
![ViewPartsVisibilitySystemTest](https://user-images.githubusercontent.com/33445445/89276290-0f55fd00-d676-11ea-8ffb-209fe3a3b229.PNG)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 @wangyangshi @QilongTang @mjkkirschner @Amoursol 

### FYIs

Screenshots of the dynamo graphs for the system test
![CanGetSetPartsVisibility_2020-08-04_05-15-55](https://user-images.githubusercontent.com/33445445/89276416-36acca00-d676-11ea-8584-32f91415626b.png)

