### PR TITLE
Update parameter type and GetSpecTypeId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Add new Viewport nodes - Viewport.LabelOffset, Viewport.SetLabelOffset, Viewport.LabelLineLength, Viewport.SetLabelLineLength.
 * Update Floor API with new RevitAPI.
 * Add new Ceiling&CeilingType nodes - Ceiling.ByOutlineTypeAndLevel, Ceiling.ByOutlineTypeAndLevel(polycurve), Ceiling Types, CeilingType.ByName, CeilingType.Name, CeilingTypeGetThermalProperties.
+* Update ParameterType and some related contents because of RevitAPI changed.
 
 ## 0.3.1
 * Fix CICD issue with nuget.

--- a/src/Libraries/RevitNodes/Application/FamilyDocument.cs
+++ b/src/Libraries/RevitNodes/Application/FamilyDocument.cs
@@ -144,10 +144,10 @@ namespace Revit.Application
             switch (familyParameter.StorageType)
             {
                 case Autodesk.Revit.DB.StorageType.Integer:
-                    return FamilyManager.CurrentType.AsInteger(familyParameter) * UnitConverter.HostToDynamoFactor(familyParameter.Definition.GetSpecTypeId());
+                    return FamilyManager.CurrentType.AsInteger(familyParameter) * UnitConverter.HostToDynamoFactor(familyParameter.Definition.GetDataType());
 
                 case Autodesk.Revit.DB.StorageType.Double:
-                    return FamilyManager.CurrentType.AsDouble(familyParameter) * UnitConverter.HostToDynamoFactor(familyParameter.Definition.GetSpecTypeId());
+                    return FamilyManager.CurrentType.AsDouble(familyParameter) * UnitConverter.HostToDynamoFactor(familyParameter.Definition.GetDataType());
 
                 case Autodesk.Revit.DB.StorageType.String:
                     return FamilyManager.CurrentType.AsString(familyParameter);
@@ -212,13 +212,15 @@ namespace Revit.Application
         public Elements.FamilyParameter AddParameter(string parameterName, string parameterGroup, string parameterType, bool isInstance)
         {
             // parse parameter type
-            Autodesk.Revit.DB.ParameterType type;
-            if (!System.Enum.TryParse<Autodesk.Revit.DB.ParameterType>(parameterType, out type))
+            Autodesk.Revit.DB.ForgeTypeId type = Revit.Elements.InternalUtilities.ElementUtils.ParseParameterType(parameterType);
+            if (type == null) 
+            {
                 throw new System.Exception(Properties.Resources.ParameterTypeNotFound);
+            }
 
             // parse parameter group
-            Autodesk.Revit.DB.BuiltInParameterGroup group;
-            if (!System.Enum.TryParse<Autodesk.Revit.DB.BuiltInParameterGroup>(parameterGroup, out group))
+            var group = Revit.Elements.InternalUtilities.ElementUtils.ParseBuiltInParameterGroup(parameterGroup);
+            if (group == null)
                 throw new System.Exception(Properties.Resources.ParameterTypeNotFound);
 
             TransactionManager.Instance.EnsureInTransaction(this.InternalDocument);
@@ -308,7 +310,7 @@ namespace Revit.Application
                 throw new InvalidOperationException(string.Format(Properties.Resources.WrongStorageType, familyParameter.StorageType));
             }
 
-            double doubleValueToSet = doubleValue * UnitConverter.DynamoToHostFactor(familyParameter.Definition.GetSpecTypeId());
+            double doubleValueToSet = doubleValue * UnitConverter.DynamoToHostFactor(familyParameter.Definition.GetDataType());
             FamilyManager.Set(familyParameter, doubleValueToSet);
         }
 
@@ -323,7 +325,7 @@ namespace Revit.Application
             {
                 throw new InvalidOperationException(string.Format(Properties.Resources.WrongStorageType, familyParameter.StorageType)); ;
             }
-            var intValueToSet = intValue * UnitConverter.DynamoToHostFactor(familyParameter.Definition.GetSpecTypeId());
+            var intValueToSet = intValue * UnitConverter.DynamoToHostFactor(familyParameter.Definition.GetDataType());
             FamilyManager.Set(familyParameter, intValueToSet);
         }
 

--- a/src/Libraries/RevitNodes/Elements/FamilyParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilyParameter.cs
@@ -38,7 +38,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get the parameter type
         /// </summary>
-        public string ParameterType => InternalFamilyParameter.Definition.ParameterType.ToString();
+        public string ParameterType => InternalUtilities.ElementUtils.ParseForgeId(InternalFamilyParameter.Definition.GetDataType());
 
         /// <summary>
         /// Get the parameter's element Id
