### PR TITLE
Keep the revit element with Node when Disable Transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 
-
-## 0.3.8
-* Upgrade Greg, GregRevitOAuth, and RestSharp to RestSharp 106.12.0 to address a security issue.
-
-## 0.3.7
 * Add Transaction controls - "Sync with Revit" Toggle button.
+* Upgrade Greg, GregRevitOAuth, and RestSharp to RestSharp 106.12.0 to address a security issue.
+* Keep ElementBinding when set Transaction disabled.
 
 ## 0.3.6
 * Upgrade DynamoRevit to 2.13.0.

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -576,16 +576,18 @@ namespace Dynamo.Applications
             var runsettingStackPanel = runsettingsGrid.Children.OfType<StackPanel>().FirstOrDefault();
 
             var srcDic = Dynamo.UI.SharedDictionaryManager.DynamoModernDictionary;
+            if (TransactionManager.Instance.DisableTransactions)
+                TransactionManager.Instance.DisableTransactions = false;
 
             var toggleItem = new System.Windows.Controls.Primitives.ToggleButton
             {
                 Width = 40,
                 Height = 20,
-                IsChecked = true,
+                IsChecked = !TransactionManager.Instance.DisableTransactions,
                 VerticalContentAlignment = System.Windows.VerticalAlignment.Center,
                 ToolTip = Resources.SyncWithRevitToolTip
             };
-            
+
             toggleItem.SetValue(System.Windows.Controls.Primitives.ToggleButton.StyleProperty, srcDic["EllipseToggleButton1"]);
 
             toggleItem.Click += OnReadOnlyModeToggleChecked;

--- a/src/Libraries/RevitNodes/Elements/AbstractFamilyInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/AbstractFamilyInstance.cs
@@ -1,4 +1,5 @@
 ﻿using Autodesk.DesignScript.Runtime;
+using Autodesk.Revit.DB;
 using Revit.GeometryConversion;
 using RevitServices.Persistence;
 using RevitServices.Transactions;
@@ -31,6 +32,15 @@ namespace Revit.Elements
         public override Autodesk.Revit.DB.Element InternalElement
         {
             get { return InternalFamilyInstance; }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetFamilyInstance(element as Autodesk.Revit.DB.FamilyInstance);
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/Area.cs
+++ b/src/Libraries/RevitNodes/Elements/Area.cs
@@ -26,6 +26,15 @@ namespace Revit.Elements
             get { return InternalArea; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetArea(element as Autodesk.Revit.DB.Area);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Ceiling.cs
+++ b/src/Libraries/RevitNodes/Elements/Ceiling.cs
@@ -34,6 +34,15 @@ namespace Revit.Elements
             get { return InternalCeiling; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetCeiling(element as Autodesk.Revit.DB.Ceiling);
+        }
+
         #endregion
 
         #region Private constructors
@@ -117,7 +126,8 @@ namespace Revit.Elements
             }
 
             var ceiling = ByOutlineTypeAndLevel(PolyCurve.ByJoinedCurves(outlineCurves), ceilingType, level);
-            DocumentManager.Regenerate();
+            if (!TransactionManager.Instance.DisableTransactions)
+                DocumentManager.Regenerate();
             return ceiling;
         }
 
@@ -161,7 +171,8 @@ namespace Revit.Elements
             }
 
             var ceiling = new Ceiling(loops, ceilingType.InternalCeilingType, level.InternalLevel);
-            DocumentManager.Regenerate();
+            if (!TransactionManager.Instance.DisableTransactions)
+                DocumentManager.Regenerate();
             return ceiling;
         }
 

--- a/src/Libraries/RevitNodes/Elements/CurtainSystem.cs
+++ b/src/Libraries/RevitNodes/Elements/CurtainSystem.cs
@@ -32,6 +32,15 @@ namespace Revit.Elements
             get { return InternalCurtainSystem; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetCurtainSystem(element as Autodesk.Revit.DB.CurtainSystem);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/CurveElement.cs
+++ b/src/Libraries/RevitNodes/Elements/CurveElement.cs
@@ -28,6 +28,15 @@ namespace Revit.Elements
             private set;
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetCurveElement(element as Autodesk.Revit.DB.CurveElement);
+        }
+
         #region public properties
 
         /// <summary>

