### PR TITLE
Update to Dynamo Core 2.8

### DIFF
--- a/src/Config/packages.aget
+++ b/src/Config/packages.aget
@@ -1,23 +1,23 @@
 {
   "nuget": {
     "references": {
-        "DynamicLanguageRuntime": "1.2.2",
-        "DynamoVisualProgramming.Core": "2.8.0-beta2195",
-        "DynamoVisualProgramming.DynamoCoreNodes": "2.8.0-beta2195",
-        "DynamoVisualProgramming.DynamoServices": "2.8.0-beta2195",
-        "DynamoVisualProgramming.Tests": "2.8.0-beta2195",
-        "DynamoVisualProgramming.WpfUILibrary": "2.8.0-beta2195",
-        "DynamoVisualProgramming.ZeroTouchLibrary": "2.8.0-beta2195",
-        "DynamoVisualProgramming.DynamoSamples": "2.8.0-beta2195",
-        "Greg": "2.0.7507.22529",
-        "GregRevitAuth": "1.0.7057.20655",
-        "IronPython": "2.7.9",
-        "pythonnet_py38_win": "2.5.1",
-        "Newtonsoft.Json": "8.0.3",
-        "NUnit": "2.6.3",
-        "Prism": "4.1.0",
-        "RestSharp": "105.2.3",
-        "Unofficial.Ionic.Zip": "1.9.1.8"
+      "DynamicLanguageRuntime": "1.2.2",
+      "DynamoVisualProgramming.Core": "2.8.0-beta2195",
+      "DynamoVisualProgramming.DynamoCoreNodes": "2.8.0-beta2195",
+      "DynamoVisualProgramming.DynamoServices": "2.8.0-beta2195",
+      "DynamoVisualProgramming.Tests": "2.8.0-beta2195",
+      "DynamoVisualProgramming.WpfUILibrary": "2.8.0-beta2195",
+      "DynamoVisualProgramming.ZeroTouchLibrary": "2.8.0-beta2195",
+      "DynamoVisualProgramming.DynamoSamples": "2.8.0-beta2195",
+      "Greg": "2.0.7507.22529",
+      "GregRevitAuth": "1.0.7057.20655",
+      "IronPython": "2.7.9",
+      "pythonnet_py38_win": "2.5.1",
+      "Newtonsoft.Json": "8.0.3",
+      "NUnit": "2.6.3",
+      "Prism": "4.1.0",
+      "RestSharp": "105.2.3",
+      "Unofficial.Ionic.Zip": "1.9.1.8"
     }
   }
 }

--- a/src/Config/packages.aget
+++ b/src/Config/packages.aget
@@ -1,22 +1,23 @@
 {
   "nuget": {
     "references": {
-      "DynamicLanguageRuntime" : "1.2.2",
-      "DynamoVisualProgramming.Core" : "2.6.0.8481",
-      "DynamoVisualProgramming.DynamoCoreNodes" : "2.6.0.8481",
-      "DynamoVisualProgramming.DynamoServices" : "2.6.0.8481",
-      "DynamoVisualProgramming.Tests" : "2.6.0.8481",
-      "DynamoVisualProgramming.WpfUILibrary" : "2.6.0.8481",
-      "DynamoVisualProgramming.ZeroTouchLibrary" : "2.6.0.8481",
-      "DynamoVisualProgramming.DynamoSamples" : "2.6.0.8481",
-      "Greg" : "1.2.7177.24952",
-      "GregRevitAuth" : "1.0.7057.20655",
-      "IronPython" : "2.7.9",
-      "Newtonsoft.Json" : "8.0.3",
-      "NUnit" : "2.6.3",
-      "Prism" : "4.1.0",
-      "RestSharp" : "105.2.3",
-      "Unofficial.Ionic.Zip" : "1.9.1.8"
+        "DynamicLanguageRuntime": "1.2.2",
+        "DynamoVisualProgramming.Core": "2.8.0-beta2195",
+        "DynamoVisualProgramming.DynamoCoreNodes": "2.8.0-beta2195",
+        "DynamoVisualProgramming.DynamoServices": "2.8.0-beta2195",
+        "DynamoVisualProgramming.Tests": "2.8.0-beta2195",
+        "DynamoVisualProgramming.WpfUILibrary": "2.8.0-beta2195",
+        "DynamoVisualProgramming.ZeroTouchLibrary": "2.8.0-beta2195",
+        "DynamoVisualProgramming.DynamoSamples": "2.8.0-beta2195",
+        "Greg": "2.0.7507.22529",
+        "GregRevitAuth": "1.0.7057.20655",
+        "IronPython": "2.7.9",
+        "pythonnet_py38_win": "2.5.1",
+        "Newtonsoft.Json": "8.0.3",
+        "NUnit": "2.6.3",
+        "Prism": "4.1.0",
+        "RestSharp": "105.2.3",
+        "Unofficial.Ionic.Zip": "1.9.1.8"
     }
   }
 }

