### PR TITLE
Make dynamo node for material texture be easier for end user

### DIFF
--- a/src/Libraries/RevitNodes/Elements/AppearanceAssetElement.cs
+++ b/src/Libraries/RevitNodes/Elements/AppearanceAssetElement.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Threading.Tasks;
 using DynamoServices;
 using RevitServices.Transactions;
+using Autodesk.DesignScript.Runtime;
+using System.Reflection;
 
 namespace Revit.Elements
 {
@@ -70,50 +72,57 @@ namespace Revit.Elements
             this.InternalUniqueId = appearanceAssetElement.UniqueId;
         }
 
-        #endregion
+      #endregion
 
-        #region Properties
+      #region public methods
 
-        /// <summary>
-        /// Get RenderingAsset Texture Images
-        /// </summary>
-        public Dictionary<string, string> GetRenderingAssetTextureImages
+      /// <summary>
+      /// Get texture image path of the appearance asset
+      /// </summary>
+      /// <returns name = "imageProperties">The list of all the properties that have images connected. A property's meaning can be queried in Revit API documentation, e.g., for "GenericDiffuse.UnifiedbitmapBitmap", it means property "GenericDiffuse" connects a texture asset which has a "UnifiedbitmapBitmap" property</returns>
+      /// <returns name = "imagePaths">The list of all the image path</returns>
+      [MultiReturn(new[] { "imageProperties", "imagePaths" })]
+        public Dictionary<string, object> GetRenderingAssetTextureImages()
         {
-            get
+            var asset = this.InternalAppearanceAssetElement.GetRenderingAsset();
+            List<string> keys = new List<string>();
+            List<string> values = new List<string>();
+            List<string> KeyValue = new List<string>();
+            KeyValue.AddRange(GetAssetProperties(asset, ""));
+            foreach(var value in KeyValue)
             {
-                var asset = this.InternalAppearanceAssetElement.GetRenderingAsset();
-
-                List<string> KeyValue = new List<string>();
-                Dictionary<string, string> keyValues = new Dictionary<string, string>();
-                KeyValue.AddRange(GetAssetProperties(asset, ""));
-                foreach(var value in KeyValue)
-                {
-                    var strs = value.Split(new Char[] { ':' }, 2);
-                    if (strs.Length == 2)
-                    { 
-                        keyValues.Add(strs[0], strs[1]); 
-                    }
-                }
-                return keyValues;
+               var strs = value.Split(new Char[] { ':' }, 2);
+               if (strs.Length == 2)
+               {
+                  keys.Add(strs[0]);
+                  values.Add(strs[1]); 
+               }
             }
+            Dictionary<string, object> keyValues = new Dictionary<string, object>();
+            keyValues.Add("imageProperties", keys);
+            keyValues.Add("imagePaths", values);
+            return keyValues;
         }
 