--- a/src/Libraries/RevitNodes/Elements/Dimension.cs
+++ b/src/Libraries/RevitNodes/Elements/Dimension.cs
@@ -37,6 +37,15 @@ namespace Revit.Elements
             get { return InternalRevitElement; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element as Autodesk.Revit.DB.Dimension);
+        }
+
         #endregion
 
         #region Private mutators

--- a/src/Libraries/RevitNodes/Elements/DimensionType.cs
+++ b/src/Libraries/RevitNodes/Elements/DimensionType.cs
@@ -31,6 +31,15 @@ namespace Revit.Elements
             get { return InternalRevitElement; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element as Autodesk.Revit.DB.DimensionType);
+        }
+
         #endregion
 
         #region Private mutators

--- a/src/Libraries/RevitNodes/Elements/DirectShape.cs
+++ b/src/Libraries/RevitNodes/Elements/DirectShape.cs
@@ -86,6 +86,15 @@ namespace Revit.Elements
             get { return InternalDirectShape; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetDirectShape(element as Autodesk.Revit.DB.DirectShape);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/DividedPath.cs
+++ b/src/Libraries/RevitNodes/Elements/DividedPath.cs
@@ -48,6 +48,15 @@ namespace Revit.Elements
         }
 
         /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetDividedPath(element as Autodesk.Revit.DB.DividedPath);
+        }
+
+        /// <summary>
         /// All points along the DividedPath.
         /// </summary>
         public IEnumerable<Autodesk.DesignScript.Geometry.Point> Points

--- a/src/Libraries/RevitNodes/Elements/DividedSurface.cs
+++ b/src/Libraries/RevitNodes/Elements/DividedSurface.cs
@@ -34,6 +34,15 @@ namespace Revit.Elements
             get { return InternalDividedSurface; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetDividedSurface(element as Autodesk.Revit.DB.DividedSurface);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/ElementType.cs
+++ b/src/Libraries/RevitNodes/Elements/ElementType.cs
@@ -36,6 +36,15 @@ namespace Revit.Elements
             get { return InternalElementType; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InitElementType(element as Autodesk.Revit.DB.ElementType);
+        }
+
         #endregion
 
         #region Protected constructors

--- a/src/Libraries/RevitNodes/Elements/ElevationMarker.cs
+++ b/src/Libraries/RevitNodes/Elements/ElevationMarker.cs
@@ -33,6 +33,15 @@ namespace Revit.Elements
             get { return InternalMarker; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElevationMarker(element as Autodesk.Revit.DB.ElevationMarker);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/FaceWall.cs
+++ b/src/Libraries/RevitNodes/Elements/FaceWall.cs
@@ -32,6 +32,15 @@ namespace Revit.Elements
             get { return InternalFaceWall; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetFaceWall(element as Autodesk.Revit.DB.FaceWall);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Family.cs
+++ b/src/Libraries/RevitNodes/Elements/Family.cs
@@ -28,6 +28,15 @@ namespace Revit.Elements
             get { return InternalFamily; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetFamily(element as Autodesk.Revit.DB.Family);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/FillPatternElement.cs
+++ b/src/Libraries/RevitNodes/Elements/FillPatternElement.cs
@@ -30,6 +30,15 @@ namespace Revit.Elements
             get { return InternalRevitElement; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element as Autodesk.Revit.DB.FillPatternElement);
+        }
+
         #endregion
 
         #region Private mutators

--- a/src/Libraries/RevitNodes/Elements/FilledRegion.cs
+++ b/src/Libraries/RevitNodes/Elements/FilledRegion.cs
@@ -35,6 +35,15 @@ namespace Revit.Elements
             get { return InternalRevitElement; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element as Autodesk.Revit.DB.FilledRegion);
+        }
+
         #endregion
 
         #region Private mutators

--- a/src/Libraries/RevitNodes/Elements/Floor.cs
+++ b/src/Libraries/RevitNodes/Elements/Floor.cs
@@ -35,6 +35,15 @@ namespace Revit.Elements
             get { return InternalFloor; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetFloor(element as Autodesk.Revit.DB.Floor);
+        }
+
         private static readonly double Tolerance = 1e-6;
 
         #endregion
@@ -126,7 +135,8 @@ namespace Revit.Elements
             }
 
             var floor = ByOutlineTypeAndLevel(PolyCurve.ByJoinedCurves(outlineCurves), floorType, level);
-            DocumentManager.Regenerate();
+            if (!TransactionManager.Instance.DisableTransactions)
+                DocumentManager.Regenerate();
             return floor;
         }
 
