### PR TITLE
Improve some node API

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Floor.cs
+++ b/src/Libraries/RevitNodes/Elements/Floor.cs
@@ -35,6 +35,8 @@ namespace Revit.Elements
             get { return InternalFloor; }
         }
 
+        private static readonly double Tolerance = 1e-6;
+
         #endregion
 
         #region Private constructors
@@ -73,12 +75,12 @@ namespace Revit.Elements
         private void InitFloor(List<CurveLoop> profiles, Autodesk.Revit.DB.FloorType floorType, Autodesk.Revit.DB.Level level, double offset = 0)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
-
+            
             // we assume the floor is not structural here, this may be a bad assumption
             Autodesk.Revit.DB.Floor floor = Autodesk.Revit.DB.Floor.Create(Document, profiles, floorType.Id, level.Id);
             var param = floor.get_Parameter(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM);
             
-            if(param !=null && offset != 0)
+            if(param !=null && Math.Abs(offset - 0) > Tolerance)
             {
                 InternalUtilities.ElementUtils.SetParameterValue(param, offset);
             }

--- a/src/Libraries/RevitNodes/Elements/Floor.cs
+++ b/src/Libraries/RevitNodes/Elements/Floor.cs
@@ -77,8 +77,8 @@ namespace Revit.Elements
             // we assume the floor is not structural here, this may be a bad assumption
             Autodesk.Revit.DB.Floor floor = Autodesk.Revit.DB.Floor.Create(Document, profiles, floorType.Id, level.Id);
             var param = floor.get_Parameter(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM);
-            var paramName = param.ToString();
-            if(param.AsDouble() == 0 && offset != 0)
+            
+            if(param !=null && offset != 0)
             {
                 InternalUtilities.ElementUtils.SetParameterValue(param, offset);
             }

--- a/src/Libraries/RevitNodes/Elements/Floor.cs
+++ b/src/Libraries/RevitNodes/Elements/Floor.cs
@@ -50,9 +50,9 @@ namespace Revit.Elements
         /// <summary>
         /// Private constructor
         /// </summary>
-        private Floor(List<CurveLoop> profiles, Autodesk.Revit.DB.FloorType floorType, Autodesk.Revit.DB.Level level)
+        private Floor(List<CurveLoop> profiles, Autodesk.Revit.DB.FloorType floorType, Autodesk.Revit.DB.Level level, double offset = 0)
         {
-            SafeInit(() => InitFloor(profiles, floorType, level));
+            SafeInit(() => InitFloor(profiles, floorType, level, offset));
         }
 
         #endregion
@@ -70,13 +70,18 @@ namespace Revit.Elements
         /// <summary>
         /// Initialize a floor element
         /// </summary>
-        private void InitFloor(List<CurveLoop> profiles, Autodesk.Revit.DB.FloorType floorType, Autodesk.Revit.DB.Level level)
+        private void InitFloor(List<CurveLoop> profiles, Autodesk.Revit.DB.FloorType floorType, Autodesk.Revit.DB.Level level, double offset = 0)
         {
             TransactionManager.Instance.EnsureInTransaction(Document);
 
             // we assume the floor is not structural here, this may be a bad assumption
             Autodesk.Revit.DB.Floor floor = Autodesk.Revit.DB.Floor.Create(Document, profiles, floorType.Id, level.Id);
-
+            var param = floor.get_Parameter(BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM);
+            var paramName = param.ToString();
+            if(param.AsDouble() == 0 && offset != 0)
+            {
+                InternalUtilities.ElementUtils.SetParameterValue(param, offset);
+            }
             InternalSetFloor(floor);
 
             TransactionManager.Instance.TransactionTaskDone();
@@ -152,6 +157,9 @@ namespace Revit.Elements
                 throw new ArgumentException(Properties.Resources.OpenInputPolyCurveError);
             }
 
+            var levelHeight = level.Elevation;
+            var outlineHeight = (outline.BoundingBox.MinPoint.Z + outline.BoundingBox.MaxPoint.Z) / 2;
+            var offset = outlineHeight - levelHeight;
             CurveLoop loop = new CurveLoop();
             outline.Curves().ForEach(x => loop.Append(x.ToRevitType()));
 
@@ -162,7 +170,7 @@ namespace Revit.Elements
                 throw new ArgumentException(Properties.Resources.NotHorizontalInputPolyCurveError);
             }
 
-            var floor = new Floor(loops, floorType.InternalFloorType, level.InternalLevel);
+            var floor = new Floor(loops, floorType.InternalFloorType, level.InternalLevel, offset);
             DocumentManager.Regenerate();
             return floor;
         }

--- a/src/Libraries/RevitNodes/Elements/Revision.cs
+++ b/src/Libraries/RevitNodes/Elements/Revision.cs
@@ -142,7 +142,7 @@ namespace Revit.Elements
             }
 
             var seqElem = document.GetElement(RevisionElem.RevisionNumberingSequenceId) as RevisionNumberingSequence;
