### PR TITLE
Add Get Element&Category Override and Hidden status nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Add some view 3d properties - View.Outline, View.Origin, View.Scale, View.CropBox, View.SetCropBox, View.CropBoxActive, View.SetCropBoxActive, View.CropBoxVisible, View.SetCropBoxVisible, View.ViewDirection, View.RightDirection.
 * Add some view properties - View.Discipline, View.SetDiscipline, View.DisplayStyle, View.SetDisplayStyle, View.SketchPlane, View.SetSketchPlane.
 * Add some view properties - View.CanViewBeDuplicated, View.Partsvisibility, View.SetPartsVisibility
+* Add some new nodes - View.GetCategoryOverrides, View.IsCategoryHidden, Element.OverridesInView, Element.IsHiddeninView
 
 ## 0.2.18
 * Add a Category ScheduleOnSheet and its nodes - ScheduleOnSheet.Sheet, ScheduleOnSheet.Schedule, ScheduleOnSheet.BySheetViewLocation, ScheduleOnSheet.Location and ScheduleOnSheet.SetLocation

--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -487,6 +487,29 @@ namespace Revit.Elements
         }
 
         /// <summary>
+        /// Gets graphic overrides for an element in the view. 
+        /// </summary>
+        public Revit.Filter.OverrideGraphicSettings OverridesInView
+        {
+            get
+            {
+                var view = DocumentManager.Instance.CurrentUIDocument.ActiveView;
+
+                return new Filter.OverrideGraphicSettings(view.GetElementOverrides(InternalElementId));
+            }
+        }
+
+        /// <summary>
+        /// Identifies if the element has been permanently hidden in the view.
+        /// </summary>
+        /// <param name="view"></param>
+        /// <returns></returns>
+        public bool IsHiddeninView(Revit.Elements.Views.View view)
+        {
+            return InternalElement.IsHidden(view.InternalView);
+        }
+
+        /// <summary>
         /// Set one of the element's parameters.
         /// </summary>
         /// <param name="parameterName">The name of the parameter to set.</param>

--- a/src/Libraries/RevitNodes/Elements/Views/View.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View.cs
@@ -401,6 +401,34 @@ namespace Revit.Elements.Views
             return this;
         }
 
+        /// <summary>
+        /// Gets graphic overrides for a category in view.
+        /// </summary>
+        /// <param name="category"></param>
+        /// <returns></returns>
+        public Revit.Filter.OverrideGraphicSettings GetCategoryOverrides(Category category)
+        {
+            Autodesk.Revit.DB.ElementId catId = category.InternalCategory.Id;
+            if (!this.InternalView.IsCategoryOverridable(catId))
+            {
+                throw new ArgumentException(Properties.Resources.CategoryVisibilityOverrideError);
+            }
+
+            return new Filter.OverrideGraphicSettings(InternalView.GetCategoryOverrides(catId));
+        }
+
+        /// <summary>
+        /// Checks if elements of the given category are set to be invisible (hidden) in this view. 
+        /// </summary>
+        /// <param name="category"></param>
+        /// <returns></returns>
+        public bool IsCategoryHidden(Category category)
+        {
+            Autodesk.Revit.DB.ElementId catId = category.InternalCategory.Id;
+
+            return InternalView.GetCategoryHidden(catId);
+        }
+
         #endregion
 
         #region Scale

--- a/test/Libraries/RevitIntegrationTests/ElementTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementTests.cs
@@ -328,5 +328,24 @@ namespace RevitSystemTests
             Assert.AreEqual(expectedElementId, firstJoinedElementId);
             Assert.IsNull(nonIntersectingElementsResult);
         }
+
+        [Test]
+        [TestModel(@".\element.rvt")]
+        public void CanGetSetOverrideHiddenInActiveView()
+        {
+            // Arrange
+            string samplePath = Path.Combine(workingDirectory, @".\Element\canGetSetOverrideHiddenInActiveView.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            // Act
+            ViewModel.OpenCommand.Execute(testPath);
+            RunCurrentModel();
+
+            // Assert
+            var elementOverrides = GetPreviewValue("608bd27fa5d2484bab4354d96eb4979b") as Revit.Filter.OverrideGraphicSettings;
+            Assert.IsNotNull(elementOverrides);
+
+            Assert.IsTrue((bool)GetPreviewValue("d79db509ece946f390c686651f53b735"));
+        }
     }
 }

