### PR TITLE
Update ParameterType and BuiltInParameterGroup because of RevitAPI ch…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Add new Viewport nodes - Viewport.LabelOffset, Viewport.SetLabelOffset, Viewport.LabelLineLength, Viewport.SetLabelLineLength.
 * Update Floor API with new RevitAPI.
 * Add new Ceiling&CeilingType nodes - Ceiling.ByOutlineTypeAndLevel, Ceiling.ByOutlineTypeAndLevel(polycurve), Ceiling Types, CeilingType.ByName, CeilingType.Name, CeilingTypeGetThermalProperties.
+* Update ParameterType and some related contents because of RevitAPI changed.
 
 ## 0.3.1
 * Fix CICD issue with nuget.

--- a/src/DynamoRevit/Resources/LayoutSpecs.json
+++ b/src/DynamoRevit/Resources/LayoutSpecs.json
@@ -170,6 +170,9 @@
                   "path": "RevitNodes.Revit.Elements.FloorType"
                 },
                 {
+                  "path": "RevitNodes.Revit.Elements.ForgeType"
+                },
+                {
                   "path": "RevitNodes.Revit.Elements.Form"
                 },
                 {

--- a/src/Libraries/RevitNodes/Application/FamilyDocument.cs
+++ b/src/Libraries/RevitNodes/Application/FamilyDocument.cs
@@ -233,14 +233,14 @@ namespace Revit.Application
         /// Add a new family parameter with a given name.
         /// </summary>
         /// <param name="parameterName">The name of the new family parameter.</param>
-        /// <param name="group">The name of the group to which the family parameter belongs.</param>
-        /// <param name="spec">The name of the type of new family parameter.</param>
+        /// <param name="groupType">The type of the group to which the family parameter belongs.</param>
+        /// <param name="specType">The type of new family parameter.</param>
         /// <param name="isInstance">Indicates if the new family parameter is instance or type (true if parameter should be instance).</param>
         /// <returns></returns>
-        public Elements.FamilyParameter AddParameter(string parameterName, ForgeType group, ForgeType spec, bool isInstance)
+        public Elements.FamilyParameter AddParameter(string parameterName, ForgeType groupType, ForgeType specType, bool isInstance)
         {
             TransactionManager.Instance.EnsureInTransaction(this.InternalDocument);
-            var famParameter = FamilyManager.AddParameter(parameterName, group.InternalForgeTypeId, spec.InternalForgeTypeId, isInstance);
+            var famParameter = FamilyManager.AddParameter(parameterName, groupType.InternalForgeTypeId, specType.InternalForgeTypeId, isInstance);
             TransactionManager.Instance.TransactionTaskDone();
             return new Elements.FamilyParameter(famParameter);
         }

--- a/src/Libraries/RevitNodes/Elements/FamilyParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilyParameter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Autodesk.Revit.DB;
 using RevitServices.Transactions;
+using Dynamo.Graph.Nodes;
 
 namespace Revit.Elements
 {
@@ -33,11 +34,13 @@ namespace Revit.Elements
         /// <summary>
         /// Get the parameter's group
         /// </summary>
+        [NodeObsolete("GroupObsolete", typeof(Properties.Resources))]
         public string Group => InternalFamilyParameter.Definition.ParameterGroup.ToString();
 
         /// <summary>
         /// Get the parameter type
         /// </summary>
+        [NodeObsolete("ParameterTypeObsolete", typeof(Properties.Resources))]
         public string ParameterType => InternalFamilyParameter.Definition.ParameterType.ToString();
 
         /// <summary>
@@ -48,7 +51,18 @@ namespace Revit.Elements
         /// <summary>
         /// Get the parameter's unit type
         /// </summary>
+        [NodeObsolete("UnitTypeObsolete", typeof(Properties.Resources))]
         public string UnitType => InternalFamilyParameter.Definition.GetSpecTypeId().ToString();
+
+        /// <summary>
+        /// Get the parameter's spec type
+        /// </summary>
+        public ForgeType SpecType => ForgeType.FromExisting(InternalFamilyParameter.Definition.GetDataType());
+
+        /// <summary>
+        /// Get the parameter's group type
+        /// </summary>
+        public ForgeType GroupType => ForgeType.FromExisting(InternalFamilyParameter.Definition.GetGroupTypeId());
 
         /// <summary>
         /// Get Parameter Storage Type

--- a/src/Libraries/RevitNodes/Elements/ForgeType.cs
+++ b/src/Libraries/RevitNodes/Elements/ForgeType.cs
@@ -1,0 +1,116 @@
+﻿using Autodesk.Revit.DB;
+using Autodesk.DesignScript.Runtime;
+
+namespace Revit.Elements
+{
+    public class ForgeType
+    {
+        #region Internal properties
+
+        /// <summary>
+        /// Internal reference to Revit ForgeTypeId
+        /// </summary>
+        internal ForgeTypeId InternalForgeTypeId
+        {
+            get; private set;
+        }
+
+        #endregion
+
+        #region Private Construction
+        
+        /// <summary>
+        /// Init ForgeType with typeId of a ForgeTypeId
+        /// </summary>
+        /// <param name="typeId"></param>
+        private ForgeType(string typeId)
+        {
+            ForgeTypeId forgeTypeId = new ForgeTypeId(typeId);
+            InternalSetForgeType(forgeTypeId);
+        }
+
+        /// <summary>
+        /// Init ForgeType with an existing ForgeTypeId
+        /// </summary>
+        /// <param name="forgeTypeId"></param>
+        private ForgeType(ForgeTypeId forgeTypeId)
+        {
+            InternalSetForgeType(forgeTypeId);
+        }
+
+        #endregion
+
+        #region Private mutators
+
+        /// <summary>
+        /// Set the internal ForgeTypeId
+        /// </summary>
+        /// <param name="forgeTypeId"></param>
+        private void InternalSetForgeType(ForgeTypeId forgeTypeId)
+        {
+            this.InternalForgeTypeId = forgeTypeId;
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// The schema identifier. 
+        /// </summary>
+        public string TypeId
+        {
+            get
+            {
+                return InternalForgeTypeId.TypeId;
+            }
+        }
+
+        /// <summary>
+        /// Specifies whether the .NET object represents a valid Revit entity. 
+        /// </summary>
+        public bool IsValidObject
+        {
+            get
+            {
+                return InternalForgeTypeId.IsValidObject;
+            }
+        }
+
+        #endregion
+
+        #region Public static constructors
+
+        /// <summary>
+        /// Get a ForgeTypeId by schema identifier.
+        /// </summary>
+        /// <param name="typeId">a schema identifier</param>
+        /// <returns></returns>
+        public static ForgeType ByTypeId(string typeId)
+        {
+            return new ForgeType(typeId);
+        }
+
+        #endregion
+
+        [IsVisibleInDynamoLibrary(false)]
+        public override string ToString()
+        {
+            return InternalForgeTypeId.TypeId;
+        }
+
+        #region Internal static constructor
+
+        /// <summary>
+        /// Wrap an exsiting ForgeTypeId to ForgeType
+        /// </summary>
+        /// <param name="forgeTypeId"></param>
+        /// <returns></returns>
+        internal static ForgeType FromExisting(ForgeTypeId forgeTypeId)
+        {
+            return new ForgeType(forgeTypeId);
+        }
+
+        #endregion
+    }
+}

--- a/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
@@ -380,7 +380,7 @@ namespace Revit.Elements
         /// Create a new Global Parameter by Name and Type
         /// </summary>
         /// <param name="name">Name fo the parameter</param>
-        /// <param name="specType">Spec Type</param>
+        /// <param name="specType">The type of new global parameter.</param>
         /// <returns></returns>
         public static GlobalParameter ByName(string name, ForgeType specType)
         {

--- a/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
@@ -4,6 +4,7 @@ using DynamoServices;
 using Revit.GeometryConversion;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
+using Dynamo.Graph.Nodes;
 
 namespace Revit.Elements
 {
@@ -55,6 +56,11 @@ namespace Revit.Elements
             SafeInit(() => InitGlobalParameter(name, type));
         }
 
+        private GlobalParameter(string name, Autodesk.Revit.DB.ForgeTypeId forgeTypeId)
+        {
+            SafeInit(() => InitGlobalParameter(name, forgeTypeId));
+        }
+
         #endregion
 
 
@@ -89,6 +95,28 @@ namespace Revit.Elements
                 // Create a new GP
                 TransactionManager.Instance.EnsureInTransaction(Document);
                 Autodesk.Revit.DB.GlobalParameter newParameter = Autodesk.Revit.DB.GlobalParameter.Create(Document, name, type);
+                InternalSetGlobalParameter(newParameter);
+                TransactionManager.Instance.TransactionTaskDone();
+            }
+
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalGlobalParameter);
+        }
+
+        private void InitGlobalParameter(string name, Autodesk.Revit.DB.ForgeTypeId forgeTypeId)
+        {
+            var existingId = Autodesk.Revit.DB.GlobalParametersManager.FindByName(Document, name);
+
+            if (existingId != null && existingId != Autodesk.Revit.DB.ElementId.InvalidElementId)
+            {
+                // GP already exists
+                var existingParameter = Document.GetElement(existingId) as Autodesk.Revit.DB.GlobalParameter;
+                InternalSetGlobalParameter(existingParameter);
+            }
+            else
+            {
+                // Create a new GP
+                TransactionManager.Instance.EnsureInTransaction(Document);
+                Autodesk.Revit.DB.GlobalParameter newParameter = Autodesk.Revit.DB.GlobalParameter.Create(Document, name, forgeTypeId);
                 InternalSetGlobalParameter(newParameter);
                 TransactionManager.Instance.TransactionTaskDone();
             }
@@ -189,7 +217,7 @@ namespace Revit.Elements
                         var valueDouble = valueWrapper as Autodesk.Revit.DB.DoubleParameterValue;
 
                         return valueDouble.Value * Revit.GeometryConversion.UnitConverter.HostToDynamoFactor(
-                            this.InternalGlobalParameter.GetDefinition().GetSpecTypeId());
+                            this.InternalGlobalParameter.GetDefinition().GetDataType());
                     }
                     else
                     {
@@ -235,7 +263,7 @@ namespace Revit.Elements
                 }
                 else if (value.GetType() == typeof(double))
                 {
-                    var valueToSet = (double)value * UnitConverter.DynamoToHostFactor(parameter.InternalGlobalParameter.GetDefinition().GetSpecTypeId());
+                    var valueToSet = (double)value * UnitConverter.DynamoToHostFactor(parameter.InternalGlobalParameter.GetDefinition().GetDataType());
 
                     parameter.InternalGlobalParameter.SetValue(
                         new Autodesk.Revit.DB.DoubleParameterValue(valueToSet));
@@ -269,6 +297,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get Parameter Group
         /// </summary>
+        [NodeObsolete("GroupObsolete", typeof(Properties.Resources))]
         public string ParameterGroup
         {
             get
@@ -291,6 +320,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get Parameter Type
         /// </summary>
+        [NodeObsolete("ParameterTypeObsolete", typeof(Properties.Resources))]
         public string ParameterType
         {
             get
@@ -299,6 +329,27 @@ namespace Revit.Elements
             }
         }
 
+        /// <summary>
+        /// Get SpecType
+        /// </summary>
+        public ForgeType SpecType
+        {
+            get
+            {
+                return ForgeType.FromExisting(this.InternalGlobalParameter.GetDefinition().GetDataType());
+            }
+        }
+
+        /// <summary>
+        /// Get Parameter Group Type
+        /// </summary>
+        public ForgeType GroupType
+        {
+            get
+            {
+                return ForgeType.FromExisting(this.InternalGlobalParameter.GetDefinition().GetGroupTypeId());
+            }
+        }
 
         #endregion
 
@@ -310,6 +361,7 @@ namespace Revit.Elements
         /// <param name="name">Name fo the parameter</param>
         /// <param name="parameterType">Parameter type</param>
         /// <returns></returns>
+        [NodeObsolete("GlobalParameterByNameObsolete", typeof(Properties.Resources))]
         public static GlobalParameter ByName(string name, string parameterType)
         {
             Autodesk.Revit.DB.ParameterType ptype = Autodesk.Revit.DB.ParameterType.Text;
@@ -322,6 +374,22 @@ namespace Revit.Elements
             }
 
             return new GlobalParameter(name, ptype);
+        }
+
+        /// <summary>
+        /// Create a new Global Parameter by Name and Type
+        /// </summary>
+        /// <param name="name">Name fo the parameter</param>
+        /// <param name="specType">Spec Type</param>
+        /// <returns></returns>
+        public static GlobalParameter ByName(string name, ForgeType specType)
+        {
+            if (!Autodesk.Revit.DB.GlobalParametersManager.AreGlobalParametersAllowed(Document))
+            {
+                throw new Exception(Properties.Resources.DocumentDoesNotSupportGlobalParams);
+            }
+
+            return new GlobalParameter(name, specType.InternalForgeTypeId);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementUtils.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementUtils.cs
@@ -97,7 +97,7 @@ namespace Revit.Elements.InternalUtilities
                     result = param.AsInteger();
                     break;
                 case StorageType.Double:
-                    result = param.AsDouble() * Revit.GeometryConversion.UnitConverter.HostToDynamoFactor(param.Definition.GetSpecTypeId());
+                    result = param.AsDouble() * Revit.GeometryConversion.UnitConverter.HostToDynamoFactor(param.Definition.GetDataType());
                     break;
                 default:
                     throw new Exception(string.Format(Properties.Resources.ParameterWithoutStorageType, param));
@@ -114,7 +114,7 @@ namespace Revit.Elements.InternalUtilities
             if (param.StorageType != StorageType.Integer && param.StorageType != StorageType.Double)
                 throw new Exception(Properties.Resources.ParameterStorageNotNumber);
 
-            var valueToSet = value * UnitConverter.DynamoToHostFactor(param.Definition.GetSpecTypeId());
+            var valueToSet = value * UnitConverter.DynamoToHostFactor(param.Definition.GetDataType());
 
             param.Set(valueToSet);
         }
