### PR TITLE
Add converter for internal Revit unit types not found ForgeUnit SDK

### DIFF
--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -320,7 +320,10 @@ namespace Revit.Application
         public DynamoUnits.Unit UnitTypeBySpecType(ForgeType specType)
         {
             var units = InternalDocument.GetUnits();
-            return Unit.ByTypeID(units.GetFormatOptions(specType.InternalForgeTypeId).GetUnitTypeId().TypeId);
+            var unitTypeId = units.GetFormatOptions(specType.InternalForgeTypeId).GetUnitTypeId();
+            var cleanUnitTypeId = UnitConverter.ConvertRevitInternalUnitTypeIdToSupportedUnitTypeId(unitTypeId);
+
+            return Unit.ByTypeID(cleanUnitTypeId.TypeId);
         }
     }
 

--- a/src/Libraries/RevitNodes/Elements/FamilyParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilyParameter.cs
@@ -2,6 +2,7 @@
 using Autodesk.Revit.DB;
 using RevitServices.Transactions;
 using Dynamo.Graph.Nodes;
+using Revit.GeometryConversion;
 
 namespace Revit.Elements
 {
@@ -67,7 +68,13 @@ namespace Revit.Elements
         /// </summary>
         public DynamoUnits.Unit Unit
         {
-            get { return DynamoUnits.Unit.ByTypeID(InternalFamilyParameter.GetUnitTypeId().TypeId); }
+            get
+            {
+                var unitTypeId = InternalFamilyParameter.GetUnitTypeId();
+                var cleanUnitTypeId = UnitConverter.ConvertRevitInternalUnitTypeIdToSupportedUnitTypeId(unitTypeId);
+
+                return DynamoUnits.Unit.ByTypeID(cleanUnitTypeId.TypeId);
+            }
         }
 
         /// <summary>

--- a/src/Libraries/RevitNodes/Elements/Parameter.cs
+++ b/src/Libraries/RevitNodes/Elements/Parameter.cs
@@ -2,6 +2,7 @@
 using Autodesk.Revit.DB;
 using RevitServices.Transactions;
 using Dynamo.Graph.Nodes;
+using Revit.GeometryConversion;
 
 namespace Revit.Elements
 {
@@ -102,7 +103,13 @@ namespace Revit.Elements
         /// </summary>
         public DynamoUnits.Unit Unit
         {
-            get { return DynamoUnits.Unit.ByTypeID(InternalParameter.GetUnitTypeId().TypeId); }
+            get
+            {
+                var unitTypeId = InternalParameter.GetUnitTypeId();
+                var cleanUnitTypeId = UnitConverter.ConvertRevitInternalUnitTypeIdToSupportedUnitTypeId(unitTypeId);
+
+                return DynamoUnits.Unit.ByTypeID(cleanUnitTypeId.TypeId);
+            }
         }
 
         /// <summary>

--- a/src/Libraries/RevitNodes/GeometryConversion/UnitConverter.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/UnitConverter.cs
@@ -24,6 +24,41 @@ namespace Revit.GeometryConversion
             return UnitUtils.ConvertToInternalUnits(1, unitTypeId);
         }
 
+        public static ForgeTypeId ConvertRevitInternalUnitTypeIdToSupportedUnitTypeId(ForgeTypeId forgeTypeId)
+        {
+            //Handle conversion of the Revit Handwritten units to UnitsSDK equivalents
+
+            if (forgeTypeId.Equals(UnitTypeId.FeetFractionalInches)
+                || forgeTypeId.Equals(UnitTypeId.StationingFeet))
+            {
+                return UnitTypeId.Feet;
+            }
+
+            if (forgeTypeId.Equals(UnitTypeId.StationingSurveyFeet))
+            {
+                return UnitTypeId.UsSurveyFeet;
+            }
+
+            if (forgeTypeId.Equals(UnitTypeId.FeetFractionalInches))
+            {
+                return UnitTypeId.Inches;
+            }
+
+            if (forgeTypeId.Equals(UnitTypeId.MetersCentimeters)
+                || forgeTypeId.Equals(UnitTypeId.StationingMeters))
+            {
+                return UnitTypeId.Meters;
+            }
+
+            if (forgeTypeId.Equals(UnitTypeId.DegreesMinutes)
+                || forgeTypeId.Equals(UnitTypeId.SlopeDegrees))
+            {
+                return UnitTypeId.Degrees;
+            }
+
+            return forgeTypeId;
+        }
+
         public static double HostToDynamoFactor(ForgeTypeId specTypeId)
         {
             // Here we invert the conversion factor to return

--- a/src/Libraries/RevitNodes/GeometryConversion/UnitConverter.cs
+++ b/src/Libraries/RevitNodes/GeometryConversion/UnitConverter.cs
@@ -24,6 +24,13 @@ namespace Revit.GeometryConversion
             return UnitUtils.ConvertToInternalUnits(1, unitTypeId);
         }
 
+        /// <summary>
+        /// Converts a Revit ForgeTypeId of type UnitTypeID to the subset of supported types that are available
+        /// in the ForgeUnitSDK.  There are a few special cases hardcoded into the Revit API that require a conversion.
+        /// For example, FeetFractionalInches would be converted to the ForgeUnitCLR.Unit type of Feet.
+        /// </summary>
+        /// <param name="forgeTypeId">The UnitTypeId to convert</param>
+        /// <returns>A UnitTypeId supported in ForgeUnitSDK</returns>
         public static ForgeTypeId ConvertRevitInternalUnitTypeIdToSupportedUnitTypeId(ForgeTypeId forgeTypeId)
         {
             //Handle conversion of the Revit Handwritten units to UnitsSDK equivalents
@@ -39,7 +46,7 @@ namespace Revit.GeometryConversion
                 return UnitTypeId.UsSurveyFeet;
             }
 
-            if (forgeTypeId.Equals(UnitTypeId.FeetFractionalInches))
+            if (forgeTypeId.Equals(UnitTypeId.FractionalInches))
             {
                 return UnitTypeId.Inches;
             }


### PR DESCRIPTION
### Purpose

The purpose of this PR is to add support for the internal Revit Unit types (handwritten) not found in the ForgeUnitSDK. 

These Unit types are: `DegreesMinutes`, `FeetFractionalInches`, `FractionalInches`, `MetersCentimeters`, `SlopeDegrees`, `StationingFeet`, `StationingMeters`, and `StationingSurveyFeet`

This PR introduces a converter function that will convert these to their equivalent ForgeUnitSDK types.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @ZiyunShang @dbecroft

### FYIs

@nate-peters 
