### PR TITLE
Set sheet information when duplicating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update DynamoCore to 2.8.0 for Dynamo CPython3 engine.
 * Add some View Nodes - View.HideCategoriesTemporary, View.HideElementsTemporary, View.IsolateCategoriesTemporary, View.IsolateElementsTemporary.
 * Improve DuplicateSheet Node - add "duplicateWithContents" option, add default suffix value when prefix & suffix are both empty.
+* Improve DuplicateSheet Node - Set Sheet information when duplicating; Improve View Temporary Nodes.
 
 ## 0.2.18
 * Add a Category ScheduleOnSheet and its nodes - ScheduleOnSheet.Sheet, ScheduleOnSheet.Schedule, ScheduleOnSheet.BySheetViewLocation, ScheduleOnSheet.Location and ScheduleOnSheet.SetLocation

--- a/src/Libraries/RevitNodes/Elements/Views/Sheet.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/Sheet.cs
@@ -550,6 +550,21 @@ namespace Revit.Elements.Views
             }
         }
 
+        public Revision[] Revisions
+        {
+            get
+            {
+                foreach(var id in InternalViewSheet.GetAllRevisionIds())
+                {
+                    string str = InternalViewSheet.GetRevisionNumberOnSheet(id);
+                }
+                var elements = InternalViewSheet.GetAllRevisionIds().Select(x => Document.GetElement(x)).OfType<Autodesk.Revit.DB.Revision>();
+
+                return elements.Select(x => (Revision)ElementWrapper.ToDSType(x, true))
+                        .ToArray();
+            }
+        }
+
         #endregion
 
         #region Public static constructors
@@ -808,6 +823,7 @@ namespace Revit.Elements.Views
                     newSheet = new Sheet(viewSheet);
                     newSheet.InternalSetSheetName(newSheetName);
                     newSheet.InternalSetSheetNumber(newSheetNumber);
+                    SetSheetInformation(sheet, newSheet);
 
                     TraceElements.Add(newSheet.InternalElement);
 
@@ -860,6 +876,26 @@ namespace Revit.Elements.Views
         }
 
         #endregion
+
+        #region Private Helper
+
+        private static void SetSheetInformation(Sheet oldSheet, Sheet newSheet)
+        {
+            List<BuiltInParameter> Filters = new List<BuiltInParameter>
+            {
+                BuiltInParameter.SHEET_APPROVED_BY,
+                BuiltInParameter.SHEET_DESIGNED_BY,
+                BuiltInParameter.SHEET_CHECKED_BY,
+                BuiltInParameter.SHEET_DRAWN_BY
+            };
+            foreach(var parameter in Filters)
+            {
+                var oldParam = oldSheet.InternalViewSheet.get_Parameter(parameter);
+                var value = oldParam.AsString();
+                var newParam = newSheet.InternalViewSheet.get_Parameter(parameter);
+                newParam.Set(value);
+            }
+        }
 
         private static void DuplicateSheetAnnotations(Sheet oldSheet, Sheet newSheet)
         {
@@ -1019,5 +1055,7 @@ namespace Revit.Elements.Views
 
             return IsUnique;
         }
+
+        #endregion
     }
 }

--- a/src/Libraries/RevitNodes/Elements/Views/Sheet.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/Sheet.cs
@@ -550,21 +550,6 @@ namespace Revit.Elements.Views
             }
         }
 
-        public Revision[] Revisions
-        {
-            get
-            {
-                foreach(var id in InternalViewSheet.GetAllRevisionIds())
-                {
-                    string str = InternalViewSheet.GetRevisionNumberOnSheet(id);
-                }
-                var elements = InternalViewSheet.GetAllRevisionIds().Select(x => Document.GetElement(x)).OfType<Autodesk.Revit.DB.Revision>();
-
-                return elements.Select(x => (Revision)ElementWrapper.ToDSType(x, true))
-                        .ToArray();
-            }
-        }
-
         #endregion
 
         #region Public static constructors

--- a/src/Libraries/RevitNodes/Elements/Views/View.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View.cs
@@ -447,6 +447,10 @@ namespace Revit.Elements.Views
             }
 
             RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
+            if (this.InternalView.IsTemporaryHideIsolateActive())
+            {
+                this.InternalView.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
+            }
             this.InternalView.HideCategoriesTemporary(CatIds);
             RevitServices.Transactions.TransactionManager.Instance.TransactionTaskDone();
 
@@ -467,6 +471,10 @@ namespace Revit.Elements.Views
             }
 
             RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
+            if (this.InternalView.IsTemporaryHideIsolateActive())
+            {
+                this.InternalView.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
+            }
             this.InternalView.HideElementsTemporary(EleIds);
             RevitServices.Transactions.TransactionManager.Instance.TransactionTaskDone();
 
@@ -491,6 +499,10 @@ namespace Revit.Elements.Views
             }
 
             RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
+            if (this.InternalView.IsTemporaryHideIsolateActive())
+            {
+                this.InternalView.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
+            }
             this.InternalView.IsolateCategoriesTemporary(CatIds);
             RevitServices.Transactions.TransactionManager.Instance.TransactionTaskDone();
 
@@ -511,6 +523,10 @@ namespace Revit.Elements.Views
             }
 
             RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
+            if (this.InternalView.IsTemporaryHideIsolateActive())
+            {
+                this.InternalView.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
+            }
             this.InternalView.IsolateElementsTemporary(EleIds);
             RevitServices.Transactions.TransactionManager.Instance.TransactionTaskDone();
 


### PR DESCRIPTION

### Purpose

1. Duplicate Sheet with its information
2. Improve View Temporary Nodes

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 @wangyangshi 

### FYIs

@Amoursol 