@@ -173,7 +183,8 @@ namespace Revit.Elements
             }
 
             var floor = new Floor(loops, floorType.InternalFloorType, level.InternalLevel, offset);
-            DocumentManager.Regenerate();
+            if(!TransactionManager.Instance.DisableTransactions)
+                DocumentManager.Regenerate();
             return floor;
         }
 

--- a/src/Libraries/RevitNodes/Elements/Form.cs
+++ b/src/Libraries/RevitNodes/Elements/Form.cs
@@ -30,6 +30,15 @@ namespace Revit.Elements
             get { return InternalForm; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetForm(element as Autodesk.Revit.DB.Form);
+        }
+
         #endregion
 
         #region Private constructor

--- a/src/Libraries/RevitNodes/Elements/FreeForm.cs
+++ b/src/Libraries/RevitNodes/Elements/FreeForm.cs
@@ -36,6 +36,15 @@ namespace Revit.Elements
             get { return InternalFreeFormElement; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetFreeFormElement(element as Autodesk.Revit.DB.FreeFormElement);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
@@ -33,6 +33,15 @@ namespace Revit.Elements
             get { return InternalGlobalParameter; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetGlobalParameter(element as Autodesk.Revit.DB.GlobalParameter);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Grid.cs
+++ b/src/Libraries/RevitNodes/Elements/Grid.cs
@@ -33,6 +33,15 @@ namespace Revit.Elements
             get { return InternalGrid; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetGrid(element as Autodesk.Revit.DB.Grid);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Group.cs
+++ b/src/Libraries/RevitNodes/Elements/Group.cs
@@ -33,6 +33,15 @@ namespace Revit.Elements
             get { return InternalGroup; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InitGroup(element as Autodesk.Revit.DB.Group);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/ImportInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/ImportInstance.cs
@@ -27,6 +27,15 @@ namespace Revit.Elements
             get { return InternalImportInstance; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetImportInstance(element as Autodesk.Revit.DB.ImportInstance);
+        }
+
         internal Autodesk.Revit.DB.ImportInstance InternalImportInstance
         {
             get;

--- a/src/Libraries/RevitNodes/Elements/Level.cs
+++ b/src/Libraries/RevitNodes/Elements/Level.cs
@@ -68,6 +68,15 @@ namespace Revit.Elements
             get { return InternalLevel; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetLevel(element as Autodesk.Revit.DB.Level);
+        }
+
         #endregion
 
         #region Private constructor

--- a/src/Libraries/RevitNodes/Elements/LinePatternElement.cs
+++ b/src/Libraries/RevitNodes/Elements/LinePatternElement.cs
@@ -30,6 +30,15 @@ namespace Revit.Elements
             get { return InternalRevitElement; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element as Autodesk.Revit.DB.LinePatternElement);
+        }
+
         #endregion
 
         #region Private mutators

--- a/src/Libraries/RevitNodes/Elements/Material.cs
+++ b/src/Libraries/RevitNodes/Elements/Material.cs
@@ -28,6 +28,15 @@ namespace Revit.Elements
             get { return InternalMaterial; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetMaterial(element as Autodesk.Revit.DB.Material);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/ModelText.cs
+++ b/src/Libraries/RevitNodes/Elements/ModelText.cs
@@ -41,6 +41,15 @@ namespace Revit.Elements
             get { return InternalModelText; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetModelText(element as Autodesk.Revit.DB.ModelText);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/PathOfTravel.cs
+++ b/src/Libraries/RevitNodes/Elements/PathOfTravel.cs
@@ -36,6 +36,15 @@ namespace Revit.Elements
          get { return m_rvtPathOfTravel; }
       }
 
+      /// <summary>
+      /// Set Internal Element from a exsiting element.
+      /// </summary>
+      /// <param name="element"></param>
+      internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+      {
+         InitPathOfTravel(element as RvtAnalysis.PathOfTravel);
+      }
+
       #endregion
 
       #region Private constructors
@@ -373,6 +382,21 @@ namespace Revit.Elements
       private static PathOfTravel[] InternalByViewEndPoints(Rvt.View rvtView, IEnumerable<XYZ> startPoints, IEnumerable<XYZ> endPoints)
       {
          List<PathOfTravel> pathsOfTravel = new List<PathOfTravel>();
+
+         if(TransactionManager.Instance.DisableTransactions)
+         {
+            IEnumerable<RvtAnalysis.PathOfTravel> persistRvtElements = ElementBinder.GetElementsFromTrace<RvtAnalysis.PathOfTravel>(Document);
+            if(persistRvtElements != null)
+            {
+               foreach (var ele in persistRvtElements)
+               {
+                  var persisEle = new PathOfTravel(ele);
+                  pathsOfTravel.Add(persisEle);
+               }
+
+               return pathsOfTravel.ToArray();
+            }   
+         }
 
          TransactionManager.Instance.EnsureInTransaction(Document);
 

--- a/src/Libraries/RevitNodes/Elements/ReferencePlane.cs
+++ b/src/Libraries/RevitNodes/Elements/ReferencePlane.cs
@@ -38,6 +38,15 @@ namespace Revit.Elements
             get { return InternalReferencePlane; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetReferencePlane(element as Autodesk.Revit.DB.ReferencePlane);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/ReferencePoint.cs
+++ b/src/Libraries/RevitNodes/Elements/ReferencePoint.cs
@@ -42,6 +42,15 @@ namespace Revit.Elements
             get { return InternalReferencePoint; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetReferencePoint(element as Autodesk.Revit.DB.ReferencePoint);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Revision.cs
+++ b/src/Libraries/RevitNodes/Elements/Revision.cs
@@ -34,6 +34,15 @@ namespace Revit.Elements
             get { return InternalRevitElement; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element as Autodesk.Revit.DB.Revision);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/RevisionCloud.cs
+++ b/src/Libraries/RevitNodes/Elements/RevisionCloud.cs
@@ -35,6 +35,15 @@ namespace Revit.Elements
             get { return InternalRevitElement; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element as Autodesk.Revit.DB.RevisionCloud);
+        }
+
         #endregion
 
         #region Private constructors
@@ -66,7 +75,7 @@ namespace Revit.Elements
         /// <summary>
         /// Set the internal Element, ElementId, and UniqueId
         /// </summary>
-        /// <param name="wall"></param>
+        /// <param name="element"></param>
         private void InternalSetElement(Autodesk.Revit.DB.RevisionCloud element)
         {
             InternalRevitElement = element;

--- a/src/Libraries/RevitNodes/Elements/Roof.cs
+++ b/src/Libraries/RevitNodes/Elements/Roof.cs
@@ -35,6 +35,15 @@ namespace Revit.Elements
             get { return InternalRoof; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetRoof(element as Autodesk.Revit.DB.RoofBase);
+        }
+
         #endregion
 
         #region Private constructors
@@ -130,7 +139,7 @@ namespace Revit.Elements
         /// <summary>
         /// Set the InternalRoof property and the associated element id and unique id
         /// </summary>
-        /// <param name="Roof"></param>
+        /// <param name="roof"></param>
         private void InternalSetRoof(Autodesk.Revit.DB.RoofBase roof)
         {
             InternalRoof = roof;
@@ -165,7 +174,8 @@ namespace Revit.Elements
                 });
             
             var roof = new Roof(ca, level.InternalLevel,roofType.InternalRoofType);
-            DocumentManager.Regenerate();
+            if (!TransactionManager.Instance.DisableTransactions)
+                DocumentManager.Regenerate();
             return roof;
         }
 
@@ -194,7 +204,8 @@ namespace Revit.Elements
                 });
 
             var roof = new Roof(ca, plane.InternalReferencePlane, level.InternalLevel, roofType.InternalRoofType, extrusionStart, extrusionEnd);
-            DocumentManager.Regenerate();
+            if (!TransactionManager.Instance.DisableTransactions)
+                DocumentManager.Regenerate();
             return roof;
         }
 

--- a/src/Libraries/RevitNodes/Elements/Room.cs
+++ b/src/Libraries/RevitNodes/Elements/Room.cs
@@ -33,7 +33,16 @@ namespace Revit.Elements
         {
             get { return InternalRevitElement; }
         }
-       
+
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element as Autodesk.Revit.DB.Architecture.Room);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/ScheduleOnSheet.cs
+++ b/src/Libraries/RevitNodes/Elements/ScheduleOnSheet.cs
@@ -31,6 +31,15 @@ namespace Revit.Elements
         {
             get { return InternalScheduleOnSheet; }
         }
+
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetScheduleOnSheet(element as Autodesk.Revit.DB.ScheduleSheetInstance);
+        }
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/SketchPlane.cs
+++ b/src/Libraries/RevitNodes/Elements/SketchPlane.cs
@@ -35,6 +35,15 @@ namespace Revit.Elements
             get { return InternalSketchPlane; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetSketchPlane(element as Autodesk.Revit.DB.SketchPlane);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Space.cs
+++ b/src/Libraries/RevitNodes/Elements/Space.cs
@@ -32,6 +32,15 @@ namespace Revit.Elements
             get { return InternalRevitElement; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element as Autodesk.Revit.DB.Mechanical.Space);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/SunSettings.cs
+++ b/src/Libraries/RevitNodes/Elements/SunSettings.cs
@@ -39,6 +39,15 @@ namespace Revit.Elements
         }
 
         /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InitSunSettings(element as Autodesk.Revit.DB.SunAndShadowSettings);
+        }
+
+        /// <summary>
         ///     Calculates the direction of the sun.
         /// </summary>
         public Vector SunDirection

