### PR TITLE
Add new material node and appearance asset element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add 3 new nodes - Material.AppearanceAssetElement, AppearanceAssetElement.GetRenderingAssetTextureImages, AppearanceAssetElement.SetRenderingAssetTextureImage
+
 ## 0.4.1
 * Update Foreground Color For Selection by Category Nodes.
 * Update ComboBox Style for Selection by Category Nodes.

--- a/src/DynamoRevit/Resources/LayoutSpecs.json
+++ b/src/DynamoRevit/Resources/LayoutSpecs.json
@@ -92,6 +92,9 @@
                   "path": "RevitNodes.Revit.Elements.AdaptiveComponent"
                 },
                 {
+                  "path": "RevitNodes.Revit.Elements.AppearanceAssetElement"
+                },
+                {
                   "path": "RevitNodes.Revit.Elements.Area"
                 },
                 {

--- a/src/Libraries/RevitNodes/Application/Document.cs
+++ b/src/Libraries/RevitNodes/Application/Document.cs
@@ -189,7 +189,7 @@ namespace Revit.Application
         private List<Autodesk.Revit.DB.ElementId> PurgeMaterialAssets(List<Autodesk.Revit.DB.ElementId> elementIds)
         {
             List<ElementId> appearanceAssetIds = new FilteredElementCollector(this.InternalDocument)
-                .OfClass(typeof(AppearanceAssetElement))
+                .OfClass(typeof(Autodesk.Revit.DB.AppearanceAssetElement))
                 .ToElementIds()
                 .ToList();
 

--- a/src/Libraries/RevitNodes/Elements/AppearanceAssetElement.cs
+++ b/src/Libraries/RevitNodes/Elements/AppearanceAssetElement.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DynamoServices;
+using RevitServices.Transactions;
+
+namespace Revit.Elements
+{
+    [RegisterForTrace]
+    public class AppearanceAssetElement : Element
+    {
+        #region Internal properties
+
+        /// <summary>
+        /// Internal reference to the Element
+        /// </summary>
+        internal Autodesk.Revit.DB.AppearanceAssetElement InternalAppearanceAssetElement
+        {
+            get; private set;
+        }
+
+        /// <summary>
+        /// Reference to the Element
+        /// </summary>
+        public override Autodesk.Revit.DB.Element InternalElement
+        {
+            get { return InternalAppearanceAssetElement; }
+        }
+
+        #endregion
+
+        #region Private constructors
+
+        /// <summary>
+        /// Private constructor for DSAppearanceAssetElement
+        /// </summary>
+        /// <param name="appearanceAssetElement"></param>
+        private AppearanceAssetElement(Autodesk.Revit.DB.AppearanceAssetElement appearanceAssetElement)
+        {
+            SafeInit(() => InitAppearanceAssetElement(appearanceAssetElement), true);
+        }
+
+        #endregion
+
+        #region Helper for private constructors
+
+        /// <summary>
+        /// Initialize a AppearanceAssetElement element
+        /// </summary>
+        /// <param name="appearanceAssetElement"></param>
+        private void InitAppearanceAssetElement(Autodesk.Revit.DB.AppearanceAssetElement appearanceAssetElement)
+        {
+            InternalSetAppearanceAssetElement(appearanceAssetElement);
+        }
+
+        #endregion
+
+        #region Private mutators
+
+        /// <summary>
+        /// Set the internal Element, ELementId, and UniqueId
+        /// </summary>
+        /// <param name="appearanceAssetElement"></param>
+        private void InternalSetAppearanceAssetElement(Autodesk.Revit.DB.AppearanceAssetElement appearanceAssetElement)
+        {
+            this.InternalAppearanceAssetElement = appearanceAssetElement;
+            this.InternalElementId = appearanceAssetElement.Id;
+            this.InternalUniqueId = appearanceAssetElement.UniqueId;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Get RenderingAsset Texture Images
+        /// </summary>
+        public Dictionary<string, string> GetRenderingAssetTextureImages
+        {
+            get
+            {
+                var asset = this.InternalAppearanceAssetElement.GetRenderingAsset();
+
+                List<string> KeyValue = new List<string>();
+                Dictionary<string, string> keyValues = new Dictionary<string, string>();
+                KeyValue.AddRange(GetAssetProperties(asset, ""));
+                foreach(var value in KeyValue)
+                {
+                    var strs = value.Split(new Char[] { ':' }, 2);
+                    if (strs.Length == 2)
+                    { 
+                        keyValues.Add(strs[0], strs[1]); 
+                    }
+                }
+                return keyValues;
+            }
+        }
+
+        /// <summary>
+        /// Set ImagePath for a Texture Asset.
+        /// </summary>
+        /// <param name="propertyPath"></param>
+        /// <param name="imagePath"></param>
+        /// <returns></returns>
+        public AppearanceAssetElement SetRenderingAssetTextureImage(string propertyPath, string imagePath)
+        {
+            var properties = propertyPath.Split('.');
+            TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
+            {
+                using (Autodesk.Revit.DB.Visual.AppearanceAssetEditScope editScope =
+                    new Autodesk.Revit.DB.Visual.AppearanceAssetEditScope(Application.Document.Current.InternalDocument))
+                {
+                    Autodesk.Revit.DB.Visual.Asset editableAsset = editScope.Start(InternalElementId);
+                    Autodesk.Revit.DB.Visual.AssetProperty assetProperty = editableAsset.FindByName(properties[0]);
+                    if(assetProperty == null)
+                    {
+                        throw new ArgumentException(Properties.Resources.AppearanceAssetElementPropertyPathInvalid);
+                    }
+                    Autodesk.Revit.DB.Visual.Asset connentedAsset = assetProperty.GetSingleConnectedAsset();
+                    for (int i = 1; i < properties.Length; i++)
+                    {
+                        if(connentedAsset == null)
+                        {
+                            throw new ArgumentException(Properties.Resources.AppearanceAssetElementPropertyPathInvalid);
+                        }
+                        assetProperty = connentedAsset.FindByName(properties[i]);
+                        if (assetProperty == null)
+                        {
+                            throw new ArgumentException(Properties.Resources.AppearanceAssetElementPropertyPathInvalid);
+                        }
+                        connentedAsset = assetProperty.GetSingleConnectedAsset();
+                    }
+                    if (assetProperty != null && assetProperty.Name == Autodesk.Revit.DB.Visual.UnifiedBitmap.UnifiedbitmapBitmap)
+                    {
+                        (assetProperty as Autodesk.Revit.DB.Visual.AssetPropertyString).Value = imagePath;
+                    }
+                    else
+                    {
+                        throw new ArgumentException(Properties.Resources.AppearanceAssetElementPropertyPathInvalid);
+                    }
+                    editScope.Commit(true);
+                }
+            }
+
+            TransactionManager.Instance.TransactionTaskDone();
+            return this;
+        }
+
+        #endregion
+
+        #region Private Helpers
+
+        private List<string> GetAssetProperties(Autodesk.Revit.DB.Visual.Asset asset, string keyName)
+        {
+            List<string> AssetProps = new List<string>();
+
+            if(asset.Name == "UnifiedBitmapSchema")
+            {
+                var path = asset.FindByName(Autodesk.Revit.DB.Visual.UnifiedBitmap.UnifiedbitmapBitmap) as Autodesk.Revit.DB.Visual.AssetPropertyString;
+                if (path != null) 
+                {
+                    string newKeyName = keyName + "." + path.Name;
+
+                    AssetProps.Add(newKeyName + ":" + path.Value);
+                    return AssetProps;
+                }
+            }
+
+            for (int i = 0; i < asset.Size; i++)
+            {
+                Autodesk.Revit.DB.Visual.AssetProperty assetProperty = asset.Get(i);
+                if (assetProperty.NumberOfConnectedProperties > 0)
+                {
+                    var connProps = assetProperty.GetAllConnectedProperties();
+                    foreach(var prop in connProps)
+                    {
+                        string newKeyName = String.IsNullOrEmpty(keyName) ? assetProperty.Name : keyName + "." + assetProperty.Name;
+                        AssetProps.AddRange(GetAssetProperties(prop as Autodesk.Revit.DB.Visual.Asset, newKeyName));
+                    }
+                }
+            }
+
+            return AssetProps;
+        }
+
+        #endregion
+
+        #region Internal static constructors
+
+        /// <summary>
+        /// Wrap an element in the associated DS type
+        /// </summary>
+        /// <param name="appearanceAssetElement">The appearanceAssetElement</param>
+        /// <param name="isRevitOwned"></param>
+        /// <returns></returns>
+        internal static AppearanceAssetElement FromExisting(Autodesk.Revit.DB.AppearanceAssetElement appearanceAssetElement, bool isRevitOwned)
+        {
+            return new AppearanceAssetElement(appearanceAssetElement)
+            {
+                IsRevitOwned = isRevitOwned
+            };
+        }
+
+        #endregion
+    }
+}

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -381,6 +381,11 @@ namespace Revit.Elements
             return ScheduleOnSheet.FromExisting(ele, isRevitOwned);
         }
 
+        public static AppearanceAssetElement Wrap(Autodesk.Revit.DB.AppearanceAssetElement ele, bool isRevitOwned)
+        {
+            return AppearanceAssetElement.FromExisting(ele, isRevitOwned);
+        }
+
         #endregion
     }
 

--- a/src/Libraries/RevitNodes/Elements/Material.cs
+++ b/src/Libraries/RevitNodes/Elements/Material.cs
@@ -289,7 +289,28 @@ namespace Revit.Elements
             }
         }
 
