### PR TITLE
change assembly shared info

### DIFF
--- a/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
+++ b/src/AssemblySharedInfoGenerator/AssemblySharedInfo.tt
@@ -68,7 +68,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("<#= this.MajorVersion #>.<#= this.MinorVersion #>.<#= this.BuildNumber #>.<#= this.RevisionNumber #>")]
 <#+
 int MajorVersion = 2;
-int MinorVersion = 14;
+int MinorVersion = 15;
 int BuildNumber = 0;
 int RevisionNumber = ((int)(DateTime.UtcNow - new DateTime(2021,1,1)).TotalDays)*10+((int)DateTime.UtcNow.Hour)/3;
 #>


### PR DESCRIPTION

### Purpose

we need to change "AssemblySharedInfo.tt" to keep its version same with dynamo core version

### Reviewers

@ShengxiZhang 
@honghuiqin 