--- a/test/Libraries/RevitIntegrationTests/ViewTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ViewTests.cs
@@ -248,5 +248,24 @@ namespace RevitSystemTests
             var partsVisibility = GetPreviewValue("22843a82efe942b2b89437e4a115e69a");
             Assert.AreEqual("ShowPartsAndOriginal", partsVisibility);
         }
+
+        [Test]
+        [TestModel(@".\element.rvt")]
+        public void CanGetSetCategoryOverridesAndHidden()
+        {
+            // Arrange
+            string samplePath = Path.Combine(workingDirectory, @".\View\CanGetSetCategoryOverridesAndHidden.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            // Act
+            ViewModel.OpenCommand.Execute(testPath);
+            RunCurrentModel();
+
+            // Assert
+            var categoryOverrides = GetPreviewValue("66dc72c413124c57a8416d0f97bca1de") as Revit.Filter.OverrideGraphicSettings;
+            Assert.IsNotNull(categoryOverrides);
+
+            Assert.IsTrue((bool)GetPreviewValue("c07c8e0e57ab42769fa86b8df7b6056c"));
+        }
     }
 }

--- a/test/System/Element/canGetSetOverrideHiddenInActiveView.dyn
+++ b/test/System/Element/canGetSetOverrideHiddenInActiveView.dyn
@@ -1,0 +1,534 @@
+{
+  "Uuid": "f7c043a5-9ecd-43f5-bc70-09990cf6a752",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "canGetSetOverrideHiddenInActiveView",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Nodes.DSModelElementSelection, DSRevitNodesUI",
+      "NodeType": "ExtensionNode",
+      "InstanceId": [
+        "fd3a4d17-47e3-4720-b3a9-b8f28e80f6d1-0002d004"
+      ],
+      "Id": "2642644b2dbd44e9b35d27ec6ebdead7",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "0ba21414bdbb4702b5335d16c1dccd99",
+          "Name": "Element",
+          "Description": "The selected elements.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Element.IsHiddeninView@Revit.Elements.Views.View",
+      "Id": "d79db509ece946f390c686651f53b735",
+      "Inputs": [
+        {
+          "Id": "1541875788fc48f58a752d6544b12d13",
+          "Name": "element",
+          "Description": "Revit.Elements.Element",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e284605315af46b48243e801a80bfa20",
+          "Name": "view",
+          "Description": "View",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "9f2be0a6c55547e0875336c968a2ba88",
+          "Name": "bool",
+          "Description": "bool",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Element.IsHiddeninView (view: View): bool"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Element.OverrideInView@Revit.Filter.OverrideGraphicSettings,bool",
+      "Id": "64cdd9a8cd60435ca98b7e48eb60d969",
+      "Inputs": [
+        {
+          "Id": "8997385c7e0a4b44a8cce1a70cbb3cbc",
+          "Name": "element",
+          "Description": "Revit.Elements.Element",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5069a5f2f0af4c8c9e930149f1be22a5",
+          "Name": "overrides",
+          "Description": "Override Graphics Settings.\n\nOverrideGraphicSettings",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b5a3b5934859494cb1dc4819bd0f2e75",
+          "Name": "hide",
+          "Description": "If True given Element will be hidden.\n\nbool\nDefault value : false",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "2b20e962bdcc40f784075bb884495392",
+          "Name": "Element",
+          "Description": "Element",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Override Elements Graphics Settings in Active View.\n\nElement.OverrideInView (overrides: OverrideGraphicSettings, hide: bool = false): Element"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Filter.OverrideGraphicSettings.ByProperties@DSCore.Color,DSCore.Color,DSCore.Color,DSCore.Color,Revit.Elements.FillPatternElement,Revit.Elements.FillPatternElement,Revit.Elements.LinePatternElement,Revit.Elements.LinePatternElement,int,int,int,string,bool",
+      "Id": "6fd45cb859294e4cb9dfe50ec45edf54",
+      "Inputs": [
+        {
+          "Id": "dbb176763d144f2f8b9db61470071f9b",
+          "Name": "cutFillColor",
+          "Description": "Fill color\n\nColor\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "983dbaad0f224715a95c609a96c75a00",
+          "Name": "projectionFillColor",
+          "Description": "Projection color\n\nColor\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "289f11be41fc4d3faec436fb99d899d9",
+          "Name": "cutLineColor",
+          "Description": "Cut line color\n\nColor\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3205d07c07734d8091c391a3f343753c",
+          "Name": "projectionLineColor",
+          "Description": "Projection line color\n\nColor\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "2bbe169cc8ff46dfb66930eefc7651ec",
+          "Name": "cutFillPattern",
+          "Description": "Cut fill pattern\n\nFillPatternElement\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f5d4187be0be47dfafbd687c2b1d3fb1",
+          "Name": "projectionFillPattern",
+          "Description": "Projection fill pattern\n\nFillPatternElement\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "bb313da542484bcbaf2702dce64da1a7",
+          "Name": "cutLinePattern",
+          "Description": "Cut line pattern\n\nLinePatternElement\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "cbe56bb9995143b297eb063461e06317",
+          "Name": "projectionLinePattern",
+          "Description": "Projection line pattern\n\nLinePatternElement\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f525ba95f0e145c2b3e3a16b1c77a297",
+          "Name": "cutLineWeight",
+          "Description": "Cut line weight\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "aa31a61e9eae4ad4bbcf24ff2d6895b4",
+          "Name": "projectionLineWeight",
+          "Description": "Projection line weight\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "5a0510cba939434db573bd83b949cced",
+          "Name": "transparency",
+          "Description": "Transparency as integer between 1-100.\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e5030c322da64d508d611de0c586453d",
+          "Name": "detailLevel",
+          "Description": "Detail Level setting, ex: Coarse, Fine etc.\n\nstring\nDefault value : \"Undefined\"",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "9921d31925434def9546971391092ecb",
+          "Name": "halftone",
+          "Description": "Halftone. True = halftone.\n\nbool\nDefault value : false",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "93b8e34d6851428096a34a816892fc86",
+          "Name": "overrides",
+          "Description": "Override Graphic Settings",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a OverrideGraphicSettings Element.\n\nOverrideGraphicSettings.ByProperties (cutFillColor: Color = null, projectionFillColor: Color = null, cutLineColor: Color = null, projectionLineColor: Color = null, cutFillPattern: FillPatternElement = null, projectionFillPattern: FillPatternElement = null, cutLinePattern: LinePatternElement = null, projectionLinePattern: LinePatternElement = null, cutLineWeight: int = -1, projectionLineWeight: int = -1, transparency: int = -1, detailLevel: string = \"Undefined\", halftone: bool = false): OverrideGraphicSettings"
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.DetailLevel, DSRevitNodesUI",
+      "SelectedIndex": 2,
+      "SelectedString": "Medium",
+      "NodeType": "ExtensionNode",
+      "Id": "70fffd99002948e889d5503db97a8d8b",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "c5eaa72746ae4552ab9863a09f36a27f",
+          "Name": "Detail Level",
+          "Description": "The selected Detail Level",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "View Detail Level"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "50;",
+      "Id": "0047dd5d9e9f481680de4e3055f3d2b2",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "3ff753339317443b9373acf43bece54b",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.BoolSelector, CoreNodeModels",
+      "NodeType": "BooleanInputNode",
+      "InputValue": true,
+      "Id": "f0deac6ea57e489c8e5797d57e119054",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "aefc7d21d0284f508271024f3a214301",
+          "Name": "",
+          "Description": "Boolean",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Selection between a true and false."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Element.OverridesInView",
+      "Id": "608bd27fa5d2484bab4354d96eb4979b",
+      "Inputs": [
+        {
+          "Id": "2d45912212ba489c993b2b3553304a93",
+          "Name": "element",
+          "Description": "Revit.Elements.Element",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "3f9d17ee4eec4b34bcca330ecc07c2ac",
+          "Name": "OverrideGraphicSettings",
+          "Description": "OverrideGraphicSettings",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Element.OverridesInView: OverrideGraphicSettings"
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.Views, DSRevitNodesUI",
+      "SelectedIndex": 0,
+      "SelectedString": "{3D}",
+      "NodeType": "ExtensionNode",
+      "Id": "ae766cd50b79453d80a72e828da0f4b9",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "04244a6490744fb78a231f82a72c5434",
+          "Name": "Views",
+          "Description": "The selected Views",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "All views available in the current document."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "0ba21414bdbb4702b5335d16c1dccd99",
+      "End": "8997385c7e0a4b44a8cce1a70cbb3cbc",
+      "Id": "9d0b1ac39f4e4343bb3340daf123ec99"
+    },
+    {
+      "Start": "2b20e962bdcc40f784075bb884495392",
+      "End": "2d45912212ba489c993b2b3553304a93",
+      "Id": "3d2dc5f6eda941a29ea40fa869caa1cb"
+    },
+    {
+      "Start": "2b20e962bdcc40f784075bb884495392",
+      "End": "1541875788fc48f58a752d6544b12d13",
+      "Id": "6581cd3222b44a5a9f75e703828183b0"
+    },
+    {
+      "Start": "93b8e34d6851428096a34a816892fc86",
+      "End": "5069a5f2f0af4c8c9e930149f1be22a5",
+      "Id": "e10bc08c0397438c94006ee0eb490e69"
+    },
+    {
+      "Start": "c5eaa72746ae4552ab9863a09f36a27f",
+      "End": "e5030c322da64d508d611de0c586453d",
+      "Id": "7a857970cedc45f586a02b3896e7676f"
+    },
+    {
+      "Start": "3ff753339317443b9373acf43bece54b",
+      "End": "5a0510cba939434db573bd83b949cced",
+      "Id": "9555ee3550644889a2c2db1a5c1da57a"
+    },
+    {
+      "Start": "aefc7d21d0284f508271024f3a214301",
+      "End": "b5a3b5934859494cb1dc4819bd0f2e75",
+      "Id": "5c67eb221c54427db5452d369113bd47"
+    },
+    {
+      "Start": "04244a6490744fb78a231f82a72c5434",
+      "End": "e284605315af46b48243e801a80bfa20",
+      "Id": "f6641b068fc24a1ca27667336d51184b"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.6.1.9130",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Select Model Element",
+        "Id": "2642644b2dbd44e9b35d27ec6ebdead7",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 29.5,
+        "Y": 104.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Element.IsHiddeninView",
+        "Id": "d79db509ece946f390c686651f53b735",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 754.5,
+        "Y": 402.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Element.OverrideInView",
+        "Id": "64cdd9a8cd60435ca98b7e48eb60d969",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 428.5,
+        "Y": 308.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "OverrideGraphicSettings.ByProperties",
+        "Id": "6fd45cb859294e4cb9dfe50ec45edf54",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 29.5,
+        "Y": 239.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Detail Level",
+        "Id": "70fffd99002948e889d5503db97a8d8b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -252.5,
+        "Y": 569.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "0047dd5d9e9f481680de4e3055f3d2b2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -252.5,
+        "Y": 459.21333333333331
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Boolean",
+        "Id": "f0deac6ea57e489c8e5797d57e119054",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 29.5,
+        "Y": 659.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Element.OverridesInView",
+        "Id": "608bd27fa5d2484bab4354d96eb4979b",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 754.5,
+        "Y": 294.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Views",
+        "Id": "ae766cd50b79453d80a72e828da0f4b9",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 428.5,
+        "Y": 468.0
+      }
+    ],
+    "Annotations": [],
+    "X": -401.75464207869061,
+    "Y": -96.478340160759188,
+    "Zoom": 0.84761857199822688
+  }
+}

--- a/test/System/View/CanGetSetCategoryOverridesAndHidden.dyn
+++ b/test/System/View/CanGetSetCategoryOverridesAndHidden.dyn
@@ -1,0 +1,562 @@
+{
+  "Uuid": "b2f3f0e2-72b7-40f8-a230-de36e765d53b",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "CanGetSetCategoryOverridesAndHidden",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "DSRevitNodesUI.Categories, DSRevitNodesUI",
+      "SelectedIndex": 659,
+      "SelectedString": "OST_Walls",
+      "NodeType": "ExtensionNode",
+      "Id": "dc6adbb7f25a4c678c9f35dd06b7ef96",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "a1ec637c567f4480ac269687340e1d45",
+          "Name": "Category",
+          "Description": "The selected Category.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "All built-in categories."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Views.View.SetCategoryOverrides@Revit.Elements.Category,Revit.Filter.OverrideGraphicSettings,bool",
+      "Id": "50dbf0021ed34501914277ed7e8e6feb",
+      "Inputs": [
+        {
+          "Id": "48c22f6270544c42bbeebfb8ce055e14",
+          "Name": "view",
+          "Description": "Revit.Elements.Views.View",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "50975b7a96db400ca4f74587e4d09f33",
+          "Name": "category",
+          "Description": "Category\n\nCategory",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "dceb36dc80d14e1cb269492ebbc8fbee",
+          "Name": "overrides",
+          "Description": "Graphics Overrides Settings.\n\nOverrideGraphicSettings",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "f2782d5ce7fe42dab38c1d0dae7f414b",
+          "Name": "hide",
+          "Description": "If True givent Category will be hidden.\n\nbool\nDefault value : false",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "02caf5a80fc84074a07bf67fa0ef952e",
+          "Name": "view",
+          "Description": "View",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Set Category Overrides.\n\nView.SetCategoryOverrides (category: Category, overrides: OverrideGraphicSettings, hide: bool = false): View"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Filter.OverrideGraphicSettings.ByProperties@DSCore.Color,DSCore.Color,DSCore.Color,DSCore.Color,Revit.Elements.FillPatternElement,Revit.Elements.FillPatternElement,Revit.Elements.LinePatternElement,Revit.Elements.LinePatternElement,int,int,int,string,bool",
+      "Id": "c44e99d9ddf44ec7a2747f6a36ebf1fd",
+      "Inputs": [
+        {
+          "Id": "d060aca743e642b69978b068a9741d45",
+          "Name": "cutFillColor",
+          "Description": "Fill color\n\nColor\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "127b667e06844f7db68946f5b6653a36",
+          "Name": "projectionFillColor",
+          "Description": "Projection color\n\nColor\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "550050add39d4c43aeb5a3ca9a69b908",
+          "Name": "cutLineColor",
+          "Description": "Cut line color\n\nColor\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d9b6273b346c4f4aad446600d4c6a755",
+          "Name": "projectionLineColor",
+          "Description": "Projection line color\n\nColor\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "ff689d174976478cb4fb1b78cd9eaaa1",
+          "Name": "cutFillPattern",
+          "Description": "Cut fill pattern\n\nFillPatternElement\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d0d181055bc04d5c81b35b0d2f53c4e4",
+          "Name": "projectionFillPattern",
+          "Description": "Projection fill pattern\n\nFillPatternElement\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "384d561e186348b79b149c67995a16d0",
+          "Name": "cutLinePattern",
+          "Description": "Cut line pattern\n\nLinePatternElement\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "26922bac51594d28b44dc5be967b43f2",
+          "Name": "projectionLinePattern",
+          "Description": "Projection line pattern\n\nLinePatternElement\nDefault value : null",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "d199585332f5403a971df0bfffb0a254",
+          "Name": "cutLineWeight",
+          "Description": "Cut line weight\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "af73af72cce84f83919a48b98f2b4c94",
+          "Name": "projectionLineWeight",
+          "Description": "Projection line weight\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c6f55b20a2674dc09263d570ecbcdeae",
+          "Name": "transparency",
+          "Description": "Transparency as integer between 1-100.\n\nint\nDefault value : -1",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "3a5c85313e034620b806b2d57f7507c9",
+          "Name": "detailLevel",
+          "Description": "Detail Level setting, ex: Coarse, Fine etc.\n\nstring\nDefault value : \"Undefined\"",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "b80312bc0bdb44d7b12d708340299edd",
+          "Name": "halftone",
+          "Description": "Halftone. True = halftone.\n\nbool\nDefault value : false",
+          "UsingDefaultValue": true,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "afea182a3ae240809d09ab348e1ad860",
+          "Name": "overrides",
+          "Description": "Override Graphic Settings",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a OverrideGraphicSettings Element.\n\nOverrideGraphicSettings.ByProperties (cutFillColor: Color = null, projectionFillColor: Color = null, cutLineColor: Color = null, projectionLineColor: Color = null, cutFillPattern: FillPatternElement = null, projectionFillPattern: FillPatternElement = null, cutLinePattern: LinePatternElement = null, projectionLinePattern: LinePatternElement = null, cutLineWeight: int = -1, projectionLineWeight: int = -1, transparency: int = -1, detailLevel: string = \"Undefined\", halftone: bool = false): OverrideGraphicSettings"
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.Views, DSRevitNodesUI",
+      "SelectedIndex": 0,
+      "SelectedString": "{3D}",
+      "NodeType": "ExtensionNode",
+      "Id": "1098fc3dcad84c629d3c5403a30ae14c",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "f2989e29477e4a5199a1d44acaace489",
+          "Name": "Views",
+          "Description": "The selected Views",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "All views available in the current document."
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.BoolSelector, CoreNodeModels",
+      "NodeType": "BooleanInputNode",
+      "InputValue": true,
+      "Id": "9616b3bf9f8c468d8e56741bafc9ebbb",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4e4d9f8fb85c402e9f37c36f80faca8b",
+          "Name": "",
+          "Description": "Boolean",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Selection between a true and false."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "100;",
+      "Id": "cba86841d10546018d89856f34239d90",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "a13cde0044e44ecb85d2f4823b3f3adb",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.DetailLevel, DSRevitNodesUI",
+      "SelectedIndex": 1,
+      "SelectedString": "Fine",
+      "NodeType": "ExtensionNode",
+      "Id": "cf4f138ab5874306927b62b85e7ab2d2",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "835646bcd5b84e89bb7a0d4b56883726",
+          "Name": "Detail Level",
+          "Description": "The selected Detail Level",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "View Detail Level"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Views.View.GetCategoryOverrides@Revit.Elements.Category",
+      "Id": "66dc72c413124c57a8416d0f97bca1de",
+      "Inputs": [
+        {
+          "Id": "c778b67a96fd40799eb2a64ccb2b1b24",
+          "Name": "view",
+          "Description": "Revit.Elements.Views.View",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "bfd2acc958264b96a9a9a32ccf5d993f",
+          "Name": "category",
+          "Description": "Category",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "67be5483522d439e98cf6b8db0ecf174",
+          "Name": "OverrideGraphicSettings",
+          "Description": "OverrideGraphicSettings",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "View.GetCategoryOverrides (category: Category): OverrideGraphicSettings"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Views.View.IsCategoryHidden@Revit.Elements.Category",
+      "Id": "c07c8e0e57ab42769fa86b8df7b6056c",
+      "Inputs": [
+        {
+          "Id": "47fc8594e4114beea3df1ced10433ff8",
+          "Name": "view",
+          "Description": "Revit.Elements.Views.View",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "594b05ccbe3744c980302b52940a6036",
+          "Name": "category",
+          "Description": "Category",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e5951d3ddba04a18b8a0b62a3b565491",
+          "Name": "bool",
+          "Description": "bool",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "View.IsCategoryHidden (category: Category): bool"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "a1ec637c567f4480ac269687340e1d45",
+      "End": "50975b7a96db400ca4f74587e4d09f33",
+      "Id": "5c3d33cc747a48aebbda9ffdccad4ca5"
+    },
+    {
+      "Start": "a1ec637c567f4480ac269687340e1d45",
+      "End": "bfd2acc958264b96a9a9a32ccf5d993f",
+      "Id": "f9034d847864465c85b20b0888ecb2c4"
+    },
+    {
+      "Start": "a1ec637c567f4480ac269687340e1d45",
+      "End": "594b05ccbe3744c980302b52940a6036",
+      "Id": "8c3a4aac88374029a41da455487d455a"
+    },
+    {
+      "Start": "02caf5a80fc84074a07bf67fa0ef952e",
+      "End": "c778b67a96fd40799eb2a64ccb2b1b24",
+      "Id": "fc14d2d2de48498ebeac463931eb9f29"
+    },
+    {
+      "Start": "02caf5a80fc84074a07bf67fa0ef952e",
+      "End": "47fc8594e4114beea3df1ced10433ff8",
+      "Id": "a72df0ceaa2444aea32db82ef6c0279b"
+    },
+    {
+      "Start": "afea182a3ae240809d09ab348e1ad860",
+      "End": "dceb36dc80d14e1cb269492ebbc8fbee",
+      "Id": "c6c456d60b6440389ef904c400afc335"
+    },
+    {
+      "Start": "f2989e29477e4a5199a1d44acaace489",
+      "End": "48c22f6270544c42bbeebfb8ce055e14",
+      "Id": "7e62031153cc42b4b795c4cce887873f"
+    },
+    {
+      "Start": "4e4d9f8fb85c402e9f37c36f80faca8b",
+      "End": "f2782d5ce7fe42dab38c1d0dae7f414b",
+      "Id": "5c8f38818b99451188ded89e4609ed70"
+    },
+    {
+      "Start": "a13cde0044e44ecb85d2f4823b3f3adb",
+      "End": "c6f55b20a2674dc09263d570ecbcdeae",
+      "Id": "fcde280d4f8c41c2a35bf5d6934d18e2"
+    },
+    {
+      "Start": "835646bcd5b84e89bb7a0d4b56883726",
+      "End": "3a5c85313e034620b806b2d57f7507c9",
+      "Id": "59561452ac4642688c629dbff45a01e9"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.6.1.9130",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Categories",
+        "Id": "dc6adbb7f25a4c678c9f35dd06b7ef96",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 7.2106824925814976,
+        "Y": 52.367952522255223
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "View.SetCategoryOverrides",
+        "Id": "50dbf0021ed34501914277ed7e8e6feb",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 406.2106824925815,
+        "Y": 145.36795252225522
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "OverrideGraphicSettings.ByProperties",
+        "Id": "c44e99d9ddf44ec7a2747f6a36ebf1fd",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 7.2106824925814976,
+        "Y": 160.36795252225522
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Views",
+        "Id": "1098fc3dcad84c629d3c5403a30ae14c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 7.2106824925814976,
+        "Y": -55.632047477744777
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Boolean",
+        "Id": "9616b3bf9f8c468d8e56741bafc9ebbb",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 7.2106824925814976,
+        "Y": 580.36795252225522
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "cba86841d10546018d89856f34239d90",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -274.7893175074185,
+        "Y": 380.58128585558853
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Detail Level",
+        "Id": "cf4f138ab5874306927b62b85e7ab2d2",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -274.7893175074185,
+        "Y": 490.36795252225522
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "View.GetCategoryOverrides",
+        "Id": "66dc72c413124c57a8416d0f97bca1de",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 709.21068249258155,
+        "Y": 78.367952522255223
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "View.IsCategoryHidden",
+        "Id": "c07c8e0e57ab42769fa86b8df7b6056c",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 709.21068249258155,
+        "Y": 212.36795252225522
+      }
+    ],
+    "Annotations": [],
+    "X": 12.922902613488759,
+    "Y": 32.970358742871213,
+    "Zoom": 0.67483165842686466
+  }
+}


### PR DESCRIPTION
### Purpose

Add 4 nodes to get ElementOverrides, CategoryOverrides and Element Hidden status, Category Hidden status
![View ElementOverrides Hidden](https://user-images.githubusercontent.com/33445445/90206506-64cc9f80-de16-11ea-9155-a6928fb0b609.png)

#### SystemTests
![View ElementOverrides HiddenSystemTests](https://user-images.githubusercontent.com/33445445/90206525-71e98e80-de16-11ea-822a-db4dca576d0e.PNG)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 @wangyangshi @mjkkirschner @QilongTang @Amoursol 

### FYIs
Screenshots of the dynamo graphs for the system test
#### CanGetSetCategoryOverridesAndHidden
![CanGetSetCategoryOverridesAndHidden_2020-08-14_10-08-28](https://user-images.githubusercontent.com/33445445/90206685-e4f30500-de16-11ea-9648-608875219efe.png)


#### CanGetSetOverrideHiddenInActiveView
![canGetSetOverrideHiddenInActiveView_2020-08-14_10-08-52](https://user-images.githubusercontent.com/33445445/90206695-ede3d680-de16-11ea-8761-f88325d0de68.png)