@@ -48,7 +48,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get the parameter's unit type
         /// </summary>
-        public string UnitType => InternalFamilyParameter.Definition.GetSpecTypeId().ToString();
+        public string UnitType => InternalFamilyParameter.Definition.GetDataType().TypeId;
 
         /// <summary>
         /// Get Parameter Storage Type

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementUtils.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementUtils.cs
@@ -99,7 +99,7 @@ namespace Revit.Elements.InternalUtilities
                     result = param.AsInteger();
                     break;
                 case StorageType.Double:
-                    result = param.AsDouble() * Revit.GeometryConversion.UnitConverter.HostToDynamoFactor(param.Definition.GetSpecTypeId());
+                    result = param.AsDouble() * Revit.GeometryConversion.UnitConverter.HostToDynamoFactor(param.Definition.GetDataType());
                     break;
                 default:
                     throw new Exception(string.Format(Properties.Resources.ParameterWithoutStorageType, param));
@@ -116,7 +116,7 @@ namespace Revit.Elements.InternalUtilities
             if (param.StorageType != StorageType.Integer && param.StorageType != StorageType.Double)
                 throw new Exception(Properties.Resources.ParameterStorageNotNumber);
 
-            var valueToSet = value * UnitConverter.DynamoToHostFactor(param.Definition.GetSpecTypeId());
+            var valueToSet = value * UnitConverter.DynamoToHostFactor(param.Definition.GetDataType());
 
             param.Set(valueToSet);
         }
@@ -136,7 +136,7 @@ namespace Revit.Elements.InternalUtilities
             if (param.StorageType != StorageType.Integer && param.StorageType != StorageType.Double)
                 throw new Exception(Properties.Resources.ParameterStorageNotNumber);
 
-            var valueToSet = value * UnitConverter.DynamoToHostFactor(param.Definition.GetSpecTypeId());
+            var valueToSet = value * UnitConverter.DynamoToHostFactor(param.Definition.GetDataType());
 
             param.Set(valueToSet);
         }

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementUtils.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementUtils.cs
@@ -3,6 +3,8 @@ using Autodesk.DesignScript.Runtime;
 using Autodesk.Revit.DB;
 using Revit.GeometryConversion;
 using RevitServices.Persistence;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Revit.Elements.InternalUtilities
 {
@@ -157,5 +159,98 @@ namespace Revit.Elements.InternalUtilities
             param.Set(value == false ? 0 : 1);
         }
         #endregion
+
+        public static Autodesk.Revit.DB.ForgeTypeId ParseParameterType(string parameterType)
+        {
+            Autodesk.Revit.DB.ForgeTypeId type = null;
+            var property = typeof(Autodesk.Revit.DB.SpecTypeId).GetProperty(parameterType);
+            if (property == null)
+            {
+                var nesttypes = typeof(Autodesk.Revit.DB.SpecTypeId).GetNestedTypes();
+                foreach (var nesttype in nesttypes)
+                {
+                    property = nesttype.GetProperty(parameterType);
+                    if (property != null)
+                    {
+                        type = (Autodesk.Revit.DB.ForgeTypeId)property.GetValue(null, null);
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                type = (Autodesk.Revit.DB.ForgeTypeId)property.GetValue(null, null);
+            }
+
+            return type;
+        }
+
+        public static Autodesk.Revit.DB.ForgeTypeId ParseBuiltInParameterGroup(string parameterGroup)
+        {
+            var split = parameterGroup.Split('_');
+            var propertyName = "";
+            for (int i = 1; i < split.Length; i++)
+            {
+                string temp = split[i].ToLower();
+                propertyName += temp.Substring(0, 1).ToUpper() + temp.Substring(1);
+            }
+
+            Autodesk.Revit.DB.ForgeTypeId type = null;
+            var property = typeof(Autodesk.Revit.DB.GroupTypeId).GetProperty(propertyName);
+            if(property !=null)
+                type = (Autodesk.Revit.DB.ForgeTypeId)property.GetValue(null, null);
+            return type;
+        }
+
+        public static string ParseForgeId(ForgeTypeId forgeType)
+        {
+            System.Reflection.PropertyInfo expected = null;
+            
+            var list = new List<System.Reflection.PropertyInfo>();
+            var nesttypes = typeof(Autodesk.Revit.DB.SpecTypeId).GetNestedTypes();
+            foreach(var nesttype in nesttypes)
+            {
+                var props = nesttype.GetProperties();
+                list.AddRange(props);
+            }
+            expected = list.Find(x => (ForgeTypeId)x.GetValue(null, null) == forgeType);
+            if (expected != null)
+                return expected.Name;
+
+            expected = null;
+            list.Clear();
+
+            var properties = typeof(SpecTypeId).GetProperties();
+            list.AddRange(properties);
+            expected = list.Find(x => (ForgeTypeId)x.GetValue(null, null) == forgeType);
+            if (expected != null)
+                return expected.Name;
+
+            //if (SpecTypeId.Acceleration == forgeType)
+            //    result = "Acceleration";
+            //else if (SpecTypeId.AirFlow == forgeType)
+            //    result = "AirFlow";
+            //else if (SpecTypeId.AirFlowDensity == forgeType)
+            //    result = "Text";
+            //else if (SpecTypeId.AirFlowDividedByCoolingLoad == forgeType)
+            //    result = "Text";
+            //else if (SpecTypeId.AirFlowDividedByVolume == forgeType)
+            //    result = "Text";
+            //else if (SpecTypeId.Angle == forgeType)
+            //    result = "Text";
+            //else if (SpecTypeId.String.Text == forgeType)
+            //    result = "Text";
+            //else if (SpecTypeId.String.Text == forgeType)
+            //    result = "Text";
+            //else if (SpecTypeId.String.Text == forgeType)
+            //    result = "Text";
+            //else if (SpecTypeId.String.Text == forgeType)
+            //    result = "Text";
+            //else if (SpecTypeId.String.Text == forgeType)
+            //    result = "Text";
+            //else
+            //    result = null;
+            return null;
+        }
     }
 }

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementUtils.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementUtils.cs
@@ -226,30 +226,6 @@ namespace Revit.Elements.InternalUtilities
             if (expected != null)
                 return expected.Name;
 
