### PR TITLE
Pass the Preferences as part of the Initializacion configuration

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -607,7 +607,8 @@ namespace Dynamo.Applications
                 AuthProvider = new RevitOAuth2Provider(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher)),
                 ExternalCommandData = commandData,
                 UpdateManager = revitUpdateManager,
-                ProcessMode = isAutomationMode ? TaskProcessMode.Synchronous : TaskProcessMode.Asynchronous
+                ProcessMode = isAutomationMode ? TaskProcessMode.Synchronous : TaskProcessMode.Asynchronous,
+                Preferences = PreferenceSettings.Instance
             });
         }
 

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -276,7 +276,8 @@ namespace RevitTestServices
                         SchedulerThread = new TestSchedulerThread(),
                         PackageManagerAddress = "https://www.dynamopackages.com",
                         ExternalCommandData = commandData,
-                        ProcessMode = RevitTaskProcessMode
+                        ProcessMode = RevitTaskProcessMode,
+                        Preferences = PreferenceSettings.Instance
                     });
 
                 Model = DynamoRevit.RevitDynamoModel;


### PR DESCRIPTION
### Purpose

As part of the task https://jira.autodesk.com/browse/DYN-5816 the DynamoModel that the class RevitDynamoModel inherits, needs to pass the explicit Preferences as part of its initialization configuration.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@QilongTang 
@reddyashish 