-        /// <summary>
-        /// Set ImagePath for a Texture Asset.
-        /// </summary>
-        /// <param name="propertyPath"></param>
-        /// <param name="imagePath"></param>
-        /// <returns></returns>
-        public AppearanceAssetElement SetRenderingAssetTextureImage(string propertyPath, string imagePath)
+      /// <summary>
+      /// Set texture image path of the appearance asset
+      /// </summary>
+      /// <param name="imageProperty">A property that has a image connected. This can be queried by calling GetRenderingAssetTextureImages first</param>
+      /// <param name="imagePath">File path of the image</param>
+      /// <returns>AppearanceAssetElement</returns>
+      public AppearanceAssetElement SetRenderingAssetTextureImage(string imageProperty, string imagePath)
         {
-            var properties = propertyPath.Split('.');
+            var properties = imageProperty.Split('.');
             TransactionManager.Instance.EnsureInTransaction(Application.Document.Current.InternalDocument);
             {
                 using (Autodesk.Revit.DB.Visual.AppearanceAssetEditScope editScope =
                     new Autodesk.Revit.DB.Visual.AppearanceAssetEditScope(Application.Document.Current.InternalDocument))
                 {
                     Autodesk.Revit.DB.Visual.Asset editableAsset = editScope.Start(InternalElementId);
-                    Autodesk.Revit.DB.Visual.AssetProperty assetProperty = editableAsset.FindByName(properties[0]);
+                    Type assetClass = GetAssetClass(editableAsset);
+                    PropertyInfo pinfo = assetClass.GetProperty(properties[0]);
+                    object internalProp = pinfo.GetValue(null);
+                    Autodesk.Revit.DB.Visual.AssetProperty assetProperty = editableAsset.FindByName(internalProp.ToString());
                     if(assetProperty == null)
                     {
                         throw new ArgumentException(Properties.Resources.AppearanceAssetElementPropertyPathInvalid);
@@ -125,7 +134,10 @@ namespace Revit.Elements
                         {
                             throw new ArgumentException(Properties.Resources.AppearanceAssetElementPropertyPathInvalid);
                         }
-                        assetProperty = connentedAsset.FindByName(properties[i]);
+                        Type connentedAssetClass = GetAssetClass(connentedAsset);
+                        PropertyInfo connentedPinfo = connentedAssetClass.GetProperty(properties[i]);
+                        object connentedInternalProp = connentedPinfo.GetValue(null);
+                        assetProperty = connentedAsset.FindByName(connentedInternalProp.ToString());
                         if (assetProperty == null)
                         {
                             throw new ArgumentException(Properties.Resources.AppearanceAssetElementPropertyPathInvalid);
@@ -154,17 +166,28 @@ namespace Revit.Elements
 
         private List<string> GetAssetProperties(Autodesk.Revit.DB.Visual.Asset asset, string keyName)
         {
+            Type assetClass = GetAssetClass(asset);
+            Dictionary<string, string> InternalPropertiesMap = new Dictionary<string, string>();
+            foreach (var p in assetClass.GetProperties())
+            {
+               var v = p.GetValue(null);
+               InternalPropertiesMap.Add(v.ToString(), p.Name);
+            }
             List<string> AssetProps = new List<string>();
-
-            if(asset.Name == "UnifiedBitmapSchema")
+            Autodesk.Revit.DB.Visual.AssetProperty nameProperty = asset.FindByName("BaseSchema");
+            string assetSchema = (nameProperty as Autodesk.Revit.DB.Visual.AssetPropertyString).Value;
+            if (assetSchema == "UnifiedBitmapSchema")
             {
                 var path = asset.FindByName(Autodesk.Revit.DB.Visual.UnifiedBitmap.UnifiedbitmapBitmap) as Autodesk.Revit.DB.Visual.AssetPropertyString;
                 if (path != null) 
                 {
-                    string newKeyName = keyName + "." + path.Name;
-
-                    AssetProps.Add(newKeyName + ":" + path.Value);
-                    return AssetProps;
+                    string APIProperty;
+                    if (InternalPropertiesMap.TryGetValue(path.Name, out APIProperty))
+                    {
+                        string newKeyName = keyName + "." + APIProperty;
+                        AssetProps.Add(newKeyName + ":" + path.Value);
+                        return AssetProps;
+                    }
                 }
             }
 
@@ -176,8 +199,12 @@ namespace Revit.Elements
                     var connProps = assetProperty.GetAllConnectedProperties();
                     foreach(var prop in connProps)
                     {
-                        string newKeyName = String.IsNullOrEmpty(keyName) ? assetProperty.Name : keyName + "." + assetProperty.Name;
-                        AssetProps.AddRange(GetAssetProperties(prop as Autodesk.Revit.DB.Visual.Asset, newKeyName));
+                        string APIProperty;
+                        if (InternalPropertiesMap.TryGetValue(assetProperty.Name, out APIProperty))
+                        {
+                           string newKeyName = String.IsNullOrEmpty(keyName) ? APIProperty : keyName + "." + APIProperty;
+                           AssetProps.AddRange(GetAssetProperties(prop as Autodesk.Revit.DB.Visual.Asset, newKeyName));
+                        }
                     }
                 }
             }
@@ -185,6 +212,17 @@ namespace Revit.Elements
             return AssetProps;
         }
 
+        private Type GetAssetClass(Autodesk.Revit.DB.Visual.Asset asset)
+        {
+            Autodesk.Revit.DB.Visual.AssetProperty nameProperty = asset.FindByName("BaseSchema");
+            string assetSchema = (nameProperty as Autodesk.Revit.DB.Visual.AssetPropertyString).Value;
+            string assetType = "Autodesk.Revit.DB.Visual." + assetSchema.Substring(0, assetSchema.Length - 6);
+            // Get Revit Assembly
+            var revitAssembly = System.Reflection.Assembly.GetAssembly(typeof(Autodesk.Revit.DB.Visual.Asset));
+            // Get Type from Assembly by string
+            Type assetClass = revitAssembly.GetType(assetType);
+            return assetClass;
+        }
         #endregion
 
         #region Internal static constructors

--- a/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
@@ -577,6 +577,6 @@
     <value>The id string is not valid for object of type {0}.</value>
   </data>
   <data name="AppearanceAssetElementPropertyPathInvalid" xml:space="preserve">
-    <value>Input value for propertyPath is invalid.</value>
+    <value>Input value for imageProperty is invalid.</value>
   </data>
 </root>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -604,6 +604,6 @@
     <value>The id string is not valid for object of type {0}.</value>
   </data>
   <data name="AppearanceAssetElementPropertyPathInvalid" xml:space="preserve">
-    <value>Input value for propertyPath is invalid.</value>
+    <value>Input value for imageProperty is invalid.</value>
   </data>
 </root>

--- a/test/System/AppearanceAssetElement/GetSetTextureImage.dyn
+++ b/test/System/AppearanceAssetElement/GetSetTextureImage.dyn
@@ -108,8 +108,17 @@
       "Outputs": [
         {
           "Id": "48507e83b7be432da905c4efe5e89c33",
-          "Name": "var[]..[]",
-          "Description": "var[]..[]",
+          "Name": "imageProperties",
+          "Description": "var",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "0f0e746039374f0483e4bef532ff5eb5",
+          "Name": "imagePaths",
+          "Description": "var",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -117,37 +126,7 @@
         }
       ],
       "Replication": "Auto",
-      "Description": "Get RenderingAsset Texture Images\n\nAppearanceAssetElement.GetRenderingAssetTextureImages: var[]..[]"
-    },
-    {
-      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
-      "NodeType": "FunctionNode",
-      "FunctionSignature": "DesignScript.Builtin.Dictionary.Keys",
-      "Id": "ec4229c63d9e440b9fa9747d573b726d",
-      "Inputs": [
-        {
-          "Id": "606f99bc9cda4764bc166f7a1d32d7e8",
-          "Name": "dictionary",
-          "Description": "DesignScript.Builtin.Dictionary",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "d5ec3ad9ef974dd5bc7b87fe41daa2cb",
-          "Name": "keys",
-          "Description": "Keys of the Dictionary",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Auto",
-      "Description": "Produces the keys in a Dictionary.\n\nDictionary.Keys: string[]"
+      "Description": "Get RenderingAsset Texture Images\n\nAppearanceAssetElement.GetRenderingAssetTextureImages ( ): var[]..[]"
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
@@ -166,7 +145,7 @@
         },
         {
           "Id": "a124e09714744106a0b0e000703b0bfe",
-          "Name": "propertyPath",
+          "Name": "imageProperty",
           "Description": "string",
           "UsingDefaultValue": false,
           "Level": 2,
@@ -195,7 +174,7 @@
         }
       ],
       "Replication": "Auto",
-      "Description": "Set ImagePath for a Texture Asset.\n\nAppearanceAssetElement.SetRenderingAssetTextureImage (propertyPath: string, imagePath: string): AppearanceAssetElement"
+      "Description": "Set ImagePath for a Texture Asset.\n\nAppearanceAssetElement.SetRenderingAssetTextureImage (imageProperty: string, imagePath: string): AppearanceAssetElement"
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
@@ -246,8 +225,17 @@
       "Outputs": [
         {
           "Id": "774cff0af0eb493ab5903118ce91ea9a",
-          "Name": "var[]..[]",
-          "Description": "var[]..[]",
+          "Name": "imageProperties",
+          "Description": "var",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "e6cfc94806ff4ae4bdf082a97688d246",
+          "Name": "imagePaths",
+          "Description": "var",
           "UsingDefaultValue": false,
           "Level": 2,
           "UseLevels": false,
@@ -255,37 +243,7 @@
         }
       ],
       "Replication": "Auto",
-      "Description": "Get RenderingAsset Texture Images\n\nAppearanceAssetElement.GetRenderingAssetTextureImages: var[]..[]"
-    },
-    {
-      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
-      "NodeType": "FunctionNode",
-      "FunctionSignature": "DesignScript.Builtin.Dictionary.Values",
-      "Id": "303c4c7b95344c5ca57ddbe215660229",
-      "Inputs": [
-        {
-          "Id": "409f3a8a67ae49fc98875a58c10d1af6",
-          "Name": "dictionary",
-          "Description": "DesignScript.Builtin.Dictionary",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Outputs": [
-        {
-          "Id": "1238b769d725476cab6eb17a2f97198f",
-          "Name": "values",
-          "Description": "Values of the dictionary",
-          "UsingDefaultValue": false,
-          "Level": 2,
-          "UseLevels": false,
-          "KeepListStructure": false
-        }
-      ],
-      "Replication": "Auto",
-      "Description": "Produces the values in a Dictionary.\n\nDictionary.Values: var[]"
+      "Description": "Get RenderingAsset Texture Images\n\nAppearanceAssetElement.GetRenderingAssetTextureImages ( ): var[]..[]"
     },
     {
       "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
@@ -366,14 +324,8 @@
     },
     {
       "Start": "48507e83b7be432da905c4efe5e89c33",
-      "End": "606f99bc9cda4764bc166f7a1d32d7e8",
-      "Id": "4b34d9a6fb694a53b9db440b8e9e4b55",
-      "IsHidden": "False"
-    },
-    {
-      "Start": "d5ec3ad9ef974dd5bc7b87fe41daa2cb",
       "End": "e2d850a8ce5b4e75b908ef2b89c4a510",
-      "Id": "f14360adf8414628ad9b2c9c2970eed7",
+      "Id": "0472bfb98a2a412581fe2a930a869ac8",
       "IsHidden": "False"
     },
     {
@@ -389,15 +341,9 @@
       "IsHidden": "False"
     },
     {
-      "Start": "774cff0af0eb493ab5903118ce91ea9a",
-      "End": "409f3a8a67ae49fc98875a58c10d1af6",
-      "Id": "3e17252d2a5a46b6baec4d94c708cdc9",
-      "IsHidden": "False"
-    },
-    {
-      "Start": "1238b769d725476cab6eb17a2f97198f",
+      "Start": "e6cfc94806ff4ae4bdf082a97688d246",
       "End": "fb70e68250a8489cb6c2beab85541afa",
-      "Id": "8d2c7770ef7746c4b422577a42cc6e6c",
+      "Id": "9bd6b618f4aa40aab505c0a3f9282717",
       "IsHidden": "False"
     },
     {
@@ -408,16 +354,7 @@
     }
   ],
   "Dependencies": [],
-  "NodeLibraryDependencies": [
-    {
-      "Name": "TextureImageTest.txt",
-      "ReferenceType": "External",
-      "Nodes": [
-        "6808334fdedf4e9984d8a57a0675fb0f",
-        "8e9bb0fc48104604bedd6b3a6ec7a812"
-      ]
-    }
-  ],
+  "NodeLibraryDependencies": [],
   "Thumbnail": "",
   "GraphDocumentationURL": null,
   "ExtensionWorkspaceData": [
@@ -441,7 +378,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": true,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.14.0.4187",
+      "Version": "2.14.0.4641",
       "RunType": "Manual",
       "RunPeriod": "1000"
     },
@@ -500,16 +437,6 @@
         "Y": 103.21923078390384
       },
       {
-        "Name": "Dictionary.Keys",
-        "ShowGeometry": true,
-        "Id": "ec4229c63d9e440b9fa9747d573b726d",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 1234.3936636655339,
-        "Y": 103.21923078390381
-      },
-      {
         "Name": "AppearanceAssetElement.SetRenderingAssetTextureImage",
         "ShowGeometry": true,
         "Id": "e800bfcabe34455cbbe26fe337a43ffd",
@@ -540,16 +467,6 @@
         "Y": 126.39173078390382
       },
       {
-        "Name": "Dictionary.Values",
-        "ShowGeometry": true,
-        "Id": "303c4c7b95344c5ca57ddbe215660229",
-        "IsSetAsInput": false,
-        "IsSetAsOutput": false,
-        "Excluded": false,
-        "X": 3095.3936636655339,
-        "Y": 126.39173078390385
-      },
-      {
         "Name": "List.FirstItem",
         "ShowGeometry": true,
         "Id": "6808334fdedf4e9984d8a57a0675fb0f",
@@ -571,8 +488,8 @@
       }
     ],
     "Annotations": [],
-    "X": -6103.244025297302,
-    "Y": -194.51207629568924,
-    "Zoom": 1.8946414429334379
+    "X": -1223.9068155508792,
+    "Y": 189.96365078900152,
+    "Zoom": 0.67483165842686454
   }
 }


### PR DESCRIPTION
### Purpose

This PR is to improve the below two nodes based on end user's feedback:
AppearanceAssetElement.GetRenderingAssetTextureImages
AppearanceAssetElement.SetRenderingAssetTextureImage

![interface](https://user-images.githubusercontent.com/10184253/174735287-70b97997-8d14-4d0f-b85c-b7bb5d9c4adb.png)

1. Change the output of AppearanceAssetElement.GetRenderingAssetTextureImages from a dictionary to two lists.
2. Change the parameter names to avoid confusion.
3. Make imageProperty more user faced, and can be queried in Revit API documentation.
4. Add more comments in the two nodes so that mouse hover can show tooltips for user's understanding.

SystemTest:
![GetSetTextureImage_2022-06-21_02-48-14](https://user-images.githubusercontent.com/10184253/174734795-d13c8b73-bff7-49ec-8759-962ec6063ece.png)

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@ShengxiZhang @wangyangshi



### FYIs

None
