### PR TITLE
Fix issue with localization for SelectByCategory Nodes

### DIFF
--- a/src/Libraries/RevitNodesUI/Properties/AssemblyInfo.cs
+++ b/src/Libraries/RevitNodesUI/Properties/AssemblyInfo.cs
@@ -10,3 +10,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("0d13866c-102d-48bd-b591-ae999355c428")]
+[assembly: InternalsVisibleTo("RevitSystemTests")]

--- a/src/Libraries/RevitNodesUI/SelectionCombo.cs
+++ b/src/Libraries/RevitNodesUI/SelectionCombo.cs
@@ -64,6 +64,11 @@ namespace Dynamo.ComboNodes
             set
             {
                 DropDownNodeModel.SelectedString = value;
+
+                if (DropDownNodeModel.SelectedIndex >= 0)
+                {
+                    SelectionFilter.Category = (BuiltInCategory)DropDownNodeModel.Items[SelectedIndex].Item;
+                }
             }
         }
 
@@ -133,6 +138,11 @@ namespace Dynamo.ComboNodes
             set
             {
                 DropDownNodeModel.SelectedString = value;
+
+                if (DropDownNodeModel.SelectedIndex >= 0)
+                {
+                    SelectionFilter.Category = (BuiltInCategory)DropDownNodeModel.Items[SelectedIndex].Item;
+                }
             }
         }
 

--- a/test/Libraries/RevitIntegrationTests/SelectionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/SelectionTests.cs
@@ -619,7 +619,7 @@ namespace RevitSystemTests
         public void SelectModelElementsByCategory()
         {
             OpenAndAssertNoDummyNodes(Path.Combine(workingDirectory, @".\Selection\SelectModelElementsByCategory.dyn"));
-            TestMultipleCategorySelection<Element, Element>();
+            TestMultipleCategorySelection<Element>();
         }
 
         [Test]
@@ -627,9 +627,17 @@ namespace RevitSystemTests
         public void SelectModelElementByCategory()
         {
             OpenAndAssertNoDummyNodes(Path.Combine(workingDirectory, @".\Selection\SelectModelElementByCategory.dyn"));
-            TestMultipleCategorySelection<Element, Element>();
+            TestMultipleCategorySelection<Element>();
         }
- 
+
+        [Test]
+        [TestModel(@".\Selection\DynamoSample.rvt")]
+        public void SelectModelElementByCategoryChangeLanguage()
+        {
+            OpenAndAssertNoDummyNodes(Path.Combine(workingDirectory, @".\Selection\SelectModelElementByCategory_ESP.dyn"));
+            TestMultipleCategorySelection<Element>();
+        }
+
         [Test]
         [TestModel(@".\SampleModel.rvt")]
         public void SelectRoomsByStatus()
@@ -876,12 +884,12 @@ namespace RevitSystemTests
             Assert.IsTrue(selectNode.State == ElementState.Warning);
         }
 
-        private void TestMultipleCategorySelection<T1, T2>()
+        private void TestMultipleCategorySelection<T>() where T : Element
         {
             RunCurrentModel();
 
             var selectNode =
-                ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<RevitSelection<T1, T2>>();
+                ViewModel.Model.CurrentWorkspace.FirstNodeFromWorkspace<ElementFilterSelection<T>>();
             Assert.NotNull(selectNode);
 
             string expectedCategoryString = "Walls";
@@ -896,6 +904,10 @@ namespace RevitSystemTests
                 var elem = elements[i] as Revit.Elements.Element;
                 Assert.AreEqual(expectedCategoryString, elem.GetCategory.Name);
             }
+
+            var selectionFilter = selectNode.Filter as CategoryElementSelectionFilter<Element>;
+            Assert.IsTrue(selectionFilter.Category == BuiltInCategory.OST_Walls);
+
             selectNode.ClearSelections();
             RunCurrentModel();
             elements = GetPreviewCollection(selectNode.GUID.ToString());

--- a/test/System/Selection/SelectModelElementByCategory_ESP.dyn
+++ b/test/System/Selection/SelectModelElementByCategory_ESP.dyn
@@ -1,0 +1,78 @@
+{
+  "Uuid": "1d5146c5-fb96-4581-9213-894aaef18cff",
+  "IsCustomNode": false,
+  "Description": null,
+  "Name": "SelectModelElementByCategory_ESP",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.ComboNodes.DSModelElementByCategorySelection, DSRevitNodesUI",
+      "SelectedIndex": 495,
+      "SelectedString": "OST_Walls",
+      "NodeType": "ExtensionNode",
+      "InstanceId": [
+        "ef57b02a-5e81-49e7-93bb-ae5f002d921c-00030826"
+      ],
+      "Id": "25141fda2c244924845cfe500289447d",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "92367b3f6ed043538c183496e31924fb",
+          "Name": "Element",
+          "Description": "The selected elements.",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled"
+    }
+  ],
+  "Connectors": [],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.6.0.7733",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Vista preliminar en segundo plano",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Select Model Element By Category",
+        "Id": "25141fda2c244924845cfe500289447d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 145.33333333333331,
+        "Y": 241.33333333333331
+      }
+    ],
+    "Annotations": [],
+    "X": 0.0,
+    "Y": 0.0,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

The purpose of this PR is to address an issue observer when switching between Revit localizations with a the SelectByCategory node.  The node does not deserialize to the correct selected filter categroy if when opened in a different localization from where it was saved.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@BogdanZavu @twastvedt 

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
