### PR TITLE
ForgeType Refactor

### DIFF
--- a/src/DynamoRevit/Resources/LayoutSpecs.json
+++ b/src/DynamoRevit/Resources/LayoutSpecs.json
@@ -185,6 +185,9 @@
                   "path": "RevitNodes.Revit.Elements.Group"
                 },
                 {
+                  "path": "RevitNodes.Revit.Elements.GroupType"
+                },
+                {
                   "path": "RevitNodes.Revit.Elements.ImportInstance"
                 },
                 {
@@ -228,6 +231,9 @@
                 },
                 {
                   "path": "RevitNodes.Revit.Elements.Space"
+                },
+                {
+                  "path": "RevitNodes.Revit.Elements.SpecType"
                 },
                 {
                   "path": "RevitNodes.Revit.Elements.StructuralFraming"

--- a/src/Libraries/RevitNodes/Application/FamilyDocument.cs
+++ b/src/Libraries/RevitNodes/Application/FamilyDocument.cs
@@ -210,7 +210,7 @@ namespace Revit.Application
         /// <param name="specType">The type of new family parameter.</param>
         /// <param name="isInstance">Indicates if the new family parameter is instance or type (true if parameter should be instance).</param>
         /// <returns></returns>
-        public Elements.FamilyParameter AddParameter(string parameterName, ForgeType groupType, ForgeType specType, bool isInstance)
+        public Elements.FamilyParameter AddParameter(string parameterName, Revit.Elements.GroupType groupType, SpecType specType, bool isInstance)
         {
             TransactionManager.Instance.EnsureInTransaction(this.InternalDocument);
             var famParameter = FamilyManager.AddParameter(parameterName, groupType.InternalForgeTypeId, specType.InternalForgeTypeId, isInstance);

--- a/src/Libraries/RevitNodes/Elements/FamilyParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilyParameter.cs
@@ -39,12 +39,28 @@ namespace Revit.Elements
         /// <summary>
         /// Get the parameter's spec type
         /// </summary>
-        public SpecType SpecType => SpecType.FromExisting(InternalFamilyParameter.Definition.GetDataType());
+        public SpecType SpecType
+        {
+            get
+            {
+                var forgeTypeId = InternalFamilyParameter.Definition.GetDataType();
+
+                return string.IsNullOrEmpty(forgeTypeId.TypeId)? null : SpecType.FromExisting(forgeTypeId);
+            }
+        }
 
         /// <summary>
         /// Get the parameter's group type
         /// </summary>
-        public GroupType GroupType => GroupType.FromExisting(InternalFamilyParameter.Definition.GetGroupTypeId());
+        public GroupType GroupType
+        {
+            get
+            {
+                var forgeTypeId = InternalFamilyParameter.Definition.GetGroupTypeId();
+
+                return string.IsNullOrEmpty(forgeTypeId.TypeId) ? null : GroupType.FromExisting(forgeTypeId);
+            }
+        }
 
         /// <summary>
         /// Get Parameter Storage Type

--- a/src/Libraries/RevitNodes/Elements/FamilyParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilyParameter.cs
@@ -39,12 +39,12 @@ namespace Revit.Elements
         /// <summary>
         /// Get the parameter's spec type
         /// </summary>
-        public ForgeType SpecType => ForgeType.FromExisting(InternalFamilyParameter.Definition.GetDataType());
+        public SpecType SpecType => SpecType.FromExisting(InternalFamilyParameter.Definition.GetDataType());
 
         /// <summary>
         /// Get the parameter's group type
         /// </summary>
-        public ForgeType GroupType => ForgeType.FromExisting(InternalFamilyParameter.Definition.GetGroupTypeId());
+        public GroupType GroupType => GroupType.FromExisting(InternalFamilyParameter.Definition.GetGroupTypeId());
 
         /// <summary>
         /// Get Parameter Storage Type

--- a/src/Libraries/RevitNodes/Elements/ForgeType.cs
+++ b/src/Libraries/RevitNodes/Elements/ForgeType.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Autodesk.Revit.DB;
+﻿using Autodesk.Revit.DB;
 using Autodesk.DesignScript.Runtime;
 
 namespace Revit.Elements
@@ -85,30 +83,6 @@ namespace Revit.Elements
         public override string ToString()
         {
             return InternalForgeTypeId.TypeId;
-        }
-
-        protected static void GetForgeTypeIdNamesFromType(Type enumerationType, Dictionary<string,string> dictionary)
-        {
-            var properties = enumerationType.GetProperties();
-
-            foreach (var property in properties)
-            {
-                string name = property.Name;
-                ForgeTypeId forgeTypeID = property.GetValue(null, null) as ForgeTypeId;
-                dictionary[forgeTypeID.TypeId] = name;
-            }
-
-            var types = enumerationType.GetNestedTypes();
-            foreach (var type in types)
-            {
-                var nestProperties = type.GetProperties();
-                foreach (var nestProperty in nestProperties)
-                {
-                    string name = nestProperty.Name;
-                    ForgeTypeId forgeTypeID = nestProperty.GetValue(null, null) as ForgeTypeId;
-                    dictionary[forgeTypeID.TypeId] = name;
-                }
-            }
         }
     }
 }

