### PR TITLE
Fix a issue about Mass Family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Improve a Systemtests, CanPurgeUnusedElementsFromDocument, which use lots of element id and will fail due to changes in RevitAPI.
+* Fix a issue that it will have an offset when select a face or faces from Mass FamilyInstance into Dynamo.
 
 ## 0.2.21
 * Restore the Hide Dimension nodes and Add Dimension.ByElementDirection

--- a/src/Libraries/RevitNodes/Elements/Dimension.cs
+++ b/src/Libraries/RevitNodes/Elements/Dimension.cs
@@ -320,7 +320,7 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Create a Dimension for a Element in the specified direction and view.
+        /// Create a Dimension for an Element in the specified direction and view.
         /// </summary>
         /// <param name="view">View to place dimension in</param>
         /// <param name="element">The element of generated Dimension</param>

--- a/src/Libraries/RevitNodes/GeometryObjects/GeometryObjectSelector.cs
+++ b/src/Libraries/RevitNodes/GeometryObjects/GeometryObjectSelector.cs
@@ -67,6 +67,8 @@ namespace Revit.GeometryObjects
         /// <returns></returns>
         private static bool RequiresTransform(Autodesk.Revit.DB.FamilyInstance familyInstance)
         {
+            if (familyInstance.Category.Id.IntegerValue == (int)BuiltInCategory.OST_Mass)
+                return false;
             var geom = familyInstance.get_Geometry(new Options());
             return geom.OfType<Autodesk.Revit.DB.GeometryInstance>()
                 .Any(x => x.GetInstanceGeometry().Any());

--- a/src/Libraries/RevitNodes/GeometryReferences/ElementCurveReference.cs
+++ b/src/Libraries/RevitNodes/GeometryReferences/ElementCurveReference.cs
@@ -102,7 +102,7 @@ namespace Revit.GeometryReferences
         }
 
         /// <summary>
-        /// Try get ElementCurveReference for a Revit Curve
+        /// Try get ElementCurveReference for a Revit Curve.
         /// </summary>
         /// <param name="curve">A curve from Revit</param>
         /// <returns></returns>


### PR DESCRIPTION
### Purpose

Fix a issue that it will have an offset when select a face or faces from Mass FamilyInstance into Dynamo.
#### Steps to reproduce the problem.
1- Create a Conceptual Mass family
2- Create a simple form
3- Draw some lines around
4- Load the family into the project
5- Open Dynamo and try the Select Face or Select Faces node and select a face of the loaded mass into project
6- Try using ImportInstance.ByGeometry and see how faces are far far away from where they are supposed to be

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@AndyDu1985 @wangyangshi @QilongTang @mjkkirschner 

### FYIs

@Amoursol 
