### PR TITLE
do not import CurvePartition into the VM

### DIFF
--- a/src/Libraries/RevitNodes/GeometryConversion/CurveLoopPartition.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/CurveLoopPartition.cs
@@ -125,7 +125,7 @@ namespace Revit.GeometryConversion
         }
     }
 
-    public class CurvePartition
+    internal class CurvePartition
     {
         public List<Curve> OuterCurves;
         public List<List<Curve>> InnerCurves;


### PR DESCRIPTION
While working on a documentation generator I noticed that this class was getting imported into Dynamo - it should likely be internal or suppressed from import like the CurvePartitionLoop class above.


@ZiyunShang please take a look.