### PR TITLE
Add event for splash screen closing in DynamoRevit.

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -324,6 +325,7 @@ namespace Dynamo.Applications
                 {
                     SplashScreenExternalEvent.Raise();
                 };
+                splashScreen.Closed += OnSplashScreenClosed;
                 splashScreen.Show();
             }
             catch (Exception ex)
@@ -952,6 +954,24 @@ namespace Dynamo.Applications
             DynamoRevitApp.DynamoButtonEnabled = true;
 
             //the model is shutdown when DynamoView is closed
+            ModelState = RevitDynamoModelState.NotStarted;
+        }
+
+        /// <summary>
+        ///     Executes after the splash screen closes.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private static void OnSplashScreenClosed(object sender, EventArgs e)
+        {
+            var view = (Window)sender;
+
+            view.Dispatcher.UnhandledException -= Dispatcher_UnhandledException;
+            view.Closed -= OnSplashScreenClosed;
+
+            DynamoRevitApp.DynamoButtonEnabled = true;
+
+            //the model is shutdown when splash screen is closed
             ModelState = RevitDynamoModelState.NotStarted;
         }
 


### PR DESCRIPTION
### Purpose

This is to add a event that will shut down the Dynamo model and enable Dynamo icon in Revit. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@QilongTang @mjkkirschner 

