### PR TITLE
Zoom to Linked Element bug fix

### DIFF
--- a/src/Libraries/RevitNodes/Elements/LinkElement.cs
+++ b/src/Libraries/RevitNodes/Elements/LinkElement.cs
@@ -57,6 +57,17 @@ namespace Revit.Elements
 
             // use the center of the BoundingBox as zoom center
             BoundingBoxXYZ bb = element.InternalElement.get_BoundingBox(null);
+            // if the BBox cannot be found, attempt to find it using the active view
+            if (bb==null)
+            {
+                bb=element.InternalElement.get_BoundingBox(activeView);
+            }
+            // finally, if the BB cannot be found at all
+            if (bb==null)
+            {
+                TaskDialog.Show("Revit", "No good view can be found.");
+                return;
+            }
             XYZ bbCenter = (bb.Max + bb.Min) / 2;
             double zoomOffsetX = bb.Max.X - bbCenter.X;
             double zoomOffsetY = bb.Max.Y - bbCenter.Y;
@@ -69,8 +80,6 @@ namespace Revit.Elements
                 XYZ max = new XYZ(locationPt.X + zoomOffsetX, locationPt.Y + zoomOffsetY, locationPt.Z + zoomOffsetZ);
                 uiview.ZoomAndCenterRectangle(min, max);
             }
-
-
         }
 
         // helper to return element's location with transform


### PR DESCRIPTION
catch cases where no BBox can be found

### Purpose

Fix the bug when clicking on the green ID for linked elements. 
For linked elements, the Zoom will focus on the element's Bounding Box. The update: if the BBox cannot be found, the error message will appear saying 'No good view can be found'. 
![Zoom to linked element bug fix](https://github.com/DynamoDS/DynamoRevit/assets/43077096/6df7e232-3d3e-4d52-893d-4c4a6b4132c9)

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@Mikhinja @reddyashish @QilongTang 

### FYIs

@dnenov @Amoursol 
