### PR TITLE
Update document nodetests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Improve Floor creation node and Revision creation node API.
+* Improve 2 DocumentTests.
+
 ## 0.3.3
 * Add new FamilyInstance node - FamilyInstance.ByHostAndPoint.
 * Update DynamoCore to 2.10.0,

--- a/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/DocumentTests.cs
@@ -103,8 +103,6 @@ namespace RevitNodesTests.Elements
         [TestModel(@".\Document\DocumentPurgeUnusedTest.rvt")]
         public void CanRecursivelyPurgeUnusedElementsFromDocument()
         {
-            // Arrange
-            var expectedPurgedElementIds = new List<int>() { 217063, 221347, 216753, 416, 208080, 210695 };
             string expectedPurgeMessageSecondRun = Revit.Properties.Resources.NoElementsToPurge;
             
             // Act - second purge should throw exception as there is nothing left to purge after doing PurgeUnused(true).
@@ -113,26 +111,25 @@ namespace RevitNodesTests.Elements
             var resultSecondRun = Assert.Throws<System.InvalidOperationException>(() => document.PurgeUnused(true));
 
             // Assert
-            Assert.AreEqual(expectedPurgedElementIds, resultFirstRun);
+            Assert.IsNotNull(resultFirstRun);
+            Assert.Greater(resultFirstRun.Count, 0);
             Assert.AreEqual(expectedPurgeMessageSecondRun, resultSecondRun.Message);
         }
 
         [Test]
         [TestModel(@".\Document\DocumentPurgeUnusedTest.rvt")]
         public void CanPurgeUnusedElementsFromDocument()
-        {
-            // Arrange
-            var expectedPurgedElementIdsFirstRun = new List<int>() { 217063, 221347 };
-            var expectedPurgedElementIdsSecondRun = new List<int>() { 216753, 416, 208080, 210695 };
-
+        { 
             // Act - as we are not running recursivly, second run should return element ids
             var document = Document.Current;
             var resultFirstRun = document.PurgeUnused();
             var resultSecondRun = document.PurgeUnused();
 
             // Assert
-            Assert.AreEqual(expectedPurgedElementIdsFirstRun, resultFirstRun);
-            Assert.AreEqual(expectedPurgedElementIdsSecondRun, resultSecondRun);
+            Assert.IsNotNull(resultFirstRun);
+            Assert.Greater(resultFirstRun.Count, 0);
+            Assert.IsNotNull(resultSecondRun);
+            Assert.Greater(resultSecondRun.Count, 0);
         }
 
     }


### PR DESCRIPTION

### Purpose

Due to Revit update, the purse unused is different in each Revit version like 2020, 2021 and 2022. So we don't need any specific elements to verify that the purge has succeeded.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @wangyangshi 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
