### PR TITLE
Add ElementBinder to AnalysisDisplay Nodes

### DIFF
--- a/src/Libraries/RevitNodes/AnalysisDisplay/AbstractAnalysisDisplay.cs
+++ b/src/Libraries/RevitNodes/AnalysisDisplay/AbstractAnalysisDisplay.cs
@@ -44,6 +44,32 @@ namespace Revit.AnalysisDisplay
         }
     }
 
+    [SupressImportIntoVM]
+    [Serializable]
+    public class SpmRefPrimitiveIdListPair : ISerializable
+    {
+        public int SpatialFieldManagerID { get; set; }
+        public Dictionary<Reference, int> RefIdPairs { get; set; }
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("SpatialFieldManagerID", SpatialFieldManagerID, typeof(int));
+            info.AddValue("ReferencePrimitiveIds", RefIdPairs, typeof(Dictionary<Reference, int>));
+        }
+        public SpmRefPrimitiveIdListPair()
+        {
+            SpatialFieldManagerID = int.MinValue;
+            RefIdPairs = new Dictionary<Reference, int>();
+        }
+
+        public SpmRefPrimitiveIdListPair(SerializationInfo info, StreamingContext context)
+        {
+            SpatialFieldManagerID = (int)info.GetValue("SpatialFieldManagerID", typeof(int));
+            RefIdPairs =
+                (Dictionary<Reference, int>)
+                    info.GetValue("ReferencePrimitiveIds", typeof(Dictionary<Reference, int>));
+        }
+    }
+
     /// <summary>
     /// Superclass for all Revit Analysis Display types
     /// 


### PR DESCRIPTION

### Purpose

Add ElementBinder to AnalysisDisplay Nodes avoid these nodes will clear SpatialFieldManager every time.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@wangyangshi @ShengxiZhang @mjkkirschner @QilongTang 

### FYIs
@Amoursol 