--- a/src/DynamoRevit/DynamoRevit.csproj
+++ b/src/DynamoRevit/DynamoRevit.csproj
@@ -49,16 +49,20 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DSCPython">
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DSCPython.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="DynamoApplications">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoApplications.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoApplications.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net47\DynamoServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net48\DynamoServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Greg">
-      <HintPath>$(PACKAGESPATH)\Greg\lib\net47\Greg.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\Greg\lib\net48\Greg.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="GregRevitAuth">
@@ -93,7 +97,11 @@
       <RequiredTargetFramework>3.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="ProtoGeometry">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net47\ProtoGeometry.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net48\ProtoGeometry.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Python.Runtime">
+      <HintPath>$(PACKAGESPATH)\pythonnet\lib\net40\Python.Runtime.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="RestSharp">
@@ -158,31 +166,31 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="ProtoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\ProtoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\ProtoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DSIronPython">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DSIronPython.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DSIronPython.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoCoreWpf">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net47\DynamoCoreWpf.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net48\DynamoCoreWpf.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUtilities">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoUtilities.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoUtilities.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoShapeManager">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoShapeManager.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoShapeManager.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoInstallDetective">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoInstallDetective.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoInstallDetective.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -8,6 +8,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Events;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Events;
+using DSCPython;
 using DSIronPython;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
@@ -389,16 +390,29 @@ namespace Dynamo.Applications.Models
                 (a, b, c, d, e) => ElementBinder.IsEnabled = false;
             IronPythonEvaluator.EvaluationEnd += (a, b, c, d, e) => ElementBinder.IsEnabled = true;
 
+            var marshaler = new DataMarshaler();
+            marshaler.RegisterMarshaler(
+                (Revit.Elements.Element element) => element.InternalElement);
+            marshaler.RegisterMarshaler((Category element) => element.InternalCategory);
+            Func<object, object> unwrap = marshaler.Marshal;
             // register UnwrapElement method in ironpython
             IronPythonEvaluator.EvaluationBegin += (a, b, scope, d, e) =>
             {
-                var marshaler = new DataMarshaler();
-                marshaler.RegisterMarshaler(
-                    (Revit.Elements.Element element) => element.InternalElement);
-                marshaler.RegisterMarshaler((Category element) => element.InternalCategory);
-
-                Func<object, object> unwrap = marshaler.Marshal;
                 scope.SetVariable("UnwrapElement", unwrap);
+            };
+
+            CPythonEvaluator.OutputMarshaler.RegisterMarshaler(
+                (Element element) => element.ToDSType(true));
+
+            // Turn off element binding during cpython script execution
+            CPythonEvaluator.EvaluationBegin +=
+                (a, b, c, d) => ElementBinder.IsEnabled = false;
+            CPythonEvaluator.EvaluationEnd += (a, b, c, d) => ElementBinder.IsEnabled = true;
+
+            // register UnwrapElement method in cpython
+            CPythonEvaluator.EvaluationBegin += (a, scope, c, d) =>
+            {
+                scope.Set("UnwrapElement", unwrap);
             };
 
             setupPython = true;

