### PR TITLE
Override property - Active

### DIFF
--- a/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
+++ b/src/DynamoRevit/ViewModel/RevitWatch3DViewModel.cs
@@ -59,6 +59,24 @@ namespace Dynamo.Applications.ViewModel
                 });
         }
 
+        public override bool Active
+        {
+            get => base.Active;
+            set
+            {
+                if (active == value)
+                {
+                    return;
+                }
+
+                active = value;
+                preferences.SetIsBackgroundPreviewActive(PreferenceWatchName, value);
+                RaisePropertyChanged("Active");
+
+                OnActiveStateChanged();
+            }
+        }
+
         protected override void OnActiveStateChanged()
         {
             if (active)


### PR DESCRIPTION
### Purpose

[REVIT-166657](https://jira.autodesk.com/browse/REVIT-166657)

Some more info : 
 https://github.com/DynamoDS/Dynamo/issues/9934 
 https://github.com/DynamoDS/Dynamo/pull/9377

I have the same opinion with alfarok that when toggling "Revit Background Preview", it has no need to force a regeneration of the render packages for all nodes.
I think we can change "Active" to virtual, so it can be overridden in inherited classes.

PS: This PR can not be merged until DynamoRevit update the new DynamoCore Libs. ( at least has this change https://github.com/DynamoDS/Dynamo/pull/11597 )

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @wangyangshi 

### FYIs

@mjkkirschner @QilongTang @Amoursol 
