### PR TITLE
Handle case when GlobalParameter.SetValue node receives a value of type long

### DIFF
--- a/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
+++ b/src/Libraries/RevitNodes/Elements/GlobalParameter.cs
@@ -234,13 +234,12 @@ namespace Revit.Elements
                     parameter.InternalGlobalParameter.SetValue(
                         new Autodesk.Revit.DB.StringParameterValue((string)value));
                 }
-                else if (value.GetType() == typeof(double))
+                else if (value.GetType() == typeof(double) || value.GetType() == typeof(long))
                 {
-                    var valueToSet = (double)value * UnitConverter.DynamoToHostFactor(parameter.InternalGlobalParameter.GetDefinition().GetDataType());
-
+                    double dValue = value.GetType() == typeof(long) ? (double)(long)value : (double)value;
+                    var valueToSet = dValue * UnitConverter.DynamoToHostFactor(parameter.InternalGlobalParameter.GetDefinition().GetDataType());
                     parameter.InternalGlobalParameter.SetValue(
                         new Autodesk.Revit.DB.DoubleParameterValue(valueToSet));
-
                 }
 
                 TransactionManager.Instance.TransactionTaskDone();


### PR DESCRIPTION
### Purpose

To fix a bug reported in REVIT-212479 where the user can't set the value 30.0 to the global parameter "Wall length" using the script  GlobalParameter_SetValue.dyn. The value that is assigned to the parameter is transmitted by Dynamo as a value of type long (30.0 is treated as a long whereas 30.1 is treated as a double) and this data type isn't handled in the function setValue(). 

REVIT-212479

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@Mikhinja 

### FYIs