--- a/src/Libraries/RevitNodes/Elements/TextElement.cs
+++ b/src/Libraries/RevitNodes/Elements/TextElement.cs
@@ -69,6 +69,15 @@ namespace Revit.Elements
         }
 
         /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element);
+        }
+
+        /// <summary>
         /// Reference to the Element
         /// </summary>
         internal Autodesk.Revit.DB.Element InternalRevitElement

--- a/src/Libraries/RevitNodes/Elements/Topography.cs
+++ b/src/Libraries/RevitNodes/Elements/Topography.cs
@@ -31,6 +31,15 @@ namespace Revit.Elements
             get { return InternalTopographySurface; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetTopographySurface(element as TopographySurface);
+        }
+
         #endregion
 
         #region public properties

--- a/src/Libraries/RevitNodes/Elements/UnknownElement.cs
+++ b/src/Libraries/RevitNodes/Elements/UnknownElement.cs
@@ -19,6 +19,15 @@ namespace Revit.Elements
         }
 
         /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element);
+        }
+
+        /// <summary>
         /// Private constructor
         /// </summary>
         /// <param name="element"></param>

--- a/src/Libraries/RevitNodes/Elements/Viewport.cs
+++ b/src/Libraries/RevitNodes/Elements/Viewport.cs
@@ -32,6 +32,15 @@ namespace Revit.Elements
             get { return InternalViewport; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetViewport(element as Autodesk.Revit.DB.Viewport);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Views/DraftingView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/DraftingView.cs
@@ -35,6 +35,15 @@ namespace Revit.Elements.Views
             get { return InternalViewDrafting; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetDraftingView(element as Autodesk.Revit.DB.ViewDrafting);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Views/Legend.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/Legend.cs
@@ -27,6 +27,15 @@ namespace Revit.Elements.Views
             get { return InternalLegend; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetLegend(element as Autodesk.Revit.DB.View);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Views/PlanView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/PlanView.cs
@@ -32,6 +32,15 @@ namespace Revit.Elements
             get { return InternalViewPlan; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetPlanView(element as Autodesk.Revit.DB.ViewPlan);
+        }
+
         #endregion
 
         #region Protected mutators

--- a/src/Libraries/RevitNodes/Elements/Views/ScheduleView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/ScheduleView.cs
@@ -35,6 +35,15 @@ namespace Revit.Elements.Views
         }
 
         /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetScheduleView(element as Autodesk.Revit.DB.ViewSchedule);
+        }
+
+        /// <summary>
         /// Reference to Schedule Filters
         /// </summary>
         internal IList<Autodesk.Revit.DB.ScheduleFilter> InternalScheduleFilters

--- a/src/Libraries/RevitNodes/Elements/Views/SectionView.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/SectionView.cs
@@ -38,6 +38,15 @@ namespace Revit.Elements.Views
             get { return InternalViewSection; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetSectionView(element as Autodesk.Revit.DB.ViewSection);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Elements/Views/Sheet.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/Sheet.cs
@@ -37,6 +37,15 @@ namespace Revit.Elements.Views
             get { return InternalViewSheet; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetViewSheet(element as Autodesk.Revit.DB.ViewSheet);
+        }
+
         public override void Dispose()
         {
             if (DuplicateViews != null) 
@@ -398,12 +407,12 @@ namespace Revit.Elements.Views
         /// <summary>
         /// Set the InternalViewSheet property and the associated element id and unique id
         /// </summary>
-        /// <param name="floor"></param>
-        private void InternalSetViewSheet(Autodesk.Revit.DB.ViewSheet floor)
+        /// <param name="viewSheet"></param>
+        private void InternalSetViewSheet(Autodesk.Revit.DB.ViewSheet viewSheet)
         {
-            this.InternalViewSheet = floor;
-            this.InternalElementId = floor.Id;
-            this.InternalUniqueId = floor.UniqueId;
+            this.InternalViewSheet = viewSheet;
+            this.InternalElementId = viewSheet.Id;
+            this.InternalUniqueId = viewSheet.UniqueId;
         }
 
         /// <summary>
@@ -737,9 +746,20 @@ namespace Revit.Elements.Views
 
             Sheet newSheet = null;
 
+            if(TransactionManager.Instance.DisableTransactions)
+            {
+                var oldSheet = ElementBinder.GetElementFromTrace<Autodesk.Revit.DB.ViewSheet>(Document);
+                if(oldSheet != null)
+                {
+                    newSheet = new Sheet(oldSheet);
+
+                    return newSheet;
+                }
+            }
+
             try
             {
-                RevitServices.Transactions.TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);                
+                TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
 
                 var oldElements = ElementBinder.GetElementsFromTrace<Autodesk.Revit.DB.Element>(Document);
                 List<ElementId> elementIds = new List<ElementId>();

--- a/src/Libraries/RevitNodes/Elements/Views/View3D.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View3D.cs
@@ -32,6 +32,15 @@ namespace Revit.Elements.Views
             get { return InternalView3D; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetView3D(element as Autodesk.Revit.DB.View3D);
+        }
+
         #endregion
 
         #region Private helper methods

--- a/src/Libraries/RevitNodes/Elements/Wall.cs
+++ b/src/Libraries/RevitNodes/Elements/Wall.cs
@@ -31,6 +31,15 @@ namespace Revit.Elements
             get { return InternalWall; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetWall(element as Autodesk.Revit.DB.Wall);
+        }
+
         #endregion
 
         #region Private constructors

--- a/src/Libraries/RevitNodes/Filter/ParameterFilterElement.cs
+++ b/src/Libraries/RevitNodes/Filter/ParameterFilterElement.cs
@@ -34,6 +34,15 @@ namespace Revit.Filter
             get { return InternalRevitElement; }
         }
 
+        /// <summary>
+        /// Set Internal Element from a exsiting element.
+        /// </summary>
+        /// <param name="element"></param>
+        internal override void SetInternalElement(Autodesk.Revit.DB.Element element)
+        {
+            InternalSetElement(element as Autodesk.Revit.DB.ParameterFilterElement);
+        }
+
         #endregion
 
         #region Private mutators

--- a/src/Libraries/RevitServices/Persistence/ElementIDLifecycleManager.cs
+++ b/src/Libraries/RevitServices/Persistence/ElementIDLifecycleManager.cs
@@ -100,8 +100,13 @@ namespace RevitServices.Persistence
                 //ID already existed, check we're not over adding
                 if (existingWrappers.Contains(wrapper))
                 {
-                    int index = existingWrappers.FindIndex((x) => object.ReferenceEquals(x, wrapper));
-                    existingWrappers.RemoveAt(index);
+                    var removeList = existingWrappers.FindAll((x) => object.ReferenceEquals(x, wrapper));
+                    for (int i = 0; i < removeList.Count; i++)
+                    {
+                        int index = existingWrappers.FindIndex((x) => object.ReferenceEquals(x, wrapper));
+                        existingWrappers.RemoveAt(index);
+                    }
+                    
                     if (existingWrappers.Count == 0)
                     {
                         wrappers.Remove(elementID);


### PR DESCRIPTION

### Purpose

After add Transaction control, an issue was found that element binding was broken when disable and enable transaction. So we need to keep the Revit elementbinder with D4R nodes.
According to design, when a node runs a Revit element, then disable transaction, the node should not turn yellow and display warning because it's not user error.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @wangyangshi @saintentropy 

### FYIs

@QilongTang @mjkkirschner @Amoursol 
