### PR TITLE
Revit 185770 - 

### DIFF
--- a/src/Libraries/RevitNodesUI/SelectionCombo.cs
+++ b/src/Libraries/RevitNodesUI/SelectionCombo.cs
@@ -43,19 +43,27 @@ namespace Dynamo.ComboNodes
 
         public DSRevitNodesUI.Categories DropDownNodeModel { get; set; }
 
-        private int selectedIndex;
-
         [JsonProperty(PropertyName = "SelectedIndex")]
         public int SelectedIndex
         {
-            get { return selectedIndex; }
+            get { return DropDownNodeModel.SelectedIndex; }
             set
             {
-                selectedIndex = value;
                 DropDownNodeModel.SelectedIndex = value;
-                if (value >= 0)
+                if (DropDownNodeModel.SelectedIndex >= 0)
+                {
                     SelectionFilter.Category = (BuiltInCategory)DropDownNodeModel.Items[SelectedIndex].Item;
-                
+                }
+            }
+        }
+
+        [JsonProperty(PropertyName = "SelectedString")]
+        public string SelectedString
+        {
+            get { return DropDownNodeModel.SelectedString; }
+            set
+            {
+                DropDownNodeModel.SelectedString = value;
             }
         }
 
@@ -104,19 +112,27 @@ namespace Dynamo.ComboNodes
 
         public DSRevitNodesUI.Categories DropDownNodeModel { get; set; }
 
-        private int selectedIndex;
-
         [JsonProperty(PropertyName = "SelectedIndex")]
         public int SelectedIndex
         {
-            get { return selectedIndex; }
+            get { return DropDownNodeModel.SelectedIndex; }
             set
             {
-                selectedIndex = value;
                 DropDownNodeModel.SelectedIndex = value;
-                if (value >= 0)
+                if (DropDownNodeModel.SelectedIndex >= 0)
+                {
                     SelectionFilter.Category = (BuiltInCategory)DropDownNodeModel.Items[SelectedIndex].Item;
+                }
+            }
+        }
 
+        [JsonProperty(PropertyName = "SelectedString")]
+        public string SelectedString
+        {
+            get { return DropDownNodeModel.SelectedString; }
+            set
+            {
+                DropDownNodeModel.SelectedString = value;
             }
         }
 

--- a/test/System/Selection/SelectModelElementByCategory.dyn
+++ b/test/System/Selection/SelectModelElementByCategory.dyn
@@ -11,6 +11,8 @@
   "Nodes": [
     {
       "ConcreteType": "Dynamo.ComboNodes.DSModelElementByCategorySelection, DSRevitNodesUI",
+      "SelectedIndex": 686,
+      "SelectedString": "OST_Walls",
       "NodeType": "ExtensionNode",
       "InstanceId": [
         "ef57b02a-5e81-49e7-93bb-ae5f002d921c-00030826"

--- a/test/System/Selection/SelectModelElementsByCategory.dyn
+++ b/test/System/Selection/SelectModelElementsByCategory.dyn
@@ -11,6 +11,8 @@
   "Nodes": [
     {
       "ConcreteType": "Dynamo.ComboNodes.DSModelElementsByCategorySelection, DSRevitNodesUI",
+      "SelectedIndex": 686,
+      "SelectedString": "OST_Walls",
       "NodeType": "ExtensionNode",
       "InstanceId": [
         "ef57b02a-5e81-49e7-93bb-ae5f002d921c-00030826",


### PR DESCRIPTION
### Purpose

The purpose of this PR to fix a bug with the SelectModelElementByCategory and SelectModelElementsByCategory nodes where the the nodes will deserialize to the wrong Category if the language of the Revit Session is different from the language of the Revit session where the Dynamo file was saved.  The PR adds the SelectedString property which other Dropdown UI Nodes use to properly deserialize in this situation. 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @ZiyunShang

### FYIs

@BogdanZavu @SHKnudsen 