--- a/src/Libraries/RevitNodes/Elements/ForgeType.cs
+++ b/src/Libraries/RevitNodes/Elements/ForgeType.cs
@@ -1,4 +1,6 @@
-﻿using Autodesk.Revit.DB;
+﻿using System;
+using System.Collections.Generic;
+using Autodesk.Revit.DB;
 using Autodesk.DesignScript.Runtime;
 
 namespace Revit.Elements
@@ -18,12 +20,12 @@ namespace Revit.Elements
         #endregion
 
         #region Private Construction
-        
+
         /// <summary>
         /// Init ForgeType with typeId of a ForgeTypeId
         /// </summary>
         /// <param name="typeId"></param>
-        private ForgeType(string typeId)
+        private protected ForgeType(string typeId)
         {
             ForgeTypeId forgeTypeId = new ForgeTypeId(typeId);
             InternalSetForgeType(forgeTypeId);
@@ -33,7 +35,7 @@ namespace Revit.Elements
         /// Init ForgeType with an existing ForgeTypeId
         /// </summary>
         /// <param name="forgeTypeId"></param>
-        private ForgeType(ForgeTypeId forgeTypeId)
+        private protected ForgeType(ForgeTypeId forgeTypeId)
         {
             InternalSetForgeType(forgeTypeId);
         }
@@ -79,38 +81,34 @@ namespace Revit.Elements
 
         #endregion
 
-        #region Public static constructors
-
-        /// <summary>
-        /// Get a ForgeTypeId by schema identifier.
-        /// </summary>
-        /// <param name="typeId">a schema identifier</param>
-        /// <returns></returns>
-        public static ForgeType ByTypeId(string typeId)
-        {
-            return new ForgeType(typeId);
-        }
-
-        #endregion
-
         [IsVisibleInDynamoLibrary(false)]
         public override string ToString()
         {
             return InternalForgeTypeId.TypeId;
         }
 
-        #region Internal static constructor
-
-        /// <summary>
-        /// Wrap an exsiting ForgeTypeId to ForgeType
-        /// </summary>
-        /// <param name="forgeTypeId"></param>
-        /// <returns></returns>
-        internal static ForgeType FromExisting(ForgeTypeId forgeTypeId)
+        protected static void GetForgeTypeIdNamesFromType(Type enumerationType, Dictionary<string,string> dictionary)
         {
-            return new ForgeType(forgeTypeId);
-        }
+            var properties = enumerationType.GetProperties();
 
-        #endregion
+            foreach (var property in properties)
+            {
+                string name = property.Name;
+                ForgeTypeId forgeTypeID = property.GetValue(null, null) as ForgeTypeId;
+                dictionary[forgeTypeID.TypeId] = name;
+            }
+
+            var types = enumerationType.GetNestedTypes();
+            foreach (var type in types)
+            {
+                var nestProperties = type.GetProperties();
+                foreach (var nestProperty in nestProperties)
+                {
+                    string name = nestProperty.Name;
+                    ForgeTypeId forgeTypeID = nestProperty.GetValue(null, null) as ForgeTypeId;
+                    dictionary[forgeTypeID.TypeId] = name;
+                }
+            }
+        }
     }
 }