--- a/src/DynamoRevit/RevitPathResolver.cs
+++ b/src/DynamoRevit/RevitPathResolver.cs
@@ -38,6 +38,7 @@ namespace Dynamo.Applications
                 "DSCoreNodes.dll",
                 "DSOffice.dll",
                 "DSIronPython.dll",
+                "DSCPython.dll",
                 "FunctionObject.ds",
                 "BuiltIn.ds",
                 "DynamoConversions.dll",

--- a/src/Libraries/Migrations/Migrations.csproj
+++ b/src/Libraries/Migrations/Migrations.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DynamoServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net47\DynamoServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net48\DynamoServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -62,11 +62,11 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="DynamoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUnits">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net47\DynamoUnits.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net48\DynamoUnits.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/src/Libraries/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/RevitNodes/RevitNodes.csproj
@@ -42,7 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DynamoServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net47\DynamoServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net48\DynamoServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore" />
@@ -55,7 +55,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="ProtoGeometry">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net47\ProtoGeometry.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net48\ProtoGeometry.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -218,19 +218,19 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="DynamoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Analysis">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoCoreNodes\lib\net47\Analysis.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoCoreNodes\lib\net48\Analysis.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DSCoreNodes">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoCoreNodes\lib\net47\DSCoreNodes.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoCoreNodes\lib\net48\DSCoreNodes.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUnits">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net47\DynamoUnits.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net48\DynamoUnits.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <ProjectReference Include="..\RevitServices\RevitServices.csproj">

--- a/src/Libraries/RevitNodesUI/RevitNodesUI.csproj
+++ b/src/Libraries/RevitNodesUI/RevitNodesUI.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DynamoUtilities">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoUtilities.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoUtilities.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -46,11 +46,11 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="ProtoGeometry">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net47\ProtoGeometry.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net48\ProtoGeometry.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net47\DynamoServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net48\DynamoServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="RevitAPI">
@@ -102,31 +102,31 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="DynamoCoreWpf">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net47\DynamoCoreWpf.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net48\DynamoCoreWpf.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="ProtoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\ProtoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\ProtoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="CoreNodeModelsWpf">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net47\CoreNodeModelsWpf.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net48\CoreNodeModelsWpf.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="CoreNodeModels">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net47\CoreNodeModels.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net48\CoreNodeModels.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DSCoreNodes">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoCoreNodes\lib\net47\DSCoreNodes.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoCoreNodes\lib\net48\DSCoreNodes.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUnits">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net47\DynamoUnits.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net48\DynamoUnits.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.Prism">

--- a/src/Libraries/RevitServices/RevitServices.csproj
+++ b/src/Libraries/RevitServices/RevitServices.csproj
@@ -51,7 +51,7 @@ limitations under the License.
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DynamoServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net47\DynamoServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net48\DynamoServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.Prism">
@@ -93,11 +93,11 @@ limitations under the License.
   </ItemGroup>
   <ItemGroup>
     <Reference Include="DynamoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="ProtoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\ProtoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\ProtoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/src/restorepackages.bat
+++ b/src/restorepackages.bat
@@ -27,7 +27,7 @@ set NugetConfig=%ConfigDir%\dynamo-nuget.config
 
 REM 2. download 3rdParty packages by Aget.exe
     echo Running Python script from %AgetFile% using dynamo-nuget.config file
-    set PythonAget="%AgetFile%" -os win -config release -iset intel64 -toolchain v140 -linkage shared -packagesDir "%DynamoPackages%" -nuget "%NugetExe%" -framework net47 -nugetConfig "%NugetConfig%"
+    set PythonAget="%AgetFile%" -os win -config release -iset intel64 -toolchain v140 -linkage shared -packagesDir "%DynamoPackages%" -nuget "%NugetExe%" -framework net48 -nugetConfig "%NugetConfig%"
 
     call :TrackTime "[Aget] Downloading NuGet packages from the NuGet Gallery and the Artifactory server, might take a while if running for the first time."
     echo If any package is not found in the NuGet Gallery, redirect to look up in the Artifactory server...