@@ -134,7 +134,7 @@ namespace Revit.Elements.InternalUtilities
             if (param.StorageType != StorageType.Integer && param.StorageType != StorageType.Double)
                 throw new Exception(Properties.Resources.ParameterStorageNotNumber);
 
-            var valueToSet = value * UnitConverter.DynamoToHostFactor(param.Definition.GetSpecTypeId());
+            var valueToSet = value * UnitConverter.DynamoToHostFactor(param.Definition.GetDataType());
 
             param.Set(valueToSet);
         }

--- a/src/Libraries/RevitNodes/Elements/Parameter.cs
+++ b/src/Libraries/RevitNodes/Elements/Parameter.cs
@@ -99,7 +99,7 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Get SpecType
+        /// Get the parameter's SpecType
         /// </summary>
         public ForgeType SpecType
         {
@@ -107,7 +107,7 @@ namespace Revit.Elements
         }
 
         /// <summary>
-        /// Get Parameter Group Type
+        /// Get the Parameter's Group Type
         /// </summary>
         public ForgeType GroupType
         {
@@ -201,7 +201,7 @@ namespace Revit.Elements
         /// <param name="groupName">Group of the parameter for shared parameters</param>
         /// <param name="type">Parameter Type</param>
         /// <param name="group">Parameter Group</param>
-        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
+        /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
         [NodeObsolete("CreateSharedParameterForAllCategoriesObsolete", typeof(Properties.Resources))]
         public static void CreateSharedParameterForAllCategories(string parameterName, string groupName, string type, string group, bool instance)
         {
@@ -215,8 +215,8 @@ namespace Revit.Elements
         /// <param name="groupName">Group of the parameter for shared parameters</param>
         /// <param name="type">Parameter Type</param>
         /// <param name="group">Parameter Group</param>
-        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
-        /// <param name="categoryList">List of categories this parameter applies to, If no category is supplied, all possible categories are selected</param>
+        /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
+        /// <param name="categoryList">A list of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
         [NodeObsolete("CreateSharedParameterObsolete", typeof(Properties.Resources))]
         public static void CreateSharedParameter(string parameterName, string groupName, string type, string group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
@@ -288,12 +288,12 @@ namespace Revit.Elements
         /// </summary>
         /// <param name="parameterName">Name</param>
         /// <param name="groupName">Group of the parameter for shared parameters</param>
-        /// <param name="specType">Spec Type</param>
-        /// <param name="group">Group Type</param>
-        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
-        public static void CreateSharedParameterForAllCategories(string parameterName, string groupName, ForgeType specType, ForgeType group, bool instance)
+        /// <param name="specType">The type of new parameter.</param>
+        /// <param name="groupType">The type of the group to which the parameter belongs.</param>
+        /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
+        public static void CreateSharedParameterForAllCategories(string parameterName, string groupName, ForgeType specType, ForgeType groupType, bool instance)
         {
-            CreateSharedParameter(parameterName, groupName, specType, group, instance, null);
+            CreateSharedParameter(parameterName, groupName, specType, groupType, instance, null);
         }
 
         /// <summary>
@@ -301,11 +301,11 @@ namespace Revit.Elements
         /// </summary>
         /// <param name="parameterName">Name</param>
         /// <param name="groupName">Group of the parameter for shared parameters</param>
-        /// <param name="specType">Spec Type</param>
-        /// <param name="group">Group Type</param>
-        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
-        /// <param name="categoryList">List of categories this parameter applies to, If no category is supplied, all possible categories are selected</param>
-        public static void CreateSharedParameter(string parameterName, string groupName, ForgeType specType, ForgeType group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
+        /// <param name="specType">The type of new parameter.</param>
+        /// <param name="groupType">The type of the group to which the parameter belongs.</param>
+        /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
+        /// <param name="categoryList">A list of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
+        public static void CreateSharedParameter(string parameterName, string groupName, ForgeType specType, ForgeType groupType, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
             // get document and open transaction
             Document document = Application.Document.Current.InternalDocument;
@@ -347,7 +347,7 @@ namespace Revit.Elements
                         (Binding)document.Application.Create.NewInstanceBinding(categories) :
                         (Binding)document.Application.Create.NewTypeBinding(categories);
 
-                    document.ParameterBindings.Insert(def, bin, group.InternalForgeTypeId);
+                    document.ParameterBindings.Insert(def, bin, groupType.InternalForgeTypeId);
                 }
 
             }
@@ -371,7 +371,7 @@ namespace Revit.Elements
         /// <param name="groupName">Group of the parameter for shared parameters</param>
         /// <param name="type">Parameter Type</param>
         /// <param name="group">Parameter Group</param>
-        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
+        /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
         [NodeObsolete("CreateProjectParameterForAllCategoriesObsolete", typeof(Properties.Resources))]
         public static void CreateProjectParameterForAllCategories(string parameterName, string groupName, string type, string group, bool instance)
         {
@@ -385,8 +385,8 @@ namespace Revit.Elements
         /// <param name="groupName">Group of the parameter for shared parameters</param>
         /// <param name="type">Parameter Type</param>
         /// <param name="group">Parameter Group</param>
-        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
-        /// <param name="categoryList">List of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
+        /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
+        /// <param name="categoryList">A list of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
         [NodeObsolete("CreateProjectParameterObsolete", typeof(Properties.Resources))]
         public static void CreateProjectParameter(string parameterName, string groupName, string type, string group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
@@ -451,12 +451,12 @@ namespace Revit.Elements
         /// </summary>
         /// <param name="parameterName">Name</param>
         /// <param name="groupName">Group of the parameter for shared parameters</param>
-        /// <param name="specType">Parameter Type</param>
-        /// <param name="group">Parameter Group</param>
-        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
-        public static void CreateProjectParameterForAllCategories(string parameterName, string groupName, ForgeType specType, ForgeType group, bool instance)
+        /// <param name="specType">The type of new parameter.</param>
+        /// <param name="groupType">The type of the group to which the parameter belongs.</param>
+        /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
+        public static void CreateProjectParameterForAllCategories(string parameterName, string groupName, ForgeType specType, ForgeType groupType, bool instance)
         {
-            CreateProjectParameter(parameterName, groupName, specType, group, instance, null);
+            CreateProjectParameter(parameterName, groupName, specType, groupType, instance, null);
         }
 
         /// <summary>
@@ -464,11 +464,11 @@ namespace Revit.Elements
         /// </summary>
         /// <param name="parameterName">Name</param>
         /// <param name="groupName">Group of the parameter for shared parameters</param>
-        /// <param name="specType">Spec Type</param>
-        /// <param name="group">Group Type</param>
-        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
-        /// <param name="categoryList">List of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
-        public static void CreateProjectParameter(string parameterName, string groupName, ForgeType specType, ForgeType group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
+        /// <param name="specType">The type of new parameter.</param>
+        /// <param name="groupType">The type of the group to which the parameter belongs.</param>
+        /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
+        /// <param name="categoryList">A list of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
+        public static void CreateProjectParameter(string parameterName, string groupName, ForgeType specType, ForgeType groupType, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
             // get document and open transaction
             Document document = Application.Document.Current.InternalDocument;
@@ -497,7 +497,7 @@ namespace Revit.Elements
                     (Binding)document.Application.Create.NewTypeBinding(categories);
 
                 // Apply parameter bindings
-                document.ParameterBindings.Insert(def, bin, group.InternalForgeTypeId);
+                document.ParameterBindings.Insert(def, bin, groupType.InternalForgeTypeId);
 
                 // apply old shared parameter file
                 document.Application.SharedParametersFilename = sharedParameterFile;

--- a/src/Libraries/RevitNodes/Elements/Parameter.cs
+++ b/src/Libraries/RevitNodes/Elements/Parameter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Autodesk.Revit.DB;
 using RevitServices.Transactions;
+using Dynamo.Graph.Nodes;
 
 namespace Revit.Elements
 {
@@ -65,6 +66,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get the parameter's group
         /// </summary>
+        [NodeObsolete("GroupObsolete", typeof(Properties.Resources))]
         public string Group
         {
             get { return InternalParameter.Definition.ParameterGroup.ToString(); }
@@ -73,6 +75,7 @@ namespace Revit.Elements
         /// <summary>
         /// Get the parameter type
         /// </summary>
+        [NodeObsolete("ParameterTypeObsolete", typeof(Properties.Resources))]
         public string ParameterType
         {
             get { return InternalParameter.Definition.ParameterType.ToString(); }
@@ -89,11 +92,27 @@ namespace Revit.Elements
         /// <summary>
         /// Get the parameter's unit type
         /// </summary>
+        [NodeObsolete("UnitTypeObsolete", typeof(Properties.Resources))]
         public string UnitType
         {
             get { return InternalParameter.Definition.GetSpecTypeId().ToString(); }
         }
 
+        /// <summary>
+        /// Get SpecType
+        /// </summary>
+        public ForgeType SpecType
+        {
+            get { return ForgeType.FromExisting(InternalParameter.Definition.GetDataType()); }
+        }
+
+        /// <summary>
+        /// Get Parameter Group Type
+        /// </summary>
+        public ForgeType GroupType
+        {
+            get { return ForgeType.FromExisting(InternalParameter.Definition.GetGroupTypeId()); }
+        }
 
         /// <summary>
         /// Get Element's Parameter by Name
@@ -183,6 +202,7 @@ namespace Revit.Elements
         /// <param name="type">Parameter Type</param>
         /// <param name="group">Parameter Group</param>
         /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
+        [NodeObsolete("CreateSharedParameterForAllCategoriesObsolete", typeof(Properties.Resources))]
         public static void CreateSharedParameterForAllCategories(string parameterName, string groupName, string type, string group, bool instance)
         {
             CreateSharedParameter(parameterName, groupName, type, group, instance, null); 
@@ -197,6 +217,7 @@ namespace Revit.Elements
         /// <param name="group">Parameter Group</param>
         /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
         /// <param name="categoryList">List of categories this parameter applies to, If no category is supplied, all possible categories are selected</param>
+        [NodeObsolete("CreateSharedParameterObsolete", typeof(Properties.Resources))]
         public static void CreateSharedParameter(string parameterName, string groupName, string type, string group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
             // parse parameter type
@@ -262,6 +283,82 @@ namespace Revit.Elements
             TransactionManager.Instance.TransactionTaskDone();
         }
 
+        /// <summary>
+        /// Create a new Shared Parameter in the current Revit document for all applicable categories
+        /// </summary>
+        /// <param name="parameterName">Name</param>
+        /// <param name="groupName">Group of the parameter for shared parameters</param>
+        /// <param name="specType">Spec Type</param>
+        /// <param name="group">Group Type</param>
+        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
+        public static void CreateSharedParameterForAllCategories(string parameterName, string groupName, ForgeType specType, ForgeType group, bool instance)
+        {
+            CreateSharedParameter(parameterName, groupName, specType, group, instance, null);
+        }
+
+        /// <summary>
+        /// Create a new Shared Parameter in the current Revit document
+        /// </summary>
+        /// <param name="parameterName">Name</param>
+        /// <param name="groupName">Group of the parameter for shared parameters</param>
+        /// <param name="specType">Spec Type</param>
+        /// <param name="group">Group Type</param>
+        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
+        /// <param name="categoryList">List of categories this parameter applies to, If no category is supplied, all possible categories are selected</param>
+        public static void CreateSharedParameter(string parameterName, string groupName, ForgeType specType, ForgeType group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
+        {
+            // get document and open transaction
+            Document document = Application.Document.Current.InternalDocument;
+            TransactionManager.Instance.EnsureInTransaction(document);
+
+            try
+            {
+                // get current shared parameter file
+                string sharedParameterFile = document.Application.SharedParametersFilename;
+
+                // if the file does not exist, throw an error
+                if (sharedParameterFile == null || !System.IO.File.Exists(sharedParameterFile))
+                    throw new System.Exception(Properties.Resources.NoSharedParameterFileFound);
+
+                // Apply selected parameter categories
+                CategorySet categories = (categoryList == null) ? AllCategories() : ToCategorySet(categoryList);
+
+                // Create new parameter group if it does not exist yet
+                DefinitionGroup groupDef =
+                    document.Application.OpenSharedParameterFile()
+                    .Groups.get_Item(groupName);
+
+                if (groupDef == null)
+                {
+                    groupDef =
+                        document.Application.OpenSharedParameterFile()
+                        .Groups.Create(groupName);
+                }
+
+                // If the parameter definition does not exist yet, create it
+                if (groupDef.Definitions.get_Item(parameterName) == null)
+                {
+                    ExternalDefinition def =
+                        groupDef.Definitions.Create
+                        (new ExternalDefinitionCreationOptions(parameterName, specType.InternalForgeTypeId)) as ExternalDefinition;
+
+                    // Apply instance or type binding
+                    Binding bin = (instance) ?
+                        (Binding)document.Application.Create.NewInstanceBinding(categories) :
+                        (Binding)document.Application.Create.NewTypeBinding(categories);
+
+                    document.ParameterBindings.Insert(def, bin, group.InternalForgeTypeId);
+                }
+
+            }
+            catch (System.Exception e)
+            {
+                TransactionManager.Instance.ForceCloseTransaction();
+                throw e;
+            }
+
+            TransactionManager.Instance.TransactionTaskDone();
+        }
 
         #endregion
 
@@ -275,6 +372,7 @@ namespace Revit.Elements
         /// <param name="type">Parameter Type</param>
         /// <param name="group">Parameter Group</param>
         /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
+        [NodeObsolete("CreateProjectParameterForAllCategoriesObsolete", typeof(Properties.Resources))]
         public static void CreateProjectParameterForAllCategories(string parameterName, string groupName, string type, string group, bool instance)
         {
             CreateProjectParameter(parameterName, groupName, type, group, instance, null);
@@ -289,6 +387,7 @@ namespace Revit.Elements
         /// <param name="group">Parameter Group</param>
         /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
         /// <param name="categoryList">List of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
+        [NodeObsolete("CreateProjectParameterObsolete", typeof(Properties.Resources))]
         public static void CreateProjectParameter(string parameterName, string groupName, string type, string group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
             // parse parameter type
@@ -329,6 +428,76 @@ namespace Revit.Elements
 
                 // Apply parameter bindings
                 document.ParameterBindings.Insert(def, bin, parameterGroup);
+
+                // apply old shared parameter file
+                document.Application.SharedParametersFilename = sharedParameterFile;
+
+                // delete temp shared parameter file
+                System.IO.File.Delete(tempSharedParameterFile);
+
+
+            }
+            catch (System.Exception e)
+            {
+                TransactionManager.Instance.ForceCloseTransaction();
+                throw e;
+            }
+
+            TransactionManager.Instance.TransactionTaskDone();
+        }
+
+        /// <summary>
+        /// Create a new Project Parameter in this current Revit document for all applicable categories
+        /// </summary>
+        /// <param name="parameterName">Name</param>
+        /// <param name="groupName">Group of the parameter for shared parameters</param>
+        /// <param name="specType">Parameter Type</param>
+        /// <param name="group">Parameter Group</param>
+        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
+        public static void CreateProjectParameterForAllCategories(string parameterName, string groupName, ForgeType specType, ForgeType group, bool instance)
+        {
+            CreateProjectParameter(parameterName, groupName, specType, group, instance, null);
+        }
+
+        /// <summary>
+        /// Create a new Project Parameter in this current Revit document
+        /// </summary>
+        /// <param name="parameterName">Name</param>
+        /// <param name="groupName">Group of the parameter for shared parameters</param>
+        /// <param name="specType">Spec Type</param>
+        /// <param name="group">Group Type</param>
+        /// <param name="instance">Is instance parameter, otherwise it's a type parameter</param>
+        /// <param name="categoryList">List of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
+        public static void CreateProjectParameter(string parameterName, string groupName, ForgeType specType, ForgeType group, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
+        {
+            // get document and open transaction
+            Document document = Application.Document.Current.InternalDocument;
+            TransactionManager.Instance.EnsureInTransaction(document);
+
+            try
+            {
+                // buffer the current shared parameter file name and apply a new empty parameter file instead
+                string sharedParameterFile = document.Application.SharedParametersFilename;
+                string tempSharedParameterFile = System.IO.Path.GetTempFileName() + ".txt";
+                using (System.IO.File.Create(tempSharedParameterFile)) { }
+                document.Application.SharedParametersFilename = tempSharedParameterFile;
+
+                // Apply selected parameter categories
+                CategorySet categories = (categoryList == null) ? AllCategories() : ToCategorySet(categoryList);
+
+                // create a new shared parameter, since the file is empty everything has to be created from scratch
+                ExternalDefinition def =
+                    document.Application.OpenSharedParameterFile()
+                    .Groups.Create(groupName).Definitions.Create(
+                    new ExternalDefinitionCreationOptions(parameterName, specType.InternalForgeTypeId)) as ExternalDefinition;
+
+                // Create an instance or type binding
+                Binding bin = (instance) ?
+                    (Binding)document.Application.Create.NewInstanceBinding(categories) :
+                    (Binding)document.Application.Create.NewTypeBinding(categories);
+
+                // Apply parameter bindings
+                document.ParameterBindings.Insert(def, bin, group.InternalForgeTypeId);
 
                 // apply old shared parameter file
                 document.Application.SharedParametersFilename = sharedParameterFile;

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -196,6 +196,42 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This node may remove in future version. Use CreateProjectParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead..
+        /// </summary>
+        internal static string CreateProjectParameterForAllCategoriesObsolete {
+            get {
+                return ResourceManager.GetString("CreateProjectParameterForAllCategoriesObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This node may remove in future version. Use CreateProjectParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead..
+        /// </summary>
+        internal static string CreateProjectParameterObsolete {
+            get {
+                return ResourceManager.GetString("CreateProjectParameterObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This node may remove in future version. Use CreateSharedParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead..
+        /// </summary>
+        internal static string CreateSharedParameterForAllCategoriesObsolete {
+            get {
+                return ResourceManager.GetString("CreateSharedParameterForAllCategoriesObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This node may remove in future version. Use CreateSharedParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead..
+        /// </summary>
+        internal static string CreateSharedParameterObsolete {
+            get {
+                return ResourceManager.GetString("CreateSharedParameterObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Element has no Curtain Grid..
         /// </summary>
         internal static string CurtainGridNotFound {
@@ -511,6 +547,15 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This node may remove in future version. Use FamilyDocument.AddParameter(string, ForgeType, ForgeType, bool) instead..
+        /// </summary>
+        internal static string FamilyDocumentAddParameterObsolete {
+            get {
+                return ResourceManager.GetString("FamilyDocumentAddParameterObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not create the FamilyInstance.
         /// </summary>
         internal static string FamilyInstanceCreationFailure {
@@ -619,11 +664,29 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This node may remove in future version. Use GlobalParameter.ByName(string, ForgeType).
+        /// </summary>
+        internal static string GlobalParameterByNameObsolete {
+            get {
+                return ResourceManager.GetString("GlobalParameterByNameObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A Grid Element can only be created in a Revit Project..
         /// </summary>
         internal static string GridCreationFailure {
             get {
                 return ResourceManager.GetString("GridCreationFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This property may remove in future version. Use GroupType instead..
+        /// </summary>
+        internal static string GroupObsolete {
+            get {
+                return ResourceManager.GetString("GroupObsolete", resourceCulture);
             }
         }
         
@@ -1087,6 +1150,15 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This property may remove in future version. Use SpecType instead..
+        /// </summary>
+        internal static string ParameterTypeObsolete {
+            get {
+                return ResourceManager.GetString("ParameterTypeObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Parameter {0} has no storage type..
         /// </summary>
         internal static string ParameterWithoutStorageType {
@@ -1299,6 +1371,15 @@ namespace Revit.Properties {
         internal static string TypeNotFound {
             get {
                 return ResourceManager.GetString("TypeNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This property may remove in future version. Use SpecType instead..
+        /// </summary>
+        internal static string UnitTypeObsolete {
+            get {
+                return ResourceManager.GetString("UnitTypeObsolete", resourceCulture);
             }
         }
         

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -196,7 +196,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This node may remove in future version. Use CreateProjectParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead..
+        ///   Looks up a localized string similar to This node may be removed in future version. Use CreateProjectParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead..
         /// </summary>
         internal static string CreateProjectParameterForAllCategoriesObsolete {
             get {
@@ -205,7 +205,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This node may remove in future version. Use CreateProjectParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead..
+        ///   Looks up a localized string similar to This node may be removed in future version. Use CreateProjectParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead..
         /// </summary>
         internal static string CreateProjectParameterObsolete {
             get {
@@ -214,7 +214,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This node may remove in future version. Use CreateSharedParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead..
+        ///   Looks up a localized string similar to This node may be removed in future version. Use CreateSharedParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead..
         /// </summary>
         internal static string CreateSharedParameterForAllCategoriesObsolete {
             get {
@@ -223,7 +223,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This node may remove in future version. Use CreateSharedParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead..
+        ///   Looks up a localized string similar to This node may be removed in future version. Use CreateSharedParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead..
         /// </summary>
         internal static string CreateSharedParameterObsolete {
             get {
@@ -547,7 +547,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This node may remove in future version. Use FamilyDocument.AddParameter(string, ForgeType, ForgeType, bool) instead..
+        ///   Looks up a localized string similar to This node may be removed in future version. Use FamilyDocument.AddParameter(string, ForgeType, ForgeType, bool) instead..
         /// </summary>
         internal static string FamilyDocumentAddParameterObsolete {
             get {
@@ -664,7 +664,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This node may remove in future version. Use GlobalParameter.ByName(string, ForgeType).
+        ///   Looks up a localized string similar to This node may be removed in future version. Use GlobalParameter.ByName(string, ForgeType).
         /// </summary>
         internal static string GlobalParameterByNameObsolete {
             get {
@@ -682,7 +682,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This property may remove in future version. Use GroupType instead..
+        ///   Looks up a localized string similar to This property may be removed in future version. Use GroupType instead..
         /// </summary>
         internal static string GroupObsolete {
             get {
@@ -1150,7 +1150,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This property may remove in future version. Use SpecType instead..
+        ///   Looks up a localized string similar to This property may be removed in future version. Use SpecType instead..
         /// </summary>
         internal static string ParameterTypeObsolete {
             get {
@@ -1375,7 +1375,7 @@ namespace Revit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This property may remove in future version. Use SpecType instead..
+        ///   Looks up a localized string similar to This property may be removed in future version. Use SpecType instead..
         /// </summary>
         internal static string UnitTypeObsolete {
             get {

--- a/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
@@ -546,4 +546,31 @@
   <data name="NotHorizontalInputPolyCurveError" xml:space="preserve">
     <value>Curves does not create closed horizontal loop.</value>
   </data>
+  <data name="CreateProjectParameterForAllCategoriesObsolete" xml:space="preserve">
+    <value>This node may be removed in future version. Use CreateProjectParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead.</value>
+  </data>
+  <data name="CreateProjectParameterObsolete" xml:space="preserve">
+    <value>This node may be removed in future version. Use CreateProjectParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead.</value>
+  </data>
+  <data name="CreateSharedParameterForAllCategoriesObsolete" xml:space="preserve">
+    <value>This node may be removed in future version. Use CreateSharedParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead.</value>
+  </data>
+  <data name="CreateSharedParameterObsolete" xml:space="preserve">
+    <value>This node may be removed in future version. Use CreateSharedParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead.</value>
+  </data>
+  <data name="FamilyDocumentAddParameterObsolete" xml:space="preserve">
+    <value>This node may be removed in future version. Use FamilyDocument.AddParameter(string, ForgeType, ForgeType, bool) instead.</value>
+  </data>
+  <data name="GlobalParameterByNameObsolete" xml:space="preserve">
+    <value>This node may be removed in future version. Use GlobalParameter.ByName(string, ForgeType)</value>
+  </data>
+  <data name="GroupObsolete" xml:space="preserve">
+    <value>This property may be removed in future version. Use GroupType instead.</value>
+  </data>
+  <data name="ParameterTypeObsolete" xml:space="preserve">
+    <value>This property may be removed in future version. Use SpecType instead.</value>
+  </data>
+  <data name="UnitTypeObsolete" xml:space="preserve">
+    <value>This property may be removed in future version. Use SpecType instead.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -574,30 +574,30 @@
     <value>Curves does not create closed horizontal loop.</value>
   </data>
   <data name="CreateProjectParameterForAllCategoriesObsolete" xml:space="preserve">
-    <value>This node may remove in future version. Use CreateProjectParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead.</value>
+    <value>This node may be removed in future version. Use CreateProjectParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead.</value>
   </data>
   <data name="CreateProjectParameterObsolete" xml:space="preserve">
-    <value>This node may remove in future version. Use CreateProjectParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead.</value>
+    <value>This node may be removed in future version. Use CreateProjectParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead.</value>
   </data>
   <data name="CreateSharedParameterForAllCategoriesObsolete" xml:space="preserve">
-    <value>This node may remove in future version. Use CreateSharedParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead.</value>
+    <value>This node may be removed in future version. Use CreateSharedParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead.</value>
   </data>
   <data name="CreateSharedParameterObsolete" xml:space="preserve">
-    <value>This node may remove in future version. Use CreateSharedParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead.</value>
+    <value>This node may be removed in future version. Use CreateSharedParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead.</value>
   </data>
   <data name="FamilyDocumentAddParameterObsolete" xml:space="preserve">
-    <value>This node may remove in future version. Use FamilyDocument.AddParameter(string, ForgeType, ForgeType, bool) instead.</value>
+    <value>This node may be removed in future version. Use FamilyDocument.AddParameter(string, ForgeType, ForgeType, bool) instead.</value>
   </data>
   <data name="GlobalParameterByNameObsolete" xml:space="preserve">
-    <value>This node may remove in future version. Use GlobalParameter.ByName(string, ForgeType)</value>
+    <value>This node may be removed in future version. Use GlobalParameter.ByName(string, ForgeType)</value>
   </data>
   <data name="GroupObsolete" xml:space="preserve">
-    <value>This property may remove in future version. Use GroupType instead.</value>
+    <value>This property may be removed in future version. Use GroupType instead.</value>
   </data>
   <data name="ParameterTypeObsolete" xml:space="preserve">
-    <value>This property may remove in future version. Use SpecType instead.</value>
+    <value>This property may be removed in future version. Use SpecType instead.</value>
   </data>
   <data name="UnitTypeObsolete" xml:space="preserve">
-    <value>This property may remove in future version. Use SpecType instead.</value>
+    <value>This property may be removed in future version. Use SpecType instead.</value>
   </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -573,4 +573,31 @@
   <data name="NotHorizontalInputPolyCurveError" xml:space="preserve">
     <value>Curves does not create closed horizontal loop.</value>
   </data>
+  <data name="CreateProjectParameterForAllCategoriesObsolete" xml:space="preserve">
+    <value>This node may remove in future version. Use CreateProjectParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead.</value>
+  </data>
+  <data name="CreateProjectParameterObsolete" xml:space="preserve">
+    <value>This node may remove in future version. Use CreateProjectParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead.</value>
+  </data>
+  <data name="CreateSharedParameterForAllCategoriesObsolete" xml:space="preserve">
+    <value>This node may remove in future version. Use CreateSharedParameterForAllCategories(string, string, ForgeType, ForgeType, bool) instead.</value>
+  </data>
+  <data name="CreateSharedParameterObsolete" xml:space="preserve">
+    <value>This node may remove in future version. Use CreateSharedParameter(string, string, ForgeType, ForgeType, bool, IEnumerable&lt;Category&gt;) instead.</value>
+  </data>
+  <data name="FamilyDocumentAddParameterObsolete" xml:space="preserve">
+    <value>This node may remove in future version. Use FamilyDocument.AddParameter(string, ForgeType, ForgeType, bool) instead.</value>
+  </data>
+  <data name="GlobalParameterByNameObsolete" xml:space="preserve">
+    <value>This node may remove in future version. Use GlobalParameter.ByName(string, ForgeType)</value>
+  </data>
+  <data name="GroupObsolete" xml:space="preserve">
+    <value>This property may remove in future version. Use GroupType instead.</value>
+  </data>
+  <data name="ParameterTypeObsolete" xml:space="preserve">
+    <value>This property may remove in future version. Use SpecType instead.</value>
+  </data>
+  <data name="UnitTypeObsolete" xml:space="preserve">
+    <value>This property may remove in future version. Use SpecType instead.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/RevitNodes/RevitNodes.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Elements\ElementType.cs" />
     <Compile Include="Elements\FilledRegion.cs" />
     <Compile Include="Elements\FilledRegionType.cs" />
+    <Compile Include="Elements\ForgeType.cs" />
     <Compile Include="Elements\GlobalParameter.cs" />
     <Compile Include="Elements\FamilyParameter.cs" />
     <Compile Include="Elements\Group.cs" />

--- a/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.Designer.cs
@@ -70,7 +70,7 @@ namespace DSRevitNodesUI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select a built-in parameter group..
+        ///   Looks up a localized string similar to Select a built-in parameter group. This node may be removed in future version. Use &apos;Group Types&apos; instead..
         /// </summary>
         internal static string BuiltInParameterGroupSelectorDescription {
             get {
@@ -268,6 +268,15 @@ namespace DSRevitNodesUI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Select a Group Type..
+        /// </summary>
+        internal static string GroupTypeSelectorDescription {
+            get {
+                return ResourceManager.GetString("GroupTypeSelectorDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select the horizontal text alignment style..
         /// </summary>
         internal static string HorizontalTextAlignmentStyleSelectorDescription {
@@ -376,7 +385,7 @@ namespace DSRevitNodesUI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select a parameter type..
+        ///   Looks up a localized string similar to Select a parameter type. This node may be removed in future version. Use &apos;Spec Types&apos; instead..
         /// </summary>
         internal static string ParameterTypeSelectorDescription {
             get {
@@ -804,6 +813,15 @@ namespace DSRevitNodesUI.Properties {
         internal static string SpacingRuleLayoutDescription {
             get {
                 return ResourceManager.GetString("SpacingRuleLayoutDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select a Spec type..
+        /// </summary>
+        internal static string SpecTypeSelectorDescription {
+            get {
+                return ResourceManager.GetString("SpecTypeSelectorDescription", resourceCulture);
             }
         }
         

--- a/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.en-US.resx
@@ -121,7 +121,7 @@
     <value>Returns a list of all instances of the selected warning type.</value>
   </data>
   <data name="BuiltInParameterGroupSelectorDescription" xml:space="preserve">
-    <value>Select a built-in parameter group.</value>
+    <value>Select a built-in parameter group. This node may be removed in future version. Use 'Group Types' instead.</value>
     <comment>Description for BuiltIn Parameter Group</comment>
   </data>
   <data name="CategoriesDescription" xml:space="preserve">
@@ -237,7 +237,7 @@
     <value>No warnings in the current document.</value>
   </data>
   <data name="ParameterTypeSelectorDescription" xml:space="preserve">
-    <value>Select a parameter type.</value>
+    <value>Select a parameter type. This node may be removed in future version. Use 'Spec Types' instead.</value>
     <comment>Description for Parameter Type</comment>
   </data>
   <data name="PerformanceAdviserDescription" xml:space="preserve">
@@ -462,5 +462,13 @@
   </data>
   <data name="NoCeilingTypesAvailable" xml:space="preserve">
     <value>No ceiling types available.</value>
+  </data>
+  <data name="GroupTypeSelectorDescription" xml:space="preserve">
+    <value>Select a Group Type.</value>
+    <comment>Description for Group Types</comment>
+  </data>
+  <data name="SpecTypeSelectorDescription" xml:space="preserve">
+    <value>Select a Spec type.</value>
+    <comment>Description for Spec Types</comment>
   </data>
 </root>

--- a/src/Libraries/RevitNodesUI/Properties/Resources.resx
+++ b/src/Libraries/RevitNodesUI/Properties/Resources.resx
@@ -121,7 +121,7 @@
     <value>Returns a list of all instances of the selected warning type.</value>
   </data>
   <data name="BuiltInParameterGroupSelectorDescription" xml:space="preserve">
-    <value>Select a built-in parameter group.</value>
+    <value>Select a built-in parameter group. This node may be removed in future version. Use 'Group Types' instead.</value>
     <comment>Description for BuiltIn Parameter Group</comment>
   </data>
   <data name="CategoriesDescription" xml:space="preserve">
@@ -237,7 +237,7 @@
     <value>No warnings in the current document.</value>
   </data>
   <data name="ParameterTypeSelectorDescription" xml:space="preserve">
-    <value>Select a parameter type.</value>
+    <value>Select a parameter type. This node may be removed in future version. Use 'Spec Types' instead.</value>
     <comment>Description for Parameter Type</comment>
   </data>
   <data name="PerformanceAdviserDescription" xml:space="preserve">
@@ -462,5 +462,13 @@
   </data>
   <data name="NoCeilingTypesAvailable" xml:space="preserve">
     <value>No ceiling types available.</value>
+  </data>
+  <data name="GroupTypeSelectorDescription" xml:space="preserve">
+    <value>Select a Group Type.</value>
+    <comment>Description for Group Types</comment>
+  </data>
+  <data name="SpecTypeSelectorDescription" xml:space="preserve">
+    <value>Select a Spec type.</value>
+    <comment>Description for Spec Types</comment>
   </data>
 </root>

--- a/src/Libraries/RevitNodesUI/RevitTypes.cs
+++ b/src/Libraries/RevitNodesUI/RevitTypes.cs
@@ -122,15 +122,33 @@ namespace DSRevitNodesUI
     [NodeDescription("ParameterTypeSelectorDescription", typeof(DSRevitNodesUI.Properties.Resources))]
     [IsDesignScriptCompatible]
     [OutPortTypes("string")]
+    [IsVisibleInDynamoLibrary(false)]
+    [Obsolete("This node may remove in future version. Use SpecTypes instead.")]
     public class ParameterType : CustomGenericEnumerationDropDown
     {
         private const string outputName = "Parameter Type";
-
+        
         public ParameterType() : base(outputName, typeof(Autodesk.Revit.DB.ParameterType)) { }
 
         [JsonConstructor]
         public ParameterType(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
             : base(outputName, typeof(Autodesk.Revit.DB.ParameterType), inPorts, outPorts) { }
+    }
+
+    [NodeName("Spec Types")]
+    [NodeCategory("Revit.Elements.Parameter")]
+    [NodeDescription("SpecTypeSelectorDescription", typeof(DSRevitNodesUI.Properties.Resources))]
+    [IsDesignScriptCompatible]
+    [OutPortTypes("Revit.Elements.ForgeType")]
+    public class SpecTypes : CustomGenericNestedClassDropDown
+    {
+        private const string outputName = "ForgeType";
+
+        public SpecTypes() : base(outputName, typeof(Autodesk.Revit.DB.SpecTypeId)) { }
+
+        [JsonConstructor]
+        public SpecTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(outputName, typeof(Autodesk.Revit.DB.SpecTypeId), inPorts, outPorts) { }
     }
 
     [NodeName("Select BuiltIn Parameter Group")]
@@ -147,6 +165,22 @@ namespace DSRevitNodesUI
         [JsonConstructor]
         public BuiltInParameterGroup(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts) 
             : base(outputName, typeof(Autodesk.Revit.DB.BuiltInParameterGroup), inPorts, outPorts) { }
+    }
+
+    [NodeName("Group Types")]
+    [NodeCategory("Revit.Elements.Parameter")]
+    [NodeDescription("GroupTypeSelectorDescription", typeof(DSRevitNodesUI.Properties.Resources))]
+    [IsDesignScriptCompatible]
+    [OutPortTypes("Revit.Elements.ForgeType")]
+    public class GroupTypes : CustomGenericNestedClassDropDown
+    {
+        private const string outputName = "ForgeType";
+
+        public GroupTypes() : base(outputName, typeof(Autodesk.Revit.DB.GroupTypeId)) { }
+
+        [JsonConstructor]
+        public GroupTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
+            : base(outputName, typeof(Autodesk.Revit.DB.GroupTypeId), inPorts, outPorts) { }
     }
 
     [NodeName("Select Revision Visibility")]

--- a/src/Libraries/RevitNodesUI/RevitTypes.cs
+++ b/src/Libraries/RevitNodesUI/RevitTypes.cs
@@ -123,7 +123,7 @@ namespace DSRevitNodesUI
     [IsDesignScriptCompatible]
     [OutPortTypes("string")]
     [IsVisibleInDynamoLibrary(false)]
-    [Obsolete("This node may remove in future version. Use SpecTypes instead.")]
+    [Obsolete("This node may be removed in future version. Use Spec Types instead.")]
     public class ParameterType : CustomGenericEnumerationDropDown
     {
         private const string outputName = "Parameter Type";
@@ -156,6 +156,8 @@ namespace DSRevitNodesUI
     [NodeDescription("BuiltInParameterGroupSelectorDescription", typeof(DSRevitNodesUI.Properties.Resources))]
     [IsDesignScriptCompatible]
     [OutPortTypes("string")]
+    [IsVisibleInDynamoLibrary(false)]
+    [Obsolete("This node may be removed in future version. Use Group Types instead.")]
     public class BuiltInParameterGroup : CustomGenericEnumerationDropDown
     {
         private const string outputName = "BuiltIn Parameter Group";

--- a/test/Libraries/RevitIntegrationTests/GlobalParameterTests.cs
+++ b/test/Libraries/RevitIntegrationTests/GlobalParameterTests.cs
@@ -30,8 +30,8 @@ namespace RevitSystemTests
             RunCurrentModel();
 
             Assert.AreEqual(GetPreviewValue("97d5b4ba-76e4-40e9-b1b2-8ce98e642a40"), "MyGlobalParameter");
-            Assert.AreEqual(GetPreviewValue("04ccd2fc-45bb-4953-9306-b7eb21d991a0"), "Text");
             Assert.AreEqual(GetPreviewValue("bb83a545-0c80-4f34-b987-da1d3d0dc2b7"), true);
+            Assert.AreEqual(GetPreviewValue("d058906178b3446d941d176123ff3ffd").GetType(), typeof(Revit.Elements.ForgeType));
         }
 
 

--- a/test/Libraries/RevitNodesTests/Application/FamilyDocumentTests.cs
+++ b/test/Libraries/RevitNodesTests/Application/FamilyDocumentTests.cs
@@ -228,8 +228,8 @@ namespace RevitNodesTests.Application
             var famDoc = new FamilyDocument(Document.Current.InternalDocument);
             var familyType = famDoc.InternalFamilyDocument.FamilyManager.CurrentType.Name;
             var paramName = "TestParam";
-            var paramGroup = "PG_DATA";
-            var paramType = "Text";
+            var paramGroup = ForgeType.FromExisting(Autodesk.Revit.DB.GroupTypeId.Data);
+            var paramType = ForgeType.FromExisting(Autodesk.Revit.DB.SpecTypeId.String.Text);
             var instance = false;
 
             // Act - Check that the new parameter dosent exist by trying to get the value of it

--- a/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/GlobalParametersTests.cs
@@ -15,17 +15,17 @@ namespace RevitNodesTests.Elements
         public void SetAndGetGlobalParameterByName()
         {
 
-            var gpString = Revit.Elements.GlobalParameter.ByName("MyGlobal", Autodesk.Revit.DB.ParameterType.Text.ToString());
+            var gpString = Revit.Elements.GlobalParameter.ByName("MyGlobal", Revit.Elements.ForgeType.FromExisting(Autodesk.Revit.DB.SpecTypeId.String.Text));
             Assert.IsNotNull(gpString.InternalGlobalParameter);
             Revit.Elements.GlobalParameter.SetValue(gpString, "4711");
             Assert.AreEqual("4711", gpString.Value);
 
-            var gpInt = Revit.Elements.GlobalParameter.ByName("MyGlobalInt", Autodesk.Revit.DB.ParameterType.Integer.ToString());
+            var gpInt = Revit.Elements.GlobalParameter.ByName("MyGlobalInt", Revit.Elements.ForgeType.FromExisting(Autodesk.Revit.DB.SpecTypeId.Int.Integer));
             Assert.IsNotNull(gpInt.InternalGlobalParameter);
             Revit.Elements.GlobalParameter.SetValue(gpInt, 4711);
             Assert.AreEqual(4711, gpInt.Value);
 
-            var gpLen = Revit.Elements.GlobalParameter.ByName("MyGlobalDouble", Autodesk.Revit.DB.ParameterType.Length.ToString());
+            var gpLen = Revit.Elements.GlobalParameter.ByName("MyGlobalDouble", Revit.Elements.ForgeType.FromExisting(Autodesk.Revit.DB.SpecTypeId.Length));
             Assert.IsNotNull(gpLen.InternalGlobalParameter);
             Revit.Elements.GlobalParameter.SetValue(gpLen, 47.11);
             double val = (double)gpLen.Value;
@@ -37,11 +37,11 @@ namespace RevitNodesTests.Elements
         public void SetAndGetGlobalParameterValue()
         {
 
-            var gp = Revit.Elements.GlobalParameter.ByName("MyGlobal", "Text");
+            var gp = Revit.Elements.GlobalParameter.ByName("MyGlobal", Revit.Elements.ForgeType.FromExisting(Autodesk.Revit.DB.SpecTypeId.String.Text));
             Assert.IsNotNull(gp);
             Assert.IsTrue(typeof(Revit.Elements.GlobalParameter) == gp.GetType());
             Assert.IsTrue("MyGlobal" == gp.Name);
-            Assert.IsTrue("Text" == gp.ParameterType);
+            Assert.IsTrue(typeof(Revit.Elements.ForgeType) == gp.SpecType.GetType());
             Assert.IsTrue(true == gp.Visible);
 
             var param = Revit.Elements.GlobalParameter.FindByName("MyGlobal");

--- a/test/Libraries/RevitNodesTests/Elements/ParameterTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/ParameterTests.cs
@@ -20,7 +20,7 @@ namespace RevitNodesTests.Elements
         {
             List<Category> categories = new List<Category>() { Category.ByName("Walls") };
 
-            Parameter.CreateProjectParameter("MyParameter", "MyGroup", Autodesk.Revit.DB.ParameterType.Text.ToString(), Autodesk.Revit.DB.BuiltInParameterGroup.PG_DATA.ToString(), true, categories);
+            Parameter.CreateProjectParameter("MyParameter", "MyGroup", ForgeType.FromExisting(Autodesk.Revit.DB.SpecTypeId.String.Text), ForgeType.FromExisting(Autodesk.Revit.DB.GroupTypeId.Data), true, categories);
 
             var fec = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument).OfClass(typeof(Autodesk.Revit.DB.Wall));
             var wall = fec.FirstElement(); 
@@ -46,7 +46,7 @@ namespace RevitNodesTests.Elements
 
             List<Category> categories = new List<Category>() { Category.ByName("Walls") };
 
-            Parameter.CreateSharedParameter("MySharedParameter", "MySharedGroup", Autodesk.Revit.DB.ParameterType.Text.ToString(), Autodesk.Revit.DB.BuiltInParameterGroup.PG_DATA.ToString(), true, categories);
+            Parameter.CreateSharedParameter("MySharedParameter", "MySharedGroup", ForgeType.FromExisting(Autodesk.Revit.DB.SpecTypeId.String.Text), ForgeType.FromExisting(Autodesk.Revit.DB.GroupTypeId.Data), true, categories);
             var fec = new Autodesk.Revit.DB.FilteredElementCollector(DocumentManager.Instance.CurrentDBDocument).OfClass(typeof(Autodesk.Revit.DB.Wall));
             var wall = fec.FirstElement();
             Assert.IsNotNull(wall.LookupParameter("MySharedParameter"));

--- a/test/System/FamilyDocument/CanAddParameterToFamilyDocument.dyn
+++ b/test/System/FamilyDocument/CanAddParameterToFamilyDocument.dyn
@@ -37,7 +37,7 @@
         }
       ],
       "Replication": "Auto",
-      "Description": "FamilyDocument.ByDocument (document: Document): FamilyDocument"
+      "Description": "Get FamilyDocument from a Document if this document is a Family Document.\n\nFamilyDocument.ByDocument (document: Document): FamilyDocument"
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
@@ -62,12 +62,12 @@
     {
       "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
       "NodeType": "CodeBlockNode",
-      "Code": "paramName = \"TestParam\";\nparamGroup = \"PG_DATA\";\nparamType = \"Text\";\ninstance = false;",
+      "Code": "paramName = \"TestParam\";\ninstance = false;",
       "Id": "64ed3a7f9e24424894af93fe6ee448c0",
       "Inputs": [],
       "Outputs": [
         {
-          "Id": "796a5b5b4277424d8e4acb04100048e0",
+          "Id": "c840802675ce4d949915c29d9138ffc3",
           "Name": "",
           "Description": "paramName",
           "UsingDefaultValue": false,
@@ -76,25 +76,7 @@
           "KeepListStructure": false
         },
         {
-          "Id": "8524b87e76d74d81ab460b21411ed3d1",
-          "Name": "",
-          "Description": "paramGroup",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "1985b5b77e2947ebb3f6cd14e7b5f4d5",
-          "Name": "",
-          "Description": "paramType",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "a3b84a1db2534bdcb6a37fa4c376da7c",
+          "Id": "bf3fa7b1b7d54c73bf6c59953755fb11",
           "Name": "",
           "Description": "instance",
           "UsingDefaultValue": false,
@@ -105,72 +87,6 @@
       ],
       "Replication": "Disabled",
       "Description": "Allows for DesignScript code to be authored directly"
-    },
-    {
-      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
-      "NodeType": "FunctionNode",
-      "FunctionSignature": "Revit.Application.FamilyDocument.AddParameter@string,string,string,bool",
-      "Id": "e28a9f67f61c443cb16e3024723913cf",
-      "Inputs": [
-        {
-          "Id": "34d3590206e74640bc4d938bab35521a",
-          "Name": "familyDocument",
-          "Description": "Revit.Application.FamilyDocument",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "aed4743be3be41ae9efd742124f078c3",
-          "Name": "parameterName",
-          "Description": "The name of the new family parameter.\n\nstring",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "8500fa718d9a42689e14a990ef6f2413",
-          "Name": "parameterGroup",
-          "Description": "The name of the group to which the family parameter belongs.\n\nstring",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "2a30fc4f481545319fef43f62aa62a4e",
-          "Name": "parameterType",
-          "Description": "The name of the type of new family parameter.\n\nstring",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        },
-        {
-          "Id": "f1001f2734884c9a83567b461e069b7e",
-          "Name": "instance",
-          "Description": "Indicates if the new family parameter is instance or type.\n\nbool",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "213580c33c2845f4bb61f6d487948d63",
-          "Name": "FamilyParameter",
-          "Description": "The new family parameter.",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Auto",
-      "Description": "Add a new family parameter with a given name.\n\nFamilyDocument.AddParameter (parameterName: string, parameterGroup: string, parameterType: string, instance: bool): FamilyParameter"
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
@@ -201,13 +117,121 @@
       ],
       "Replication": "Auto",
       "Description": "The name of the parameter.\n\nFamilyParameter.Name: string"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Application.FamilyDocument.AddParameter@string,Revit.Elements.ForgeType,Revit.Elements.ForgeType,bool",
+      "Id": "e3ff897029664fd1a162b5b6ddd866a6",
+      "Inputs": [
+        {
+          "Id": "fa05d694556a4967965d86bd8b8c0a4d",
+          "Name": "familyDocument",
+          "Description": "Revit.Application.FamilyDocument",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "df4d5c4950be4c3192b6111a619ef694",
+          "Name": "parameterName",
+          "Description": "The name of the new family parameter.\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "bdc819d40c104c5d8e219ea41ebdfe3b",
+          "Name": "group",
+          "Description": "The name of the group to which the family parameter belongs.\n\nForgeType",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "ac6b45cf8076477eb119d4d845bb9fd8",
+          "Name": "spec",
+          "Description": "The name of the type of new family parameter.\n\nForgeType",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "529f92b0120e4bc48a5223d8f4638a69",
+          "Name": "isInstance",
+          "Description": "Indicates if the new family parameter is instance or type (true if parameter should be instance).\n\nbool",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "1600a61583d847d9b24d9b60b76f1f9e",
+          "Name": "FamilyParameter",
+          "Description": "FamilyParameter",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "FamilyDocument.AddParameter (parameterName: string, group: ForgeType, spec: ForgeType, isInstance: bool): FamilyParameter"
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.GroupTypes, DSRevitNodesUI",
+      "SelectedIndex": 25,
+      "SelectedString": "Data",
+      "NodeType": "ExtensionNode",
+      "Id": "f93126a37b454f4bafecd8cff3157b4e",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "ef6acd0d31b14b639eaba2f8cd37b70d",
+          "Name": "ForgeType",
+          "Description": "The selected ForgeType",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Select a Group Type."
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.SpecTypes, DSRevitNodesUI",
+      "SelectedIndex": 143,
+      "SelectedString": "Text",
+      "NodeType": "ExtensionNode",
+      "Id": "6c03bda4ab124399ab32071522c88ff3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "f2fc0006556f4f10bc563709db973874",
+          "Name": "ForgeType",
+          "Description": "The selected ForgeType",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Select a Spec type."
     }
   ],
   "Connectors": [
     {
       "Start": "df51653f7d794c7a84f3b3ae895215e9",
-      "End": "34d3590206e74640bc4d938bab35521a",
-      "Id": "d8ec82bd778847b0832987ff8f083732"
+      "End": "fa05d694556a4967965d86bd8b8c0a4d",
+      "Id": "cedf41c821d144d18bf1e1536d4d32f2"
     },
     {
       "Start": "f7a31da1c4f349f887a48937db6e1774",
@@ -215,29 +239,29 @@
       "Id": "b220e1f6bfa242c4bd4135afc377485f"
     },
     {
-      "Start": "796a5b5b4277424d8e4acb04100048e0",
-      "End": "aed4743be3be41ae9efd742124f078c3",
-      "Id": "82e7b9e1eb064fb29efde9bda0586ff4"
+      "Start": "c840802675ce4d949915c29d9138ffc3",
+      "End": "df4d5c4950be4c3192b6111a619ef694",
+      "Id": "29d20efb1092416292b64a17408184a6"
     },
     {
-      "Start": "8524b87e76d74d81ab460b21411ed3d1",
-      "End": "8500fa718d9a42689e14a990ef6f2413",
-      "Id": "f3dbeca35e7d4a77a301dd21b1e4b89f"
+      "Start": "bf3fa7b1b7d54c73bf6c59953755fb11",
+      "End": "529f92b0120e4bc48a5223d8f4638a69",
+      "Id": "ad09eae4233b4bef9380e8ef88bd1942"
     },
     {
-      "Start": "1985b5b77e2947ebb3f6cd14e7b5f4d5",
-      "End": "2a30fc4f481545319fef43f62aa62a4e",
-      "Id": "fd7c1cd371904093ba9069c9d8be238f"
-    },
-    {
-      "Start": "a3b84a1db2534bdcb6a37fa4c376da7c",
-      "End": "f1001f2734884c9a83567b461e069b7e",
-      "Id": "7f54ecf1f24a4b339b1b875000309adb"
-    },
-    {
-      "Start": "213580c33c2845f4bb61f6d487948d63",
+      "Start": "1600a61583d847d9b24d9b60b76f1f9e",
       "End": "782d29db80304824b7cbcf4f59e6c5bf",
-      "Id": "4f86f61fb2b749f79e3b36e44ac0fc99"
+      "Id": "5cca1fc378ff4ea5a484d83ef5b52034"
+    },
+    {
+      "Start": "ef6acd0d31b14b639eaba2f8cd37b70d",
+      "End": "bdc819d40c104c5d8e219ea41ebdfe3b",
+      "Id": "99e1cdaf0cb84b928ae4c8ba5f0e4a57"
+    },
+    {
+      "Start": "f2fc0006556f4f10bc563709db973874",
+      "End": "ac6b45cf8076477eb119d4d845bb9fd8",
+      "Id": "2c88f60b884b4578ab5599e7e1b411f2"
     }
   ],
   "Dependencies": [],
@@ -248,7 +272,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.6.0.7237",
+      "Version": "2.10.1.3976",
       "RunType": "Automatic",
       "RunPeriod": "1000"
     },
@@ -272,8 +296,8 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 255.99999999999994,
-        "Y": 237.33333333333331
+        "X": 285.75420375865485,
+        "Y": 237.63977013133808
       },
       {
         "ShowGeometry": true,
@@ -282,8 +306,8 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 70.666666666666657,
-        "Y": 238.0
+        "X": 51.754203758654853,
+        "Y": 237.63977013133808
       },
       {
         "ShowGeometry": true,
@@ -292,18 +316,8 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 312.03560830860522,
-        "Y": 336.5568743818003
-      },
-      {
-        "ShowGeometry": true,
-        "Name": "FamilyDocument.AddParameter",
-        "Id": "e28a9f67f61c443cb16e3024723913cf",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 682.150346191889,
-        "Y": 237.80415430267038
+        "X": 285.75420375865485,
+        "Y": 455.0664367980047
       },
       {
         "ShowGeometry": true,
@@ -312,13 +326,43 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 1073.841740850643,
-        "Y": 237.80415430267055
+        "X": 1092.754203758655,
+        "Y": 355.63977013133808
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "FamilyDocument.AddParameter",
+        "Id": "e3ff897029664fd1a162b5b6ddd866a6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 669.75420375865485,
+        "Y": 355.63977013133808
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Group Types",
+        "Id": "f93126a37b454f4bafecd8cff3157b4e",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 285.75420375865485,
+        "Y": 346.63977013133808
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Spec Types",
+        "Id": "6c03bda4ab124399ab32071522c88ff3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 285.75420375865485,
+        "Y": 573.63977013133808
       }
     ],
     "Annotations": [],
-    "X": 9.2020532393669328,
-    "Y": -15.6416091122652,
-    "Zoom": 0.70823125000000009
+    "X": -497.55637554410737,
+    "Y": -212.43358404625445,
+    "Zoom": 1.0792537289518347
   }
 }

--- a/test/System/Parameter/GlobalParameter.dyn
+++ b/test/System/Parameter/GlobalParameter.dyn
@@ -1,33 +1,308 @@
-<Workspace Version="1.2.1.2802" X="15.9109978299614" Y="64.5931612167346" zoom="0.612283078543345" Name="Home" Description="" RunType="Automatic" RunPeriod="1000" HasRunWithoutCrash="True">
-  <NamespaceResolutionMap />
-  <Elements>
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="GlobalParameter.ByName" x="348.5" y="167.5" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="RevitNodes.dll" function="Revit.Elements.GlobalParameter.ByName@string,string">
-      <PortInfo index="0" default="False" />
-      <PortInfo index="1" default="False" />
-    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="2686aa52-2a95-4d9d-b637-9bbc63e40f98" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="91" y="87" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="&quot;MyGlobalParameter&quot;;" ShouldFocus="false" />
-    <Dynamo.Graph.Nodes.CodeBlockNodeModel guid="89205379-97aa-4d39-bbf1-390e9342f7d3" type="Dynamo.Graph.Nodes.CodeBlockNodeModel" nickname="Code Block" x="204" y="253" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" CodeText="&quot;Text&quot;;" ShouldFocus="false" />
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="bb83a545-0c80-4f34-b987-da1d3d0dc2b7" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="GlobalParameter.Visible" x="702.248458777932" y="16.8103369451022" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="RevitNodes.dll" function="Revit.Elements.GlobalParameter.Visible">
-      <PortInfo index="0" default="False" />
-    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="97d5b4ba-76e4-40e9-b1b2-8ce98e642a40" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="GlobalParameter.Name" x="697.348764330819" y="315.691698218987" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="RevitNodes.dll" function="Revit.Elements.GlobalParameter.Name">
-      <PortInfo index="0" default="False" />
-    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
-    <Dynamo.Graph.Nodes.ZeroTouch.DSFunction guid="04ccd2fc-45bb-4953-9306-b7eb21d991a0" type="Dynamo.Graph.Nodes.ZeroTouch.DSFunction" nickname="GlobalParameter.ParameterType" x="690.815838401335" y="167.06763332323" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" IsFrozen="false" isPinned="false" assembly="RevitNodes.dll" function="Revit.Elements.GlobalParameter.ParameterType">
-      <PortInfo index="0" default="False" />
-    </Dynamo.Graph.Nodes.ZeroTouch.DSFunction>
-  </Elements>
-  <Connectors>
-    <Dynamo.Graph.Connectors.ConnectorModel start="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" start_index="0" end="bb83a545-0c80-4f34-b987-da1d3d0dc2b7" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" start_index="0" end="04ccd2fc-45bb-4953-9306-b7eb21d991a0" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" start_index="0" end="97d5b4ba-76e4-40e9-b1b2-8ce98e642a40" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="2686aa52-2a95-4d9d-b637-9bbc63e40f98" start_index="0" end="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" end_index="0" portType="0" />
-    <Dynamo.Graph.Connectors.ConnectorModel start="89205379-97aa-4d39-bbf1-390e9342f7d3" start_index="0" end="c165d4d4-2a9e-4893-8b1c-1fcd4fcc9971" end_index="1" portType="0" />
-  </Connectors>
-  <Notes />
-  <Annotations />
-  <Presets />
-  <Cameras>
-    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
-  </Cameras>
-</Workspace>
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "GlobalParameter",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "\"MyGlobalParameter\";",
+      "Id": "2686aa522a954d9db6379bbc63e40f98",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "ad0603b502b944d5b53be29ff4694280",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.GlobalParameter.Visible",
+      "Id": "bb83a5450c804f34b987da1d3d0dc2b7",
+      "Inputs": [
+        {
+          "Id": "d10974dd38f148e3b522079c1cadaf92",
+          "Name": "globalParameter",
+          "Description": "Revit.Elements.GlobalParameter",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8fa44d377cfb4b66a2c260763e092ab9",
+          "Name": "bool",
+          "Description": "bool",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get Parameter Visibility\n\nGlobalParameter.Visible: bool"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.GlobalParameter.Name",
+      "Id": "97d5b4ba76e440e9b1b28ce98e642a40",
+      "Inputs": [
+        {
+          "Id": "98162f850b8747a2b74a95f9ce833bfb",
+          "Name": "globalParameter",
+          "Description": "Revit.Elements.GlobalParameter",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "4256bcc9f8eb462cbe314640f7fc8d0d",
+          "Name": "string",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get Name\n\nGlobalParameter.Name: string"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.GlobalParameter.ByName@string,Revit.Elements.ForgeType",
+      "Id": "3a826db236c24f0ab94c25d2674b73fe",
+      "Inputs": [
+        {
+          "Id": "7edf6d6cffd24c6e938bc0e9928eec5f",
+          "Name": "name",
+          "Description": "Name fo the parameter\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "40a3bcb24bd34746974b0f1f0f69a369",
+          "Name": "forgeType",
+          "Description": "ForgeType",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "df5a989b95a44e41a42e2349d10c7c9f",
+          "Name": "GlobalParameter",
+          "Description": "GlobalParameter",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Create a new Global Parameter by Name and Type\n\nGlobalParameter.ByName (name: string, forgeType: ForgeType): GlobalParameter"
+    },
+    {
+      "ConcreteType": "DSRevitNodesUI.SpecTypes, DSRevitNodesUI",
+      "SelectedIndex": 143,
+      "SelectedString": "Text",
+      "NodeType": "ExtensionNode",
+      "Id": "74898c78c73a414a8411749214197af3",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "59dba8442136452cbff929c86a322ffb",
+          "Name": "ForgeType",
+          "Description": "The selected ForgeType",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Select a Spec type."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.GlobalParameter.SpecType",
+      "Id": "d058906178b3446d941d176123ff3ffd",
+      "Inputs": [
+        {
+          "Id": "5e6ea064a9424f3daa340cb5448c2875",
+          "Name": "globalParameter",
+          "Description": "Revit.Elements.GlobalParameter",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "55163bd749b64430823bec8840ee4ec7",
+          "Name": "ForgeType",
+          "Description": "ForgeType",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get SpecType\n\nGlobalParameter.SpecType: ForgeType"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "ad0603b502b944d5b53be29ff4694280",
+      "End": "7edf6d6cffd24c6e938bc0e9928eec5f",
+      "Id": "00dc54d891e7485eb68f864075b85af2"
+    },
+    {
+      "Start": "df5a989b95a44e41a42e2349d10c7c9f",
+      "End": "d10974dd38f148e3b522079c1cadaf92",
+      "Id": "3dab2f85aee94fdab6bcc53cf63d449e"
+    },
+    {
+      "Start": "df5a989b95a44e41a42e2349d10c7c9f",
+      "End": "5e6ea064a9424f3daa340cb5448c2875",
+      "Id": "d4155d707656403b8eb88572be172078"
+    },
+    {
+      "Start": "df5a989b95a44e41a42e2349d10c7c9f",
+      "End": "98162f850b8747a2b74a95f9ce833bfb",
+      "Id": "f328d55feaca4546ae63f3400e68cdf8"
+    },
+    {
+      "Start": "59dba8442136452cbff929c86a322ffb",
+      "End": "40a3bcb24bd34746974b0f1f0f69a369",
+      "Id": "c1df3657677a4befaf61203016b24b6a"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [
+    {
+      "NodeId": "3a826db2-36c2-4f0a-b94c-25d2674b73fe",
+      "Binding": {
+        "ByName_InClassDecl-1_InFunctionScope-1_Instance0_3a826db2-36c2-4f0a-b94c-25d2674b73fe": "PFNPQVAtRU5WOkVudmVsb3BlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zOnhzZD0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOlNPQVAtRU5DPSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VuY29kaW5nLyIgeG1sbnM6U09BUC1FTlY9Imh0dHA6Ly9zY2hlbWFzLnhtbHNvYXAub3JnL3NvYXAvZW52ZWxvcGUvIiB4bWxuczpjbHI9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vc29hcC9lbmNvZGluZy9jbHIvMS4wIiBTT0FQLUVOVjplbmNvZGluZ1N0eWxlPSJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy9zb2FwL2VuY29kaW5nLyI+DQo8U09BUC1FTlY6Qm9keT4NCjxhMTpDYWxsU2l0ZV94MDAyQl9UcmFjZVNlcmlhbGlzZXJIZWxwZXIgaWQ9InJlZi0xIiB4bWxuczphMT0iaHR0cDovL3NjaGVtYXMubWljcm9zb2Z0LmNvbS9jbHIvbnNhc3NlbS9Qcm90b0NvcmUvUHJvdG9Db3JlJTJDJTIwVmVyc2lvbiUzRDIuMTAuMS4zOTc2JTJDJTIwQ3VsdHVyZSUzRG5ldXRyYWwlMkMlMjBQdWJsaWNLZXlUb2tlbiUzRG51bGwiPg0KPE51bWJlck9mRWxlbWVudHM+MTwvTnVtYmVyT2ZFbGVtZW50cz4NCjxCYXNlLTBfSGFzRGF0YT50cnVlPC9CYXNlLTBfSGFzRGF0YT4NCjxCYXNlLTBfRGF0YSBpZD0icmVmLTMiPlBGTlBRVkF0UlU1V09rVnVkbVZzYjNCbElIaHRiRzV6T25oemFUMGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TVM5WVRVeFRZMmhsYldFdGFXNXpkR0Z1WTJVaUlIaHRiRzV6T25oelpEMGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TVM5WVRVeFRZMmhsYldFaUlIaHRiRzV6T2xOUFFWQXRSVTVEUFNKb2RIUndPaTh2YzJOb1pXMWhjeTU0Yld4emIyRndMbTl5Wnk5emIyRndMMlZ1WTI5a2FXNW5MeUlnZUcxc2JuTTZVMDlCVUMxRlRsWTlJbWgwZEhBNkx5OXpZMmhsYldGekxuaHRiSE52WVhBdWIzSm5MM052WVhBdlpXNTJaV3h2Y0dVdklpQjRiV3h1Y3pwamJISTlJbWgwZEhBNkx5OXpZMmhsYldGekxtMXBZM0p2YzI5bWRDNWpiMjB2YzI5aGNDOWxibU52WkdsdVp5OWpiSEl2TVM0d0lpQlRUMEZRTFVWT1ZqcGxibU52WkdsdVoxTjBlV3hsUFNKb2RIUndPaTh2YzJOb1pXMWhjeTU0Yld4emIyRndMbTl5Wnk5emIyRndMMlZ1WTI5a2FXNW5MeUkrRFFvOFUwOUJVQzFGVGxZNlFtOWtlVDROQ2p4aE1UcFRaWEpwWVd4cGVtRmliR1ZKWkNCcFpEMGljbVZtTFRFaUlIaHRiRzV6T21FeFBTSm9kSFJ3T2k4dmMyTm9aVzFoY3k1dGFXTnliM052Wm5RdVkyOXRMMk5zY2k5dWMyRnpjMlZ0TDFKbGRtbDBVMlZ5ZG1salpYTXVVR1Z5YzJsemRHVnVZMlV2VW1WMmFYUlRaWEoyYVdObGN5VXlReVV5TUZabGNuTnBiMjRsTTBReUxqRXdMakV1TkRrNE1DVXlReVV5TUVOMWJIUjFjbVVsTTBSdVpYVjBjbUZzSlRKREpUSXdVSFZpYkdsalMyVjVWRzlyWlc0bE0wUnVkV3hzSWo0TkNqeHpkSEpwYm1kSlJDQnBaRDBpY21WbUxUTWlQak0zTUdJMllqTmhMV0k1WlRBdE5ETTFZaTFoTnpVd0xURXlZV0l6WmpCaE9URTJZUzB3TURBek1tRmpZVHd2YzNSeWFXNW5TVVErRFFvOGFXNTBTVVErTWpBM05UWXlQQzlwYm5SSlJENE5Dand2WVRFNlUyVnlhV0ZzYVhwaFlteGxTV1ErRFFvOEwxTlBRVkF0UlU1V09rSnZaSGsrRFFvOEwxTlBRVkF0UlU1V09rVnVkbVZzYjNCbFBnMEs8L0Jhc2UtMF9EYXRhPg0KPEJhc2UtMF9IYXNOZXN0ZWREYXRhPmZhbHNlPC9CYXNlLTBfSGFzTmVzdGVkRGF0YT4NCjwvYTE6Q2FsbFNpdGVfeDAwMkJfVHJhY2VTZXJpYWxpc2VySGVscGVyPg0KPC9TT0FQLUVOVjpCb2R5Pg0KPC9TT0FQLUVOVjpFbnZlbG9wZT4NCg=="
+      }
+    }
+  ],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.10.1.3976",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "2686aa522a954d9db6379bbc63e40f98",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 91.0,
+        "Y": 87.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "GlobalParameter.Visible",
+        "Id": "bb83a5450c804f34b987da1d3d0dc2b7",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 702.248458777932,
+        "Y": 16.8103369451022
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "GlobalParameter.Name",
+        "Id": "97d5b4ba76e440e9b1b28ce98e642a40",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 697.348764330819,
+        "Y": 315.691698218987
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "GlobalParameter.ByName",
+        "Id": "3a826db236c24f0ab94c25d2674b73fe",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 366.54494099703993,
+        "Y": 143.79605341322281
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Spec Types",
+        "Id": "74898c78c73a414a8411749214197af3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 124.1693840732446,
+        "Y": 226.41646678901813
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "GlobalParameter.SpecType",
+        "Id": "d058906178b3446d941d176123ff3ffd",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 721.74499775570064,
+        "Y": 148.628707246674
+      }
+    ],
+    "Annotations": [],
+    "X": -154.775318367524,
+    "Y": 68.594508448517274,
+    "Zoom": 0.82770257044119033
+  }
+}


### PR DESCRIPTION
…anged.

### Purpose

1. Update ParameterType, BuiltInParameterGroup and GetSpecTypeId(). Some API will be removed from Revit in future, so we also will remove the Obsolete Nodes in future.
2. Add ForgeType to store Revit ForgeTypeId.
3. Update related tests.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@wangyangshi @ShengxiZhang 

### FYIs

@QilongTang @mjkkirschner @Amoursol 