--- a/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
@@ -285,7 +285,9 @@ namespace Revit.Elements
         {
             get
             {
-                return SpecType.FromExisting(this.InternalGlobalParameter.GetDefinition().GetDataType());
+                var forgeTypeId = this.InternalGlobalParameter.GetDefinition().GetDataType();
+
+                return string.IsNullOrEmpty(forgeTypeId.TypeId) ? null : SpecType.FromExisting(forgeTypeId);
             }
         }
 
@@ -296,7 +298,9 @@ namespace Revit.Elements
         {
             get
             {
-                return GroupType.FromExisting(this.InternalGlobalParameter.GetDefinition().GetGroupTypeId());
+                var forgeTypeId = this.InternalGlobalParameter.GetDefinition().GetGroupTypeId();
+
+                return string.IsNullOrEmpty(forgeTypeId.TypeId) ? null : GroupType.FromExisting(forgeTypeId);
             }
         }
 

--- a/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
@@ -281,22 +281,22 @@ namespace Revit.Elements
         /// <summary>
         /// Get SpecType
         /// </summary>
-        public ForgeType SpecType
+        public SpecType SpecType
         {
             get
             {
-                return ForgeType.FromExisting(this.InternalGlobalParameter.GetDefinition().GetDataType());
+                return SpecType.FromExisting(this.InternalGlobalParameter.GetDefinition().GetDataType());
             }
         }
 
         /// <summary>
         /// Get Parameter Group Type
         /// </summary>
-        public ForgeType GroupType
+        public GroupType GroupType
         {
             get
             {
-                return ForgeType.FromExisting(this.InternalGlobalParameter.GetDefinition().GetGroupTypeId());
+                return GroupType.FromExisting(this.InternalGlobalParameter.GetDefinition().GetGroupTypeId());
             }
         }
 
@@ -310,7 +310,7 @@ namespace Revit.Elements
         /// <param name="name">Name fo the parameter</param>
         /// <param name="specType">The type of new global parameter.</param>
         /// <returns></returns>
