### PR TITLE
change int to long in some d4r tests

### DIFF
--- a/src/Libraries/RevitNodes/AnalysisDisplay/AbstractAnalysisDisplay.cs
+++ b/src/Libraries/RevitNodes/AnalysisDisplay/AbstractAnalysisDisplay.cs
@@ -25,19 +25,19 @@ namespace Revit.AnalysisDisplay
  
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            info.AddValue("SpatialFieldManagerID", SpatialFieldManagerID, typeof(int));
+            info.AddValue("SpatialFieldManagerID", SpatialFieldManagerID, typeof(long));
             info.AddValue("PrimitiveIds", PrimitiveIds, typeof(List<int>));
         }
 
         public SpmPrimitiveIdPair()
         {
-            SpatialFieldManagerID = int.MinValue;
+            SpatialFieldManagerID = long.MinValue;
             PrimitiveIds = new List<int>();
         }
 
         public SpmPrimitiveIdPair(SerializationInfo info, StreamingContext context)
         {
-            SpatialFieldManagerID = (int) info.GetValue("SpatialFieldManagerID", typeof (int));
+            SpatialFieldManagerID = (long) info.GetValue("SpatialFieldManagerID", typeof (long));
             PrimitiveIds =
                 (List<int>)
                     info.GetValue("PrimitiveIds", typeof(List<int>));
@@ -52,18 +52,18 @@ namespace Revit.AnalysisDisplay
         public Dictionary<Reference, int> RefIdPairs { get; set; }
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            info.AddValue("SpatialFieldManagerID", SpatialFieldManagerID, typeof(int));
+            info.AddValue("SpatialFieldManagerID", SpatialFieldManagerID, typeof(long));
             info.AddValue("ReferencePrimitiveIds", RefIdPairs, typeof(Dictionary<Reference, int>));
         }
         public SpmRefPrimitiveIdListPair()
         {
-            SpatialFieldManagerID = int.MinValue;
+            SpatialFieldManagerID = long.MinValue;
             RefIdPairs = new Dictionary<Reference, int>();
         }
 
         public SpmRefPrimitiveIdListPair(SerializationInfo info, StreamingContext context)
         {
-            SpatialFieldManagerID = (int)info.GetValue("SpatialFieldManagerID", typeof(int));
+            SpatialFieldManagerID = (long)info.GetValue("SpatialFieldManagerID", typeof(long));
             RefIdPairs =
                 (Dictionary<Reference, int>)
                     info.GetValue("ReferencePrimitiveIds", typeof(Dictionary<Reference, int>));

--- a/src/Libraries/RevitNodes/AnalysisDisplay/PointAnalysisDisplay.cs
+++ b/src/Libraries/RevitNodes/AnalysisDisplay/PointAnalysisDisplay.cs
@@ -21,12 +21,12 @@ namespace Revit.AnalysisDisplay
     [Obsolete("Please use Revit.AnalysisDisplay.SpmPrimitiveIdPair instead")]
     public class SpmPrimitiveIdListPair : ISerializable
     {
-        public int SpatialFieldManagerID { get; set; }
+        public long SpatialFieldManagerID { get; set; }
         public List<int> PrimitiveIDs { get; set; }
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            info.AddValue("SpatialFieldManagerID", SpatialFieldManagerID, typeof(int));
+            info.AddValue("SpatialFieldManagerID", SpatialFieldManagerID, typeof(long));
             info.AddValue("PrimitiveIDCount", PrimitiveIDs.Count, typeof(int));
             foreach (var id in PrimitiveIDs)
             {
@@ -36,13 +36,13 @@ namespace Revit.AnalysisDisplay
 
         public SpmPrimitiveIdListPair()
         {
-            SpatialFieldManagerID = int.MinValue;
+            SpatialFieldManagerID = long.MinValue;
             PrimitiveIDs = new List<int>();
         }
 
         public SpmPrimitiveIdListPair(SerializationInfo info, StreamingContext context)
         {
-            SpatialFieldManagerID = (int)info.GetValue("SpatialFieldManagerID", typeof(int));
+            SpatialFieldManagerID = (long)info.GetValue("SpatialFieldManagerID", typeof(long));
 
             int count = (int)info.GetValue("PrimitiveIDCount", typeof(int));
             PrimitiveIDs = new List<int>();
@@ -277,7 +277,7 @@ namespace Revit.AnalysisDisplay
 
             var idPair = new SpmPrimitiveIdListPair
             {
-                SpatialFieldManagerID = manager.Id.IntegerValue,
+                SpatialFieldManagerID = manager.Id.Value,
                 PrimitiveIDs = primitiveIds
             };
             ElementBinder.SetRawDataForTrace(idPair);

--- a/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
+++ b/test/Libraries/RevitIntegrationTests/ElementBindingTests.cs
@@ -423,7 +423,7 @@ namespace RevitSystemTests
             var selNodes = model.CurrentWorkspace.Nodes.Where(x => x is ElementSelection<Autodesk.Revit.DB.Element>);
             var selNode = selNodes.First() as ElementSelection<Autodesk.Revit.DB.Element>;
 
-            var elId = new ElementId(184273);
+            var elId = new ElementId(184273L);
             var el = DocumentManager.Instance.CurrentDBDocument.GetElement(elId);
             //selNode.SelectionResults.Add(el);
 

--- a/test/Libraries/RevitIntegrationTests/FamilyTests.cs
+++ b/test/Libraries/RevitIntegrationTests/FamilyTests.cs
@@ -141,7 +141,7 @@ namespace RevitSystemTests
            ViewModel.OpenCommand.Execute(testPath);
 
            RunCurrentModel();
-           var elId = new Autodesk.Revit.DB.ElementId(187030);
+           var elId = new Autodesk.Revit.DB.ElementId(187030L);
            var famInst = RevitServices.Persistence.DocumentManager.Instance.CurrentDBDocument.GetElement(elId) as Autodesk.Revit.DB.FamilyInstance;
            var transform = famInst.GetTransform();
            double[] rotationAngles;
@@ -174,7 +174,7 @@ namespace RevitSystemTests
             Assert.AreEqual(pnt.Z, pos.Z, Epsilon, "Z property does not match");
 
             // Element ID of Revit face selected in DYN file
-            var elId = new Autodesk.Revit.DB.ElementId(250730);
+            var elId = new Autodesk.Revit.DB.ElementId(250730L);
             var internalFamInst = famInst.InternalElement as Autodesk.Revit.DB.FamilyInstance;
             Assert.IsNotNull(internalFamInst);
 
@@ -223,7 +223,7 @@ namespace RevitSystemTests
             Assert.AreEqual(pnt.Z, pos.Z, Epsilon, "Z property does not match");
 
             // Element ID of Revit face selected in DYN file
-            var elId = new Autodesk.Revit.DB.ElementId(250730);
+            var elId = new Autodesk.Revit.DB.ElementId(250730L);
             var internalFamInst = famInst2.InternalElement as Autodesk.Revit.DB.FamilyInstance;
             Assert.IsNotNull(internalFamInst);
 
@@ -273,7 +273,7 @@ namespace RevitSystemTests
             Assert.AreEqual(endPnt.Z, ep.Z, Epsilon, "Z property does not match");
 
             // Element ID of Revit face selected in DYN file
-            var elId = new Autodesk.Revit.DB.ElementId(250730);
+            var elId = new Autodesk.Revit.DB.ElementId(250730L);
             var internalFamInst = famInst.InternalElement as Autodesk.Revit.DB.FamilyInstance;
             Assert.IsNotNull(internalFamInst);
 
@@ -335,7 +335,7 @@ namespace RevitSystemTests
             Assert.AreEqual(endPnt.Z, ep.Z, Epsilon, "Z property does not match");
 
             // Element ID of Revit face selected in DYN file
-            var elId = new Autodesk.Revit.DB.ElementId(250730);
+            var elId = new Autodesk.Revit.DB.ElementId(250730L);
             var internalFamInst = famInst.InternalElement as Autodesk.Revit.DB.FamilyInstance;
             Assert.IsNotNull(internalFamInst);
 


### PR DESCRIPTION
### Purpose

1 some d4r test codes use the ElementId(int) to construct element id, this will be obsoleted.
so change them to long.

2 change `SpatialFieldManagerID` to long, as in revit codes, I found they are regarded as element id. so also change it.