-            //if (SpecTypeId.Acceleration == forgeType)
-            //    result = "Acceleration";
-            //else if (SpecTypeId.AirFlow == forgeType)
-            //    result = "AirFlow";
-            //else if (SpecTypeId.AirFlowDensity == forgeType)
-            //    result = "Text";
-            //else if (SpecTypeId.AirFlowDividedByCoolingLoad == forgeType)
-            //    result = "Text";
-            //else if (SpecTypeId.AirFlowDividedByVolume == forgeType)
-            //    result = "Text";
-            //else if (SpecTypeId.Angle == forgeType)
-            //    result = "Text";
-            //else if (SpecTypeId.String.Text == forgeType)
-            //    result = "Text";
-            //else if (SpecTypeId.String.Text == forgeType)
-            //    result = "Text";
-            //else if (SpecTypeId.String.Text == forgeType)
-            //    result = "Text";
-            //else if (SpecTypeId.String.Text == forgeType)
-            //    result = "Text";
-            //else if (SpecTypeId.String.Text == forgeType)
-            //    result = "Text";
-            //else
-            //    result = null;
             return null;
         }
     }

--- a/src/Libraries/RevitNodes/Elements/Parameter.cs
+++ b/src/Libraries/RevitNodes/Elements/Parameter.cs
@@ -75,7 +75,7 @@ namespace Revit.Elements
         /// </summary>
         public string ParameterType
         {
-            get { return InternalParameter.Definition.ParameterType.ToString(); }
+            get { return InternalUtilities.ElementUtils.ParseForgeId(InternalParameter.Definition.GetDataType()); }
         }
 
         /// <summary>
@@ -91,7 +91,10 @@ namespace Revit.Elements
         /// </summary>
         public string UnitType
         {
-            get { return InternalParameter.Definition.GetSpecTypeId().ToString(); }
+            get
+            {
+                return InternalParameter.Definition.GetDataType().TypeId.ToString();
+            }
         }
 
 
@@ -200,8 +203,8 @@ namespace Revit.Elements
         public static void CreateSharedParameter(string parameterName, string groupName, string type, string group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
             // parse parameter type
-            var parameterType = Autodesk.Revit.DB.ParameterType.Text;
-            if (!System.Enum.TryParse<Autodesk.Revit.DB.ParameterType>(type, out parameterType))
+            var parameterType = Revit.Elements.InternalUtilities.ElementUtils.ParseParameterType(type); 
+            if (parameterType == null)
                 throw new System.Exception(Properties.Resources.ParameterTypeNotFound);
 
             // parse parameter group
@@ -292,8 +295,8 @@ namespace Revit.Elements
         public static void CreateProjectParameter(string parameterName, string groupName, string type, string group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
             // parse parameter type
-            var parameterType = Autodesk.Revit.DB.ParameterType.Text;
-            if (!System.Enum.TryParse<Autodesk.Revit.DB.ParameterType>(type, out parameterType))
+            var parameterType = Revit.Elements.InternalUtilities.ElementUtils.ParseParameterType(type);
+            if(parameterType == null)
                 throw new System.Exception(Properties.Resources.ParameterTypeNotFound);
 
             // parse parameter group

--- a/src/Libraries/RevitNodesUI/GenericClasses.cs
+++ b/src/Libraries/RevitNodesUI/GenericClasses.cs
@@ -207,4 +207,102 @@ namespace DSRevitNodesUI
             return new List<AssociativeNode> { assign };
         }
     }