--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -44,7 +44,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DynamoCoreWpf">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net47\DynamoCoreWpf.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net48\DynamoCoreWpf.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.Prism">
@@ -58,11 +58,11 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="ProtoGeometry">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net47\ProtoGeometry.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net48\ProtoGeometry.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net47\DynamoServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net48\DynamoServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="RevitAPI">
@@ -80,11 +80,11 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xaml" />
     <Reference Include="SystemTestServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Tests\lib\net47\SystemTestServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Tests\lib\net48\SystemTestServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="TestServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Tests\lib\net47\TestServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Tests\lib\net48\TestServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="WindowsBase" />
@@ -180,15 +180,15 @@
       <Private>False</Private>
     </ProjectReference>
     <Reference Include="ProtoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\ProtoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\ProtoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="CoreNodeModels">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net47\CoreNodeModels.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net48\CoreNodeModels.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUnits">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net47\DynamoUnits.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net48\DynamoUnits.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <ProjectReference Include="$(SolutionDir)Libraries\RevitNodesUI\RevitNodesUI.csproj">
@@ -207,7 +207,7 @@
       <Private>False</Private>
     </ProjectReference>
     <Reference Include="DynamoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <ProjectReference Include="$(SolutionDir)Libraries\RevitServices\RevitServices.csproj">

--- a/test/Libraries/RevitNodesTests/RevitNodesTests.csproj
+++ b/test/Libraries/RevitNodesTests/RevitNodesTests.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DSCoreNodes">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoCoreNodes\lib\net47\DSCoreNodes.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoCoreNodes\lib\net48\DSCoreNodes.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="nunit.framework">
@@ -48,11 +48,11 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="ProtoGeometry">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net47\ProtoGeometry.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net48\ProtoGeometry.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net47\DynamoServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoServices\lib\net48\DynamoServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="RevitAPI">
@@ -158,11 +158,11 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="DynamoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Analysis">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoCoreNodes\lib\net47\Analysis.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.DynamoCoreNodes\lib\net48\Analysis.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <ProjectReference Include="$(SolutionDir)Libraries\RevitNodes\RevitNodes.csproj">
@@ -176,7 +176,7 @@
       <Private>False</Private>
     </ProjectReference>
     <Reference Include="TestServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Tests\lib\net47\TestServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Tests\lib\net48\TestServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <ProjectReference Include="..\RevitTestServices\RevitTestServices.csproj">

--- a/test/Libraries/RevitTestServices/RevitTestServices.csproj
+++ b/test/Libraries/RevitTestServices/RevitTestServices.csproj
@@ -71,11 +71,11 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="DynamoCore">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoCore.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoCore.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoCoreWpf">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net47\DynamoCoreWpf.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.WpfUILibrary\lib\net48\DynamoCoreWpf.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <ProjectReference Include="$(SolutionDir)DynamoRevit\DynamoRevit.csproj">
@@ -84,11 +84,11 @@
       <Private>False</Private>
     </ProjectReference>
     <Reference Include="DynamoUtilities">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net47\DynamoUtilities.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net48\DynamoUtilities.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUnits">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net47\DynamoUnits.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.ZeroTouchLibrary\lib\net48\DynamoUnits.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <ProjectReference Include="$(SolutionDir)Libraries\RevitServices\RevitServices.csproj">
@@ -98,11 +98,11 @@
     </ProjectReference>
     <Reference Include="System.XML" />
     <Reference Include="TestServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Tests\lib\net47\TestServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Tests\lib\net48\TestServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SystemTestServices">
-      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Tests\lib\net47\SystemTestServices.dll</HintPath>
+      <HintPath>$(PACKAGESPATH)\DynamoVisualProgramming.Tests\lib\net48\SystemTestServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
### Purpose

Includes:
- Dynamo NuGet update
- Preloading the Dynamo CPython3 engine
- Revit customizations for Dynamo CPython3 engine

Known caveats:
- No tests for new Python engine
- Dynamo Core is no longer CLS-compliant creating hundreds of warnings
- Dynamo NuGets for 2.8 are still in beta

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers



### FYIs

@mjkkirschner  @QilongTang 