+        /// <summary>
+        /// Get AppearanceAssetElement of this Material.
+        /// </summary>
+        public AppearanceAssetElement AppearanceAssetElement
+        {
+            get
+            {
+                // Get the active Document
+                Autodesk.Revit.DB.Document document = DocumentManager.Instance.CurrentDBDocument;
 
+                if (this.InternalMaterial.AppearanceAssetId != Autodesk.Revit.DB.ElementId.InvalidElementId)
+                {
+                    Autodesk.Revit.DB.AppearanceAssetElement appearance = document.GetElement(this.InternalMaterial.AppearanceAssetId) as Autodesk.Revit.DB.AppearanceAssetElement;
+
+                    return (AppearanceAssetElement)appearance.ToDSType(true);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
 
         #endregion
 

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -88,6 +88,15 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Input value for propertyPath is invalid..
+        /// </summary>
+        internal static string AppearanceAssetElementPropertyPathInvalid {
+            get {
+                return ResourceManager.GetString("AppearanceAssetElementPropertyPathInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You must supply an Area Scheme..
         /// </summary>
         internal static string AreaSchemeArgumentException {

--- a/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
@@ -576,4 +576,7 @@
   <data name="InvalidForgeTypeId" xml:space="preserve">
     <value>The id string is not valid for object of type {0}.</value>
   </data>
+  <data name="AppearanceAssetElementPropertyPathInvalid" xml:space="preserve">
+    <value>Input value for propertyPath is invalid.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -603,4 +603,7 @@
   <data name="InvalidForgeTypeId" xml:space="preserve">
     <value>The id string is not valid for object of type {0}.</value>
   </data>
+  <data name="AppearanceAssetElementPropertyPathInvalid" xml:space="preserve">
+    <value>Input value for propertyPath is invalid.</value>
+  </data>
 </root>

--- a/src/Libraries/RevitNodes/RevitNodes.csproj
+++ b/src/Libraries/RevitNodes/RevitNodes.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Application\Document.cs" />
     <Compile Include="Application\Warning.cs" />
     <Compile Include="Application\FamilyDocument.cs" />
+    <Compile Include="Elements\AppearanceAssetElement.cs" />
     <Compile Include="Elements\Area.cs" />
     <Compile Include="Elements\Category.cs" />
     <Compile Include="Elements\Ceiling.cs" />

--- a/test/Libraries/RevitIntegrationTests/AppearanceAssetElementTests.cs
+++ b/test/Libraries/RevitIntegrationTests/AppearanceAssetElementTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Dynamo.Nodes;
+using Autodesk.DesignScript.Geometry;
+using CoreNodeModels.Input;
+using NUnit.Framework;
+using RevitServices.Persistence;
+using RevitTestServices;
+using RTF.Framework;
+
+namespace RevitSystemTests
+{
+    [TestFixture]
+    public class AppearanceAssetElementTests : RevitSystemTestBase
+    {
+        [Test, TestModel(@".\Empty.rvt")]
+        public void GetSetTextureImage()
+        {
+            string samplePath = Path.Combine(workingDirectory, @".\AppearanceAssetElement\GetSetTextureImage.dyn");
+            string testPath = Path.GetFullPath(samplePath);
+
+            ViewModel.OpenCommand.Execute(testPath);
+
+            RunCurrentModel();
+
+            string expectedFileName = "TextureImageTest.txt";
+
+            var filePath = GetPreviewValue("6808334fdedf4e9984d8a57a0675fb0f") as string;
+            string fileName = Path.GetFileName(filePath);
+
+            Assert.AreEqual(expectedFileName, fileName);
+        }
+    }
+}

--- a/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
+++ b/test/Libraries/RevitIntegrationTests/RevitSystemTests.csproj
@@ -95,6 +95,7 @@
     </Compile>
     <Compile Include="AdaptiveComponentTests.cs" />
     <Compile Include="AnalysisDisplayTests.cs" />
+    <Compile Include="AppearanceAssetElementTests.cs" />
     <Compile Include="Application\FamilyDocumentTests.cs" />
     <Compile Include="AreaTests.cs" />
     <Compile Include="AsynchronousModeTests.cs" />

--- a/test/System/AppearanceAssetElement/GetSetTextureImage.dyn
+++ b/test/System/AppearanceAssetElement/GetSetTextureImage.dyn
@@ -1,0 +1,578 @@
+{
+  "Uuid": "4fb13d0e-34c9-45d5-9aa3-f9376c72bc73",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "GetSetTextureImage",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "CoreNodeModels.Input.StringInput, CoreNodeModels",
+      "NodeType": "StringInputNode",
+      "InputValue": "Acoustic Ceiling Tile 24 x 24",
+      "Id": "533c04039ef3479882feb02f45ea014a",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "bbd6c6f6d02a485d89a6000f8d813483",
+          "Name": "",
+          "Description": "String",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Creates a string."
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Material.ByName@string",
+      "Id": "527d5e8db90243a2a8350a64d2d998f3",
+      "Inputs": [
+        {
+          "Id": "2acde843d6cb43be95c54fe231824a53",
+          "Name": "name",
+          "Description": "The name of the material\n\nstring",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "dec2c849f1024d4ab3cc045b835ca545",
+          "Name": "Material",
+          "Description": "Material",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Select a material from the current document by the name\n\nMaterial.ByName (name: string): Material"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.Material.AppearanceAssetElement",
+      "Id": "e149081d71d64440bc9b129cd794021f",
+      "Inputs": [
+        {
+          "Id": "5fbc4913b37847d6b3e7cced629c1e70",
+          "Name": "material",
+          "Description": "Revit.Elements.Material",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e949f567c0f44e3fbc8b6966a967dc01",
+          "Name": "AppearanceAssetElement",
+          "Description": "AppearanceAssetElement",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get AppearanceAssetElement of this Material.\n\nMaterial.AppearanceAssetElement: AppearanceAssetElement"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.AppearanceAssetElement.GetRenderingAssetTextureImages",
+      "Id": "6fe3edd0db0b45a8846a97385e3439e6",
+      "Inputs": [
+        {
+          "Id": "c5f78086fcd2489d9170193ade1d29e1",
+          "Name": "appearanceAssetElement",
+          "Description": "Revit.Elements.AppearanceAssetElement",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "48507e83b7be432da905c4efe5e89c33",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get RenderingAsset Texture Images\n\nAppearanceAssetElement.GetRenderingAssetTextureImages: var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Keys",
+      "Id": "ec4229c63d9e440b9fa9747d573b726d",
+      "Inputs": [
+        {
+          "Id": "606f99bc9cda4764bc166f7a1d32d7e8",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "d5ec3ad9ef974dd5bc7b87fe41daa2cb",
+          "Name": "keys",
+          "Description": "Keys of the Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the keys in a Dictionary.\n\nDictionary.Keys: string[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.AppearanceAssetElement.SetRenderingAssetTextureImage@string,string",
+      "Id": "e800bfcabe34455cbbe26fe337a43ffd",
+      "Inputs": [
+        {
+          "Id": "f21dd12e7e224fb58b9ecd0812e55d43",
+          "Name": "appearanceAssetElement",
+          "Description": "Revit.Elements.AppearanceAssetElement",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a124e09714744106a0b0e000703b0bfe",
+          "Name": "propertyPath",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "04b8fff394f148fd8ae9298b6e48fdd9",
+          "Name": "imagePath",
+          "Description": "string",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "440f8b01af454289b3bf028b7ea7ae67",
+          "Name": "AppearanceAssetElement",
+          "Description": "AppearanceAssetElement",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Set ImagePath for a Texture Asset.\n\nAppearanceAssetElement.SetRenderingAssetTextureImage (propertyPath: string, imagePath: string): AppearanceAssetElement"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "a[0];",
+      "Id": "0c4d33c8914844728dd6f23a5469c6f4",
+      "Inputs": [
+        {
+          "Id": "e2d850a8ce5b4e75b908ef2b89c4a510",
+          "Name": "a",
+          "Description": "a",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "e3275a56b1ec439898d34db32c48fd21",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "Revit.Elements.AppearanceAssetElement.GetRenderingAssetTextureImages",
+      "Id": "9d8d962b2e274e04a3493caada66efdb",
+      "Inputs": [
+        {
+          "Id": "4c7c02c07c8946379b1e4a3b38ee4d28",
+          "Name": "appearanceAssetElement",
+          "Description": "Revit.Elements.AppearanceAssetElement",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "774cff0af0eb493ab5903118ce91ea9a",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Get RenderingAsset Texture Images\n\nAppearanceAssetElement.GetRenderingAssetTextureImages: var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DesignScript.Builtin.Dictionary.Values",
+      "Id": "303c4c7b95344c5ca57ddbe215660229",
+      "Inputs": [
+        {
+          "Id": "409f3a8a67ae49fc98875a58c10d1af6",
+          "Name": "dictionary",
+          "Description": "DesignScript.Builtin.Dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "1238b769d725476cab6eb17a2f97198f",
+          "Name": "values",
+          "Description": "Values of the dictionary",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Produces the values in a Dictionary.\n\nDictionary.Values: var[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "DSCore.List.FirstItem@var[]..[]",
+      "Id": "6808334fdedf4e9984d8a57a0675fb0f",
+      "Inputs": [
+        {
+          "Id": "fb70e68250a8489cb6c2beab85541afa",
+          "Name": "list",
+          "Description": "List to get the first item from.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "37bcc435b0434b489541a8f41ef633de",
+          "Name": "item",
+          "Description": "First item in the list.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Returns the first item in a list.\n\nList.FirstItem (list: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "CoreNodeModels.Input.Filename, CoreNodeModels",
+      "HintPath": "D:\\projects\\D4R_Forked\\DynamoRevit\\test\\System\\AppearanceAssetElement\\TextureImageTest.txt",
+      "InputValue": ".\\TextureImageTest.txt",
+      "NodeType": "ExtensionNode",
+      "Id": "8e9bb0fc48104604bedd6b3a6ec7a812",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "e4c13beb18034b709ccee0f236cfb097",
+          "Name": "",
+          "Description": "File Path",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows you to select a file on the system to get its file path."
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "bbd6c6f6d02a485d89a6000f8d813483",
+      "End": "2acde843d6cb43be95c54fe231824a53",
+      "Id": "e050d095241146568b5482bccf6fcf43",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "dec2c849f1024d4ab3cc045b835ca545",
+      "End": "5fbc4913b37847d6b3e7cced629c1e70",
+      "Id": "4706bab3390a4cf7a4b9f35a11e09ef7",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e949f567c0f44e3fbc8b6966a967dc01",
+      "End": "c5f78086fcd2489d9170193ade1d29e1",
+      "Id": "f8311e0e28f14302b23d74295c1485ea",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e949f567c0f44e3fbc8b6966a967dc01",
+      "End": "f21dd12e7e224fb58b9ecd0812e55d43",
+      "Id": "94b1b43af2854228abd6578fb89ca4d3",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "48507e83b7be432da905c4efe5e89c33",
+      "End": "606f99bc9cda4764bc166f7a1d32d7e8",
+      "Id": "4b34d9a6fb694a53b9db440b8e9e4b55",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "d5ec3ad9ef974dd5bc7b87fe41daa2cb",
+      "End": "e2d850a8ce5b4e75b908ef2b89c4a510",
+      "Id": "f14360adf8414628ad9b2c9c2970eed7",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "440f8b01af454289b3bf028b7ea7ae67",
+      "End": "4c7c02c07c8946379b1e4a3b38ee4d28",
+      "Id": "0b0141044e644617aa03782bd3d04f5f",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e3275a56b1ec439898d34db32c48fd21",
+      "End": "a124e09714744106a0b0e000703b0bfe",
+      "Id": "1596b32b32b64d4491a5529e56cb4669",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "774cff0af0eb493ab5903118ce91ea9a",
+      "End": "409f3a8a67ae49fc98875a58c10d1af6",
+      "Id": "3e17252d2a5a46b6baec4d94c708cdc9",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "1238b769d725476cab6eb17a2f97198f",
+      "End": "fb70e68250a8489cb6c2beab85541afa",
+      "Id": "8d2c7770ef7746c4b422577a42cc6e6c",
+      "IsHidden": "False"
+    },
+    {
+      "Start": "e4c13beb18034b709ccee0f236cfb097",
+      "End": "04b8fff394f148fd8ae9298b6e48fdd9",
+      "Id": "3524f81db3164be18c00c736e61bf03b",
+      "IsHidden": "False"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [
+    {
+      "Name": "TextureImageTest.txt",
+      "ReferenceType": "External",
+      "Nodes": [
+        "6808334fdedf4e9984d8a57a0675fb0f",
+        "8e9bb0fc48104604bedd6b3a6ec7a812"
+      ]
+    }
+  ],
+  "Thumbnail": "",
+  "GraphDocumentationURL": null,
+  "ExtensionWorkspaceData": [
+    {
+      "ExtensionGuid": "28992e1d-abb9-417f-8b1b-05e053bee670",
+      "Name": "Properties",
+      "Version": "2.14",
+      "Data": {}
+    }
+  ],
+  "Author": "",
+  "Linting": {
+    "activeLinter": "None",
+    "activeLinterId": "7b75fb44-43fd-4631-a878-29f4d5d8399a",
+    "warningCount": 0,
+    "errorCount": 0
+  },
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.14.0.4187",
+      "RunType": "Manual",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "ConnectorPins": [],
+    "NodeViews": [
+      {
+        "Name": "String",
+        "ShowGeometry": true,
+        "Id": "533c04039ef3479882feb02f45ea014a",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -458.60633633446605,
+        "Y": 114.80548078390385
+      },
+      {
+        "Name": "Material.ByName",
+        "ShowGeometry": true,
+        "Id": "527d5e8db90243a2a8350a64d2d998f3",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": -127.60633633446605,
+        "Y": 114.80548078390385
+      },
+      {
+        "Name": "Material.AppearanceAssetElement",
+        "ShowGeometry": true,
+        "Id": "e149081d71d64440bc9b129cd794021f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 178.39366366553395,
+        "Y": 114.80548078390385
+      },
+      {
+        "Name": "AppearanceAssetElement.GetRenderingAssetTextureImages",
+        "ShowGeometry": true,
+        "Id": "6fe3edd0db0b45a8846a97385e3439e6",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 609.393663665534,
+        "Y": 103.21923078390384
+      },
+      {
+        "Name": "Dictionary.Keys",
+        "ShowGeometry": true,
+        "Id": "ec4229c63d9e440b9fa9747d573b726d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1234.3936636655339,
+        "Y": 103.21923078390381
+      },
+      {
+        "Name": "AppearanceAssetElement.SetRenderingAssetTextureImage",
+        "ShowGeometry": true,
+        "Id": "e800bfcabe34455cbbe26fe337a43ffd",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1854.3936636655339,
+        "Y": 126.39173078390382
+      },
+      {
+        "Name": "Code Block",
+        "ShowGeometry": true,
+        "Id": "0c4d33c8914844728dd6f23a5469c6f4",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1544.3936636655339,
+        "Y": 103.21923078390381
+      },
+      {
+        "Name": "AppearanceAssetElement.GetRenderingAssetTextureImages",
+        "ShowGeometry": true,
+        "Id": "9d8d962b2e274e04a3493caada66efdb",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 2470.3936636655339,
+        "Y": 126.39173078390382
+      },
+      {
+        "Name": "Dictionary.Values",
+        "ShowGeometry": true,
+        "Id": "303c4c7b95344c5ca57ddbe215660229",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3095.3936636655339,
+        "Y": 126.39173078390385
+      },
+      {
+        "Name": "List.FirstItem",
+        "ShowGeometry": true,
+        "Id": "6808334fdedf4e9984d8a57a0675fb0f",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 3417.3936636655339,
+        "Y": 126.39173078390385
+      },
+      {
+        "Name": "File Path",
+        "ShowGeometry": true,
+        "Id": "8e9bb0fc48104604bedd6b3a6ec7a812",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 1544.3936636655339,
+        "Y": 251.39173078390385
+      }
+    ],
+    "Annotations": [],
+    "X": -6103.244025297302,
+    "Y": -194.51207629568924,
+    "Zoom": 1.8946414429334379
+  }
+}


### PR DESCRIPTION
### Purpose

Add 3 new nodes : 
Material.AppearanceAssetElement
AppearanceAssetElement.GetRenderingAssetTextureImages
AppearanceAssetElement.SetRenderingAssetTextureImage

![NewNodes](https://user-images.githubusercontent.com/33445445/159662679-4106b027-ffbe-4340-ac09-a576a2022cbf.png)

#### SystemTests
GetSetTextureImage:
![GetSetTextureImage_2022-03-23_05-06-37](https://user-images.githubusercontent.com/33445445/159663143-7b729184-fefe-41df-a1ac-26ce33055b82.png)

TestResult xml:
![TestResult](https://user-images.githubusercontent.com/33445445/159665099-b7e903af-ae30-472d-b460-34cd93339090.PNG)


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @wangyangshi @joethales 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