-        public static GlobalParameter ByName(string name, ForgeType specType)
+        public static GlobalParameter ByName(string name, SpecType specType)
         {
             if (!Autodesk.Revit.DB.GlobalParametersManager.AreGlobalParametersAllowed(Document))
             {

--- a/src/Libraries/RevitNodes/Elements/GroupType.cs
+++ b/src/Libraries/RevitNodes/Elements/GroupType.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using Autodesk.Revit.DB;
 using Autodesk.DesignScript.Runtime;
 
@@ -6,39 +6,25 @@ namespace Revit.Elements
 {
     public class GroupType : ForgeType
     {
-        private static Dictionary<string, string> forgeTypeIdToNameDictionary = new Dictionary<string, string>();
-
-        /// <summary>
-        /// Internal reference to Revit ForgeTypeId
-        /// </summary>
-        internal static Dictionary<string, string> ForgeTypeIdToNameDictionary
-        {
-            get
-            {
-                if (forgeTypeIdToNameDictionary.Count == 0)
-                {
-                    var enumerationType = typeof(GroupTypeId);
-
-                    GetForgeTypeIdNamesFromType(enumerationType, forgeTypeIdToNameDictionary);
-                }
-
-                return forgeTypeIdToNameDictionary;
-            }
-        }
-
         #region Private Construction
 
         /// <summary>
         /// Init SpecType with typeId of a ForgeTypeId
         /// </summary>
         /// <param name="typeId"></param>
-        private GroupType(string typeId) :base(typeId) {}
+        private GroupType(string typeId) : base(typeId)
+        {
+            CheckForValidForgeIdType();
+        }
 
         /// <summary>
         /// Init SpecType with an existing ForgeTypeId
         /// </summary>
         /// <param name="forgeTypeId"></param>
-        private GroupType(ForgeTypeId forgeTypeId): base(forgeTypeId) {}
+        private GroupType(ForgeTypeId forgeTypeId) : base(forgeTypeId)
+        {
+            CheckForValidForgeIdType();
+        }
 
         #endregion
 
@@ -59,12 +45,9 @@ namespace Revit.Elements
         [IsVisibleInDynamoLibrary(false)]
         public override string ToString()
         {
-            if (ForgeTypeIdToNameDictionary.TryGetValue(InternalForgeTypeId.TypeId, out var name))
-            {
-                return name;
-            }
+            var groupName = LabelUtils.GetLabelForGroup(InternalForgeTypeId);
 
-            return InternalForgeTypeId.TypeId;
+            return "GroupType(Name = " + groupName + ")";
         }
 
         #region Internal static constructor
@@ -80,5 +63,13 @@ namespace Revit.Elements
         }
 
         #endregion
+
+        private void CheckForValidForgeIdType()
+        {
+            if (!ParameterUtils.IsBuiltInGroup(InternalForgeTypeId))
+            {
+                throw new Exception("This id string is not valid for a " + nameof(SpecType));
+            }
+        }
     }
 }

--- a/src/Libraries/RevitNodes/Elements/GroupType.cs
+++ b/src/Libraries/RevitNodes/Elements/GroupType.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using Autodesk.Revit.DB;
+using Autodesk.DesignScript.Runtime;
+
+namespace Revit.Elements
+{
+    public class GroupType : ForgeType
+    {
+        private static Dictionary<string, string> forgeTypeIdToNameDictionary = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Internal reference to Revit ForgeTypeId
+        /// </summary>
+        internal static Dictionary<string, string> ForgeTypeIdToNameDictionary
+        {
+            get
+            {
+                if (forgeTypeIdToNameDictionary.Count == 0)
+                {
+                    var enumerationType = typeof(GroupTypeId);
+
+                    GetForgeTypeIdNamesFromType(enumerationType, forgeTypeIdToNameDictionary);
+                }
+
+                return forgeTypeIdToNameDictionary;
+            }
+        }
+
+        #region Private Construction
+
+        /// <summary>
+        /// Init SpecType with typeId of a ForgeTypeId
+        /// </summary>
+        /// <param name="typeId"></param>
+        private GroupType(string typeId) :base(typeId) {}
+
+        /// <summary>
+        /// Init SpecType with an existing ForgeTypeId
+        /// </summary>
+        /// <param name="forgeTypeId"></param>
+        private GroupType(ForgeTypeId forgeTypeId): base(forgeTypeId) {}
+
+        #endregion
+
+        #region Public static constructors
+
+        /// <summary>
+        /// Get a ForgeTypeId by schema identifier.
+        /// </summary>
+        /// <param name="typeId">a schema identifier</param>
+        /// <returns></returns>
+        public static GroupType ByTypeId(string typeId)
+        {
+            return new GroupType(typeId);
+        }
+
+        #endregion
+
+        [IsVisibleInDynamoLibrary(false)]
+        public override string ToString()
+        {
+            if (ForgeTypeIdToNameDictionary.TryGetValue(InternalForgeTypeId.TypeId, out var name))
+            {
+                return name;
+            }
+
+            return InternalForgeTypeId.TypeId;
+        }
+
+        #region Internal static constructor
+
+        /// <summary>
+        /// Wrap an exsiting ForgeTypeId to ForgeType
+        /// </summary>
+        /// <param name="forgeTypeId"></param>
+        /// <returns></returns>
+        internal static GroupType FromExisting(ForgeTypeId forgeTypeId)
+        {
+            return new GroupType(forgeTypeId);
+        }
+
+        #endregion
+    }
+}

--- a/src/Libraries/RevitNodes/Elements/Parameter.cs
+++ b/src/Libraries/RevitNodes/Elements/Parameter.cs
@@ -76,7 +76,12 @@ namespace Revit.Elements
         /// </summary>
         public SpecType SpecType
         {
-            get { return SpecType.FromExisting(InternalParameter.Definition.GetDataType()); }
+            get
+            {
+                var forgeTypeId = InternalParameter.Definition.GetDataType();
+
+                return string.IsNullOrEmpty(forgeTypeId.TypeId)? null : SpecType.FromExisting(forgeTypeId);
+            }
         }
 
         /// <summary>
@@ -84,7 +89,12 @@ namespace Revit.Elements
         /// </summary>
         public GroupType GroupType
         {
-            get { return GroupType.FromExisting(InternalParameter.Definition.GetGroupTypeId()); }
+            get
+            {
+                var forgeTypeId = InternalParameter.Definition.GetGroupTypeId();
+
+                return string.IsNullOrEmpty(forgeTypeId.TypeId) ? null : GroupType.FromExisting(forgeTypeId);
+            }
         }
 
         /// <summary>

--- a/src/Libraries/RevitNodes/Elements/Parameter.cs
+++ b/src/Libraries/RevitNodes/Elements/Parameter.cs
@@ -74,17 +74,17 @@ namespace Revit.Elements
         /// <summary>
         /// Get the parameter's SpecType
         /// </summary>
-        public ForgeType SpecType
+        public SpecType SpecType
         {
-            get { return ForgeType.FromExisting(InternalParameter.Definition.GetDataType()); }
+            get { return SpecType.FromExisting(InternalParameter.Definition.GetDataType()); }
         }
 
         /// <summary>
         /// Get the Parameter's Group Type
         /// </summary>
-        public ForgeType GroupType
+        public GroupType GroupType
         {
-            get { return ForgeType.FromExisting(InternalParameter.Definition.GetGroupTypeId()); }
+            get { return GroupType.FromExisting(InternalParameter.Definition.GetGroupTypeId()); }
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace Revit.Elements
         /// <param name="specType">The type of new parameter.</param>
         /// <param name="groupType">The type of the group to which the parameter belongs.</param>
         /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
-        public static void CreateSharedParameterForAllCategories(string parameterName, string groupName, ForgeType specType, ForgeType groupType, bool instance)
+        public static void CreateSharedParameterForAllCategories(string parameterName, string groupName, SpecType specType, GroupType groupType, bool instance)
         {
             CreateSharedParameter(parameterName, groupName, specType, groupType, instance, null);
         }
@@ -189,7 +189,7 @@ namespace Revit.Elements
         /// <param name="groupType">The type of the group to which the parameter belongs.</param>
         /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
         /// <param name="categoryList">A list of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
-        public static void CreateSharedParameter(string parameterName, string groupName, ForgeType specType, ForgeType groupType, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
+        public static void CreateSharedParameter(string parameterName, string groupName, SpecType specType, GroupType groupType, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
             // get document and open transaction
             Document document = Application.Document.Current.InternalDocument;
@@ -256,7 +256,7 @@ namespace Revit.Elements
         /// <param name="specType">The type of new parameter.</param>
         /// <param name="groupType">The type of the group to which the parameter belongs.</param>
         /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
-        public static void CreateProjectParameterForAllCategories(string parameterName, string groupName, ForgeType specType, ForgeType groupType, bool instance)
+        public static void CreateProjectParameterForAllCategories(string parameterName, string groupName, SpecType specType, GroupType groupType, bool instance)
         {
             CreateProjectParameter(parameterName, groupName, specType, groupType, instance, null);
         }
@@ -270,7 +270,7 @@ namespace Revit.Elements
         /// <param name="groupType">The type of the group to which the parameter belongs.</param>
         /// <param name="instance">True if it's an instance parameter, otherwise it's a type parameter</param>
         /// <param name="categoryList">A list of categories this parameter applies to. If no category is supplied, all possible categories are selected</param>
-        public static void CreateProjectParameter(string parameterName, string groupName, ForgeType specType, ForgeType groupType, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
+        public static void CreateProjectParameter(string parameterName, string groupName, SpecType specType, GroupType groupType, bool instance, System.Collections.Generic.IEnumerable<Category> categoryList)
         {
             // get document and open transaction
             Document document = Application.Document.Current.InternalDocument;

--- a/src/Libraries/RevitNodes/Elements/SpecType.cs
+++ b/src/Libraries/RevitNodes/Elements/SpecType.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Autodesk.Revit.DB;
 using Autodesk.DesignScript.Runtime;
 
@@ -7,39 +6,25 @@ namespace Revit.Elements
 {
     public class SpecType : ForgeType
     {
-        private static Dictionary<string, string> forgeTypeIdToNameDictionary = new Dictionary<string, string>();
-
-        /// <summary>
-        /// Internal reference to Revit ForgeTypeId
-        /// </summary>
-        internal static Dictionary<string, string> ForgeTypeIdToNameDictionary
-        {
-            get
-            {
-                if (forgeTypeIdToNameDictionary.Count == 0)
-                {
-                    var enumerationType = typeof(SpecTypeId);
-
-                    GetForgeTypeIdNamesFromType(enumerationType, forgeTypeIdToNameDictionary);
-                }
-
-                return forgeTypeIdToNameDictionary;
-            }
-        }
-
         #region Private Construction
 
         /// <summary>
         /// Init SpecType with typeId of a ForgeTypeId
         /// </summary>
         /// <param name="typeId"></param>
-        private SpecType(string typeId) :base(typeId) {}
+        private SpecType(string typeId) : base(typeId)
+        {
+            CheckForValidForgeIdType();
+        }
 
         /// <summary>
         /// Init SpecType with an existing ForgeTypeId
         /// </summary>
         /// <param name="forgeTypeId"></param>
-        private SpecType(ForgeTypeId forgeTypeId): base(forgeTypeId) {}
+        private SpecType(ForgeTypeId forgeTypeId) : base(forgeTypeId)
+        {
+            CheckForValidForgeIdType();
+        }
 
         #endregion
 
@@ -60,12 +45,9 @@ namespace Revit.Elements
         [IsVisibleInDynamoLibrary(false)]
         public override string ToString()
         {
-            if (ForgeTypeIdToNameDictionary.TryGetValue(InternalForgeTypeId.TypeId, out var name))
-            {
-                return name;
-            }
+            var specName = LabelUtils.GetLabelForSpec(InternalForgeTypeId);
 
-            return InternalForgeTypeId.TypeId;
+            return "SpecType(Name = " + specName + ")";
         }
 
         #region Internal static constructor
@@ -81,5 +63,13 @@ namespace Revit.Elements
         }
 
         #endregion
+
+        private void CheckForValidForgeIdType()
+        {
+            if (!SpecUtils.IsSpec(InternalForgeTypeId))
+            {
+                throw new Exception("This id string is not valid for a " + nameof(SpecType));
+            }
+        }
     }
 }

--- a/src/Libraries/RevitNodes/Elements/SpecType.cs
+++ b/src/Libraries/RevitNodes/Elements/SpecType.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using Autodesk.Revit.DB;
+using Autodesk.DesignScript.Runtime;
+
+namespace Revit.Elements
+{
+    public class SpecType : ForgeType
+    {
+        private static Dictionary<string, string> forgeTypeIdToNameDictionary = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Internal reference to Revit ForgeTypeId
+        /// </summary>
+        internal static Dictionary<string, string> ForgeTypeIdToNameDictionary
+        {
+            get
+            {
+                if (forgeTypeIdToNameDictionary.Count == 0)
+                {
+                    var enumerationType = typeof(SpecTypeId);
+
+                    GetForgeTypeIdNamesFromType(enumerationType, forgeTypeIdToNameDictionary);
+                }
+
+                return forgeTypeIdToNameDictionary;
+            }
+        }
+
+        #region Private Construction
+
+        /// <summary>
+        /// Init SpecType with typeId of a ForgeTypeId
+        /// </summary>
+        /// <param name="typeId"></param>
+        private SpecType(string typeId) :base(typeId) {}
+
+        /// <summary>
+        /// Init SpecType with an existing ForgeTypeId
+        /// </summary>
+        /// <param name="forgeTypeId"></param>
+        private SpecType(ForgeTypeId forgeTypeId): base(forgeTypeId) {}
+
+        #endregion
+
+        #region Public static constructors
+
+        /// <summary>
+        /// Get a ForgeTypeId by schema identifier.
+        /// </summary>
+        /// <param name="typeId">a schema identifier</param>
+        /// <returns></returns>
+        public static SpecType ByTypeId(string typeId)
+        {
+            return new SpecType(typeId);
+        }
+
+        #endregion
+
+        [IsVisibleInDynamoLibrary(false)]
+        public override string ToString()
+        {
+            if (ForgeTypeIdToNameDictionary.TryGetValue(InternalForgeTypeId.TypeId, out var name))
+            {
+                return name;
+            }
+
+            return InternalForgeTypeId.TypeId;
+        }
+
+        #region Internal static constructor
+
+        /// <summary>
+        /// Wrap an exsiting ForgeTypeId to ForgeType
+        /// </summary>
+        /// <param name="forgeTypeId"></param>
+        /// <returns></returns>
+        internal static SpecType FromExisting(ForgeTypeId forgeTypeId)
+        {
+            return new SpecType(forgeTypeId);
+        }
+
+        #endregion
+    }
+}

--- a/src/Libraries/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/RevitNodes/RevitNodes.csproj
@@ -95,6 +95,8 @@
     <Compile Include="Elements\ElementType.cs" />
     <Compile Include="Elements\FilledRegion.cs" />
     <Compile Include="Elements\FilledRegionType.cs" />
+    <Compile Include="Elements\GroupType.cs" />
+    <Compile Include="Elements\SpecType.cs" />
     <Compile Include="Elements\ForgeType.cs" />
     <Compile Include="Elements\GlobalParameter.cs" />
     <Compile Include="Elements\FamilyParameter.cs" />

--- a/src/Libraries/RevitNodesUI/GenericClasses.cs
+++ b/src/Libraries/RevitNodesUI/GenericClasses.cs
@@ -300,7 +300,7 @@ namespace DSRevitNodesUI
                 AstFactory.BuildStringNode(((Autodesk.Revit.DB.ForgeTypeId) Items[SelectedIndex].Item).TypeId)
             };
 
-            var functionCall = AstFactory.BuildFunctionCall<String, Revit.Elements.ForgeType>(Revit.Elements.ForgeType.ByTypeId, args);
+            var functionCall = GetAstFunction(args);
 
             // assign the selected name to an actual enumeration value
             var assign = AstFactory.BuildAssignment(GetAstIdentifierForOutputIndex(0), functionCall);
@@ -308,5 +308,10 @@ namespace DSRevitNodesUI
             // return the enumeration value
             return new List<AssociativeNode> { assign };
         }
+
+        public abstract AssociativeNode GetAstFunction(List<AssociativeNode> args);
+        //{
+        //    return AstFactory.BuildFunctionCall<String, Revit.Elements.ForgeType>(<<DerivedType>>.ByTypeId, args);
+        //}
     }
 }

--- a/src/Libraries/RevitNodesUI/RevitTypes.cs
+++ b/src/Libraries/RevitNodesUI/RevitTypes.cs
@@ -121,7 +121,7 @@ namespace DSRevitNodesUI
     [NodeDescription("SpecTypeSelectorDescription", typeof(DSRevitNodesUI.Properties.Resources))]
     [IsDesignScriptCompatible]
     [OutPortTypes("Revit.Elements.SpecType")]
-    public class SpecTypes : CustomGenericNestedClassDropDown
+    public class SpecTypes : CustomForgeTypeIdDropDown
     {
         private const string outputName = "SpecType";
 
@@ -142,7 +142,7 @@ namespace DSRevitNodesUI
     [NodeDescription("GroupTypeSelectorDescription", typeof(DSRevitNodesUI.Properties.Resources))]
     [IsDesignScriptCompatible]
     [OutPortTypes("Revit.Elements.GroupType")]
-    public class GroupTypes : CustomGenericNestedClassDropDown
+    public class GroupTypes : CustomForgeTypeIdDropDown
     {
         private const string outputName = "GroupType";
 

--- a/src/Libraries/RevitNodesUI/RevitTypes.cs
+++ b/src/Libraries/RevitNodesUI/RevitTypes.cs
@@ -120,32 +120,42 @@ namespace DSRevitNodesUI
     [NodeCategory("Revit.Elements.Parameter")]
     [NodeDescription("SpecTypeSelectorDescription", typeof(DSRevitNodesUI.Properties.Resources))]
     [IsDesignScriptCompatible]
-    [OutPortTypes("Revit.Elements.ForgeType")]
+    [OutPortTypes("Revit.Elements.SpecType")]
     public class SpecTypes : CustomGenericNestedClassDropDown
     {
-        private const string outputName = "ForgeType";
+        private const string outputName = "SpecType";
 
         public SpecTypes() : base(outputName, typeof(Autodesk.Revit.DB.SpecTypeId)) { }
 
         [JsonConstructor]
         public SpecTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(outputName, typeof(Autodesk.Revit.DB.SpecTypeId), inPorts, outPorts) { }
+
+        public override AssociativeNode GetAstFunction(List<AssociativeNode> args)
+        {
+            return AstFactory.BuildFunctionCall<String, Revit.Elements.SpecType>(Revit.Elements.SpecType.ByTypeId, args);
+        }
     }
 
     [NodeName("Group Types")]
     [NodeCategory("Revit.Elements.Parameter")]
     [NodeDescription("GroupTypeSelectorDescription", typeof(DSRevitNodesUI.Properties.Resources))]
     [IsDesignScriptCompatible]
-    [OutPortTypes("Revit.Elements.ForgeType")]
+    [OutPortTypes("Revit.Elements.GroupType")]
     public class GroupTypes : CustomGenericNestedClassDropDown
     {
-        private const string outputName = "ForgeType";
+        private const string outputName = "GroupType";
 
         public GroupTypes() : base(outputName, typeof(Autodesk.Revit.DB.GroupTypeId)) { }
 
         [JsonConstructor]
         public GroupTypes(IEnumerable<PortModel> inPorts, IEnumerable<PortModel> outPorts)
             : base(outputName, typeof(Autodesk.Revit.DB.GroupTypeId), inPorts, outPorts) { }
+
+        public override AssociativeNode GetAstFunction(List<AssociativeNode> args)
+        {
+            return AstFactory.BuildFunctionCall<String, Revit.Elements.GroupType>(Revit.Elements.GroupType.ByTypeId, args);
+        }
     }
 
     [NodeName("Select Revision Visibility")]


### PR DESCRIPTION
### Purpose

The purpose of this PR is to refactor the user presentation of the `ForgeTypeID` object found in the RevitAPI for the DynamoRevit context.  Note, these nodes have not be included in a Revit Release yet so all changes are not API breaking.  In general, the idea is to reduce the confusion between nodes which require a `ForgeTypeID` object as an input but in reality need a specific type of `ForegTypeID`.  For example a node like `CreateSharedParameter` requires two `ForgeType` inputs but they need to representing an underlying `SpecType` and `GroupType` respectively.  This can be confusing to a Dynamo user as there is no clear way in the Dynamo type system to understand the distinction.  This issue can be additionally confusing as some specs and groups share the same name like Length or Area.  The other reason for this change is to better reflect the way that Dynamo Core has wrapped the `ForgeUnit` types.  While the underlying data is the same as the `SpecType` and `GroupType` (ie a ForgeType object), the Dynamo Core implementation provides unique types for Unit, Quantity, and Symbol.  This change will better match the core implementation.  Specifically this PR does the follwoing: 

* Add two new unique types.  `SpecType` and `GroupType` based on the `ForgeType` as a baseclass.  
* The `ForgeType` now only has properties (`TypeID` and `IsValidType`).  The constructors are found on the derived classes.
* The constructors for the `GroupType` and `SpecType` objects guard against ForgeTypeID strings and objecst that are not valid for their respective types. 
* All nodes that require inputs of a `ForgeType` now require a `GroupType` or `SpecType`.
* All nodes that return `ForgeType` now return a `GroupType` or `SpecType` as required.

This PR also adjusts the `ToSting()` override used for displaying ForgeType object in the Dynamo preview.  Where possible we show the name of the object vs the `TypeId`.  The `TypeId` is still available as a property of the type but is not as friendly to expose as a name.  So now the preview will show _SpecType(Name = Length)_ vs _autodesk.spec.aec:length-2.0.0_ as an example.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @ZiyunShang @dbecroft 

### FYIs

@QilongTang @Amoursol @mjkkirschner 