-            if (seqElem.NumberType != numberType)
+            if (!seqElem.Name.StartsWith("Dynamo_") || seqElem.NumberType != numberType)
             {
                 RevisionElem.RevisionNumberingSequenceId = GetRevisionNumberingSequence(numberType);
             }
@@ -167,11 +167,27 @@ namespace Revit.Elements
             foreach (var id in elementids)
             {
                 var seqElem = doc.GetElement(id) as RevisionNumberingSequence;
-                if (seqElem.NumberType == numberType)
+                if (seqElem.Name.StartsWith("Dynamo_") && seqElem.NumberType == numberType)
                 {
                     revisionNumberingSequenceId = seqElem.Id;
                     break;
                 }
+            }
+            if(revisionNumberingSequenceId == ElementId.InvalidElementId)
+            {
+                RevisionNumberingSequence revisionNumberingSequence;
+                switch (numberType)
+                {
+                    case RevisionNumberType.Alphanumeric:
+                        revisionNumberingSequence = RevisionNumberingSequence.CreateAlphanumericSequence(doc, "Dynamo_Alphanumeric", new AlphanumericRevisionSettings());
+                        revisionNumberingSequenceId = revisionNumberingSequence.Id;
+                        break;
+                    case RevisionNumberType.Numeric:
+                        revisionNumberingSequence = RevisionNumberingSequence.CreateNumericSequence(doc, "Dynamo_Numeric", new NumericRevisionSettings());
+                        revisionNumberingSequenceId = revisionNumberingSequence.Id;
+                        break;
+                }
+                
             }
             
             return revisionNumberingSequenceId;

--- a/src/Libraries/RevitNodes/GeometryConversion/SurfaceExtractor.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/SurfaceExtractor.cs
@@ -238,8 +238,10 @@ namespace Revit.GeometryConversion
 
         public static Surface ExtractSurface(Autodesk.Revit.DB.RuledFace face, IEnumerable<PolyCurve> edgeLoops)
         {
-            var c0 = face.get_Curve(0).ToProtoType(false);
-            var c1 = face.get_Curve(1).ToProtoType(false);
+            var rc0 = face.get_Curve(0);
+            var rc1 = face.get_Curve(1);
+            var c0 = rc0?.ToProtoType(false);
+            var c1 = rc1?.ToProtoType(false);
 
             var result = Surface.ByLoft(new[] {c0, c1});
             c0.Dispose();

--- a/test/Libraries/RevitNodesTests/Elements/FloorTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/FloorTests.cs
@@ -140,6 +140,31 @@ namespace RevitNodesTests.Elements
             floor.Points.First().Z.ShouldBeApproximately(elev + 10);
 
         }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByOutlineTypeAndLevel_PolyCurveFloorTypeLevel_ProducesFloorWithCorrectOffset()
+        {
+            var elevation = 100;
+            var level = Level.ByElevation(elevation);
+
+            var outline = new[]
+            {
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 0, 50), Point.ByCoordinates(100, 0, 50)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(100, 0, 50), Point.ByCoordinates(100, 100, 50)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(100, 100, 50), Point.ByCoordinates(0, 100, 50)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 100, 50), Point.ByCoordinates(0, 0, 50))
+            };
+
+            var polyCurveOutline = PolyCurve.ByJoinedCurves(outline);
+
+            var floorType = FloorType.ByName("Generic - 12\"");
+
+            var floor = Floor.ByOutlineTypeAndLevel(polyCurveOutline, floorType, level);
+
+            var param = floor.GetParameterValueByName("Height Offset From Level");
+            ((double)param).ShouldBeApproximately(-50);
+        }
     }
 }
 

--- a/test/Libraries/RevitNodesTests/Elements/RevisionTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/RevisionTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Revit.Elements;
 using RevitTestServices;
 using RTF.Framework;
+using Revit.Application;
 
 namespace RevitNodesTests.Elements
 {
@@ -21,8 +22,18 @@ namespace RevitNodesTests.Elements
             Assert.AreEqual(rev1.InternalRevitElement.RevisionDate, "01.01.1970");
         }
 
+        [Test]
+        [TestModel(@".\emptyAnnotativeView.rvt")]
+        public void CreateWithNumberType_ValidArgs()
+        {
+            Revision rev1 = Revision.ByName("myTest", "01.01.1970", "myTest", false, "me", "to", "", "Alphanumeric");
+            Assert.NotNull(rev1);
 
+            Assert.IsInstanceOf(typeof(Revit.Elements.Revision), rev1);
 
+            var seqElem = Document.Current.InternalDocument.GetElement(rev1.InternalRevitElement.RevisionNumberingSequenceId) as Autodesk.Revit.DB.RevisionNumberingSequence;
+            Assert.AreEqual(seqElem.Name, "Dynamo_Alphanumeric");
+        }
 
     }
 }


### PR DESCRIPTION

### Purpose

1. Add exclusive RevisionNumberingSequence for Revision creation node.
2. Add offset for Floor creation API because of updated Revit API.
3. Add non-null judgment for ExtractSurface of RuledFace.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @wangyangshi 

### FYIs

@QilongTang @mjkkirschner @Amoursol 
