### PR TITLE
Update CreateProjectParameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Upgrade Paramater.CreateProjectParameter due to Definition will sometimes be null.
 
 ## 0.3.7
 * Add Transaction controls - "Sync with Revit" Toggle button.

--- a/src/Libraries/RevitNodes/Elements/Parameter.cs
+++ b/src/Libraries/RevitNodes/Elements/Parameter.cs
@@ -288,10 +288,9 @@ namespace Revit.Elements
                 CategorySet categories = (categoryList == null) ? AllCategories() : ToCategorySet(categoryList);
 
                 // create a new shared parameter, since the file is empty everything has to be created from scratch
-                ExternalDefinition def =
-                    document.Application.OpenSharedParameterFile()
+                document.Application.OpenSharedParameterFile()
                     .Groups.Create(groupName).Definitions.Create(
-                    new ExternalDefinitionCreationOptions(parameterName, specType.InternalForgeTypeId)) as ExternalDefinition;
+                    new ExternalDefinitionCreationOptions(parameterName, specType.InternalForgeTypeId));
 
                 // Create an instance or type binding
                 Binding bin = (instance) ?
@@ -299,6 +298,8 @@ namespace Revit.Elements
                     (Binding)document.Application.Create.NewTypeBinding(categories);
 
                 // Apply parameter bindings
+                var def = document.Application.OpenSharedParameterFile()
+                    .Groups.get_Item(groupName).Definitions.get_Item(parameterName);
                 document.ParameterBindings.Insert(def, bin, groupType.InternalForgeTypeId);
 
                 // apply old shared parameter file


### PR DESCRIPTION

### Purpose

There is an issue that when use "Parameter.CreateProjectParameter" or "Parameter.CreateProjectParameterForAllCategories", if your input is a lot of input, when this method gets called multiple times, the Definition obtained by the Create method will be cleared at parameterbinding.insert, possibly due to memory being freed.
So I re-fetch the Definition from CurrentDocument before I do the Insert.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @wangyangshi 

### FYIs