+
+
+    public abstract class CustomGenericNestedClassDropDown : RevitDropDownBase
+    {
+        public CustomGenericNestedClassDropDown(string name, Type type) : base(name)
+        {
+            this.EnumerationType = type;
+            PopulateDropDownItems();
+        }
+
+        [JsonConstructor]
+        public CustomGenericNestedClassDropDown(string name, Type type, IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(name, inPorts, outPorts)
+        {
+            this.EnumerationType = type;
+            PopulateDropDownItems();
+        }
+
+        /// <summary>
+        /// Type of Class
+        /// </summary>
+        private Type EnumerationType
+        {
+            get;
+            set;
+        }
+
+        protected override CoreNodeModels.DSDropDownBase.SelectionState PopulateItemsCore(string currentSelection)
+        {
+            PopulateDropDownItems();
+            return SelectionState.Done;
+        }
+
+        /// <summary>
+        /// Populate Items in Dropdown menu
+        /// </summary>
+        public void PopulateDropDownItems()
+        {
+            if (this.EnumerationType != null)
+            {
+                // Clear the dropdown list
+                Items.Clear();
+
+                var properties = EnumerationType.GetProperties();
+                foreach (var property in properties)
+                {
+                    string name = property.Name;
+                    Items.Add(new CoreNodeModels.DynamoDropDownItem(name, name));
+                }
+
+                var types = this.EnumerationType.GetNestedTypes();
+                foreach (var type in types)
+                {
+                    var nestProperties = type.GetProperties();
+                    foreach (var nestProperty in nestProperties)
+                    {
+                        Items.Add(new CoreNodeModels.DynamoDropDownItem(nestProperty.Name, nestProperty.Name));
+                    }
+                }
+
+                if (Items.Count <= 0)
+                {
+                    Items.Add(new CoreNodeModels.DynamoDropDownItem(Properties.Resources.NoTypesFound, null));
+                    SelectedIndex = 0;
+                    return;
+                }
+                Items = Items.OrderBy(x => x.Name).ToObservableCollection();
+            }
+        }
+
+        /// <summary>
+        /// Assign the selected Enumeration value to the output
+        /// </summary>
+        public override IEnumerable<AssociativeNode> BuildOutputAst(List<AssociativeNode> inputAstNodes)
+        {
+            // If the dropdown is still empty try to populate it again          
+            if (Items.Count == 0 || Items.Count == -1)
+            {
+                if (this.EnumerationType != null)
+                {
+                    PopulateItems();
+                }
+            }
+
+            // If there are no elements in the dropdown or the selected Index is invalid return a Null node.
+            if (!CanBuildOutputAst(Properties.Resources.NoTypesFound, Properties.Resources.None))
+                return new[] { AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), AstFactory.BuildNullNode()) };
+
+            // get the selected items name
+            var stringNode = AstFactory.BuildStringNode((string)Items[SelectedIndex].Name);
+
+            // assign the selected name to an actual enumeration value
+            var assign = AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), stringNode);
+
+            // return the enumeration value
+            return new List<AssociativeNode> { assign };
+        }
+    }
 }

--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -803,7 +803,7 @@ namespace DSRevitNodesUI
     [NodeCategory(BuiltinNodeCategories.REVIT_SELECTION)]
     [NodeDescription("LevelsDescription", typeof(Properties.Resources))]
     [IsDesignScriptCompatible]
