### PR TITLE
copy DynamoInstallDetective.dll to output

### DIFF
--- a/src/Tools/DynamoAddInGenerator/DynamoAddInGenerator.csproj
+++ b/src/Tools/DynamoAddInGenerator/DynamoAddInGenerator.csproj
@@ -31,7 +31,6 @@
     <Reference Include="DynamoInstallDetective">
 		<HintPath Condition="!Exists('$(DYNAMOBUILDPATH)')">$(PACKAGESPATH)\DynamoVisualProgramming.Core\lib\net6.0\DynamoInstallDetective.dll</HintPath>
 		<HintPath Condition=" Exists('$(DYNAMOBUILDPATH)')">$(DYNAMOBUILDPATH)\DynamoInstallDetective.dll</HintPath>
-		<Private>False</Private>
     </Reference>
     <Reference Include="RevitAddinUtility">
       <HintPath>$(ProjectDir)\RevitAddinUtility.dll</HintPath>


### PR DESCRIPTION
In this commit:
https://github.com/DynamoDS/DynamoRevit/commit/99c808797660305b279326607d07be68bdd88f43
this line was added to stop DynamoInstallDetective from being copied to build output, but it's necessary to run local builds of DynamoRevit/Dynamo following the readme directions.

Arguably it might be better to set this true in the DynamoRevitDS.dll file, but I'm just setting this back as it was in master for now.