### PR TITLE
Rename parameter View3DTemplate 

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Views/View3DTemplate.cs
+++ b/src/Libraries/RevitNodes/Elements/Views/View3DTemplate.cs
@@ -42,14 +42,14 @@ namespace Revit.Elements.Views
         /// <param name="plan"></param>
         /// <param name="isRevitOwned"></param>
         /// <returns></returns>
-        internal static View3DTemplate FromExisting(Autodesk.Revit.DB.View3D plan, bool isRevitOwned)
+        internal static View3DTemplate FromExisting(Autodesk.Revit.DB.View3D view, bool isRevitOwned)
         {
-            if (plan == null)
+            if (view == null)
             {
                 throw new ArgumentNullException("3d_view");
             }
 
-            return new View3DTemplate(plan)
+            return new View3DTemplate(view)
             {
                 IsRevitOwned = isRevitOwned
             };


### PR DESCRIPTION

### Purpose

A small PR addressing earlier [comment](https://github.com/DynamoDS/DynamoRevit/pull/2925#discussion_r1218994396). The `plan` parameter changed to `view` to better reflect the purpose of the parameter value.

- consistency with other view classes
- plan is kind of antithesis of `3D` when it comes to views

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@Mikhinja 

### FYIs