-    [OutPortTypes("Revit.Elements.Element")]
+    [OutPortTypes("Revit.Elements.Level")]
     public class Levels : RevitDropDownBase
     {
         private const string noLevels = "No levels available.";

--- a/src/Libraries/RevitNodesUI/RevitTypes.cs
+++ b/src/Libraries/RevitNodesUI/RevitTypes.cs
@@ -122,15 +122,15 @@ namespace DSRevitNodesUI
     [NodeDescription("ParameterTypeSelectorDescription", typeof(DSRevitNodesUI.Properties.Resources))]
     [IsDesignScriptCompatible]
     [OutPortTypes("string")]
-    public class ParameterType : CustomGenericEnumerationDropDown
+    public class ParameterType : CustomGenericNestedClassDropDown
     {
         private const string outputName = "Parameter Type";
 
-        public ParameterType() : base(outputName, typeof(Autodesk.Revit.DB.ParameterType)) { }
+        public ParameterType() : base(outputName, typeof(Autodesk.Revit.DB.SpecTypeId)) { }
 
         [JsonConstructor]
         public ParameterType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
-            : base(outputName, typeof(Autodesk.Revit.DB.ParameterType), inPorts, outPorts) { }
+            : base(outputName, typeof(Autodesk.Revit.DB.SpecTypeId), inPorts, outPorts) { }
     }
 
     [NodeName("Select BuiltIn Parameter Group")]

--- a/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
@@ -15,17 +15,17 @@ namespace RevitNodesTests.Elements
         public void SetAndGetGlobalParameterByName()
         {
 
-            var gpString = Revit.Elements.GlobalParameter.ByName("MyGlobal", Autodesk.Revit.DB.ParameterType.Text.ToString());
+            var gpString = Revit.Elements.GlobalParameter.ByName("MyGlobal", "Text");
             Assert.IsNotNull(gpString.InternalGlobalParameter);
             Revit.Elements.GlobalParameter.SetValue(gpString, "4711");
             Assert.AreEqual("4711", gpString.Value);
 
-            var gpInt = Revit.Elements.GlobalParameter.ByName("MyGlobalInt", Autodesk.Revit.DB.ParameterType.Integer.ToString());
+            var gpInt = Revit.Elements.GlobalParameter.ByName("MyGlobalInt", "Integer");
             Assert.IsNotNull(gpInt.InternalGlobalParameter);
             Revit.Elements.GlobalParameter.SetValue(gpInt, 4711);
             Assert.AreEqual(4711, gpInt.Value);
 
-            var gpLen = Revit.Elements.GlobalParameter.ByName("MyGlobalDouble", Autodesk.Revit.DB.ParameterType.Length.ToString());
+            var gpLen = Revit.Elements.GlobalParameter.ByName("MyGlobalDouble", "Length");
             Assert.IsNotNull(gpLen.InternalGlobalParameter);
             Revit.Elements.GlobalParameter.SetValue(gpLen, 47.11);
             double val = (double)gpLen.Value;

--- a/test/Libraries/RevitNodesTests/Elements/ParameterTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ParameterTests.cs
@@ -20,7 +20,7 @@ namespace RevitNodesTests.Elements
         {
             List<Category> categories = new List<Category>() { Category.ByName("Walls") };
 
-            Parameter.CreateProjectParameter("MyParameter", "MyGroup", Autodesk.Revit.DB.ParameterType.Text.ToString(), Autodesk.Revit.DB.BuiltInParameterGroup.PG_DATA.ToString(), true, categories);
+            Parameter.CreateProjectParameter("MyParameter", "MyGroup", "Text", Autodesk.Revit.DB.BuiltInParameterGroup.PG_DATA.ToString(), true, categories);
 
             var fec = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument).OfClass(typeof(Autodesk.Revit.DB.Wall));
             var wall = fec.FirstElement(); 
@@ -46,7 +46,7 @@ namespace RevitNodesTests.Elements
 
             List<Category> categories = new List<Category>() { Category.ByName("Walls") };
 
-            Parameter.CreateSharedParameter("MySharedParameter", "MySharedGroup", Autodesk.Revit.DB.ParameterType.Text.ToString(), Autodesk.Revit.DB.BuiltInParameterGroup.PG_DATA.ToString(), true, categories);
+            Parameter.CreateSharedParameter("MySharedParameter", "MySharedGroup", "Text", Autodesk.Revit.DB.BuiltInParameterGroup.PG_DATA.ToString(), true, categories);
             var fec = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument).OfClass(typeof(Autodesk.Revit.DB.Wall));
             var wall = fec.FirstElement();
             Assert.IsNotNull(wall.LookupParameter("MySharedParameter"));


### PR DESCRIPTION
### Purpose

Due to RevitAPI Update, ParameterType will be removed in Revit future version, so this enumeration should be replaced by SpecTypeId class. Definition.GetSpecTypeId() also should be replaced by Definition.GetDataType().

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @wangyangshi @philxia1 

### FYIs

@Amoursol @QilongTang @mjkkirschner 
