### PR TITLE
Added Revit Units Properties

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -19,6 +19,7 @@ using Autodesk.Revit.UI;
 using Dynamo.Applications;
 using Dynamo.Applications.Models;
 using Dynamo.Applications.ViewModel;
+using Dynamo.Configuration;
 using Dynamo.Controls;
 using Dynamo.Core;
 using Dynamo.Graph.Workspaces;
@@ -406,6 +407,7 @@ namespace Dynamo.Applications
             if (CheckJournalForKey(extCommandData, JournalKeys.ShowUiKey, true))
             {
                 RevitDynamoViewModel = InitializeCoreViewModel(RevitDynamoModel);
+                SetRevitProperties();
 
                 // Let the host (e.g. Revit) control the rendering mode
                 var save = RenderOptions.ProcessRenderMode;
@@ -841,6 +843,48 @@ namespace Dynamo.Applications
                 DocumentManager.Instance.CurrentUIApplication = commandData.Application;
         }
 
+        /// <summary>
+        /// Creates Revit-specific preferences 
+        /// </summary>
+        private void SetRevitProperties()
+        {
+            SetScale();
+        }
+
+        /// <summary>
+        /// Sets current Revit document units 
+        /// </summary>
+        private void SetScale()
+        {
+            var doc = extCommandData.Application.ActiveUIDocument.Document;
+            var docUnitType = doc.GetUnits().GetFormatOptions(SpecTypeId.Length).GetUnitTypeId();
+
+            if (docUnitType.TypeId == UnitTypeId.Millimeters.TypeId)
+            {
+                RevitDynamoViewModel.Model.PreferenceSettings.CurrentRevitUnits = Configurations.Units.Millimeters;
+            }
+            else if (docUnitType.TypeId == UnitTypeId.Centimeters.TypeId || docUnitType.TypeId == UnitTypeId.Decimeters.TypeId)
+            {
+                RevitDynamoViewModel.Model.PreferenceSettings.CurrentRevitUnits = Configurations.Units.Centimeters;
+            }
+            else if (docUnitType.TypeId == UnitTypeId.Meters.TypeId || docUnitType.TypeId == UnitTypeId.MetersCentimeters.TypeId)
+            {
+                RevitDynamoViewModel.Model.PreferenceSettings.CurrentRevitUnits = Configurations.Units.Meters;
+            }
+            else if (docUnitType.TypeId == UnitTypeId.Feet.TypeId || docUnitType.TypeId == UnitTypeId.FeetFractionalInches.TypeId || docUnitType.TypeId == UnitTypeId.UsSurveyFeet.TypeId)
+            {
+                RevitDynamoViewModel.Model.PreferenceSettings.CurrentRevitUnits = Configurations.Units.Feet;
+            }
+            else if (docUnitType.TypeId == UnitTypeId.Inches.TypeId || docUnitType.TypeId == UnitTypeId.FractionalInches.TypeId)
+            {
+                RevitDynamoViewModel.Model.PreferenceSettings.CurrentRevitUnits = Configurations.Units.Inches;
+            }
+            else
+            {
+                // Default unit
+                RevitDynamoViewModel.Model.PreferenceSettings.CurrentRevitUnits = Configurations.Units.Millimeters;
+            }
+        }
         #endregion
 
         #region Helpers


### PR DESCRIPTION
### Purpose

REDO of [PR](https://github.com/DynamoDS/DynamoRevit/pull/2915). Previous PR was based on 2.16. This is a redo to current master branch.

To be used in conjunction with https://github.com/DynamoDS/Dynamo/pull/13895! This PR creates an entry inside Dynamo's PreferenceSettings which track the current document's units inside Revit. This is used to help scale background graphics relative to the current project settings thus making the background helpers inside Dynamo more useful.

- this PR works with https://github.com/DynamoDS/Dynamo/pull/13895 PR on Dynamo side
- it introduces a way for Dynamo Revit to set revit units inside the PreferenceSettings in Dynamo
- to be used against the correct Dynamo Core (DynamoCore.dll can be manually referenced to make it work until release)
- units will only be set once per Dynamo start - every time Dynamo is launched, the current document units will be set 

#### generic 'Imperial' and 'Metric' Revit Units
![imeprial metric units](https://github.com/DynamoDS/DynamoRevit/assets/5354594/0c5e8e42-ec05-44b4-8041-16819a47c7ca)

![setting Revit units to scale Dynamo grids](https://user-images.githubusercontent.com/5354594/234341331-4689569a-79c2-4c18-af37-0d130dff5dc4.gif)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@reddyashish 
@Amoursol 

### FYIs

