### PR TITLE
Mikhinja/revit 212138/fix wrongly updated node search tests

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -494,7 +494,7 @@ namespace Dynamo.Applications.Models
             setupPython = true;
         }
 
-        private void InitializeDocumentManager()
+        internal void InitializeDocumentManager()
         {
             // Set the intitial document.
             var activeUIDocument = DocumentManager.Instance.CurrentUIApplication.ActiveUIDocument;

--- a/src/DynamoRevit/Properties/AssemblyInfo.cs
+++ b/src/DynamoRevit/Properties/AssemblyInfo.cs
@@ -8,4 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DynamoRevitDS")]
 [assembly: AssemblyCulture("")]
 [assembly: Guid("082cab33-cbc7-4e58-ae25-f0962f325d6e")]
-[assembly: InternalsVisibleTo("RevitTestServices")] 
+[assembly: InternalsVisibleTo("RevitTestServices")]
+[assembly: InternalsVisibleTo("RevitSystemTests")]

--- a/src/restorepackages.bat
+++ b/src/restorepackages.bat
@@ -27,7 +27,7 @@ set NugetConfig=%ConfigDir%\dynamo-nuget.config
 
 REM 2. download 3rdParty packages by Aget.exe
     echo Running Python script from %AgetFile% using dynamo-nuget.config file
-    set PythonAget="%AgetFile%" -os win -config release -iset intel64 -toolchain v140 -linkage shared -packagesDir "%DynamoPackages%" -nuget "%NugetExe%" -framework net48 -nugetConfig "%NugetConfig%"
+    set PythonAget="%AgetFile%" -os win -config release -iset intel64 -toolchain v140 -linkage shared -packagesDir "%DynamoPackages%" -nuget "%NugetExe%" -framework NET70 -nugetConfig "%NugetConfig%"
 
     call :TrackTime "[Aget] Downloading NuGet packages from the NuGet Gallery and the Artifactory server, might take a while if running for the first time."
     echo If any package is not found in the NuGet Gallery, redirect to look up in the Artifactory server...

--- a/test/Libraries/RevitIntegrationTests/CoreTests.cs
+++ b/test/Libraries/RevitIntegrationTests/CoreTests.cs
@@ -59,24 +59,18 @@ namespace RevitSystemTests
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
             // Add multiple libraries to better simulate typical Dynamo application usage.
-            //libraries.Add("Analysis.dll");
-            //libraries.Add("BuiltIn.ds");
-            //libraries.Add("DesignScriptBuiltin.dll");
-            //libraries.Add("DSCoreNodes.dll");
-            //libraries.Add("DSOffice.dll");
-            //libraries.Add("DSCPython.dll");
-            //libraries.Add("DynamoConversions.dll");
-            //libraries.Add("DynamoUnits.dll");
-            //libraries.Add("FunctionObject.ds");
-            //libraries.Add("FFITarget.dll");
-            //libraries.Add("GeometryColor.dll");
-            //libraries.Add("LiveCharts.dll");
-            //libraries.Add("ProtoGeometry.dll");
-            libraries.Add(@"Revit\RevitNodes.dll");
-            libraries.Add(@"Revit\nodes\DSRevitNodesUI.dll");
-            libraries.Add(@"Revit\nodes\analytical-automation-pkg\bin\AnalyticalAutomation.dll");
-            libraries.Add(@"Revit\nodes\analytical-automation-pkg\bin\AnalyticalAutomationGUI.dll");
-            //libraries.Add("VMDataBridge.dll");
+
+            var assemblyDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            var revitNodesDirectory = Path.Combine(assemblyDirectory, "nodes");
+            var revitUINodesDll = Path.Combine(assemblyDirectory, @"nodes\DSRevitNodesUI.dll");
+            var revitAANodesDirectory = Path.Combine(assemblyDirectory, @"nodes\analytical-automation-pkg\bin");
+            var revitAANodesDll = Path.Combine(assemblyDirectory, @"nodes\analytical-automation-pkg\bin\AnalyticalAutomation.dll");
+            var revitAAUINodesDll = Path.Combine(assemblyDirectory, @"nodes\analytical-automation-pkg\bin\AnalyticalAutomationGUI.dll");
+            libraries.Add(revitNodesDirectory);
+            //libraries.Add(revitUINodesDll); // UI nodes seem to have a problem being loaded in this context
+            //libraries.Add(revitAANodesDirectory); // do not load AA nodes, they have their own tests, for now we believe this is not really needed
+            //libraries.Add(revitAANodesDll); // UI nodes seem to have a problem being loaded in this context
+
             base.GetLibrariesToPreload(libraries);
         }
 

--- a/test/Libraries/RevitIntegrationTests/CoreTests.cs
+++ b/test/Libraries/RevitIntegrationTests/CoreTests.cs
@@ -135,7 +135,7 @@ namespace RevitSystemTests
 
         [Test, TestCaseSource("SetupCopyPastes")]
         [TestModel(@".\empty.rfa")]
-        public void CanCopyAndPasteAllNodesOnRevit(NodeModelSearchElement searchElement)
+        public void CanCopyAndPasteAllNodesOnRevit(NodeSearchElement searchElement)
         {
             var model = ViewModel.Model;
 
@@ -153,16 +153,18 @@ namespace RevitSystemTests
             model.ClearCurrentWorkspace();
         }
 
-        private IEnumerable<NodeModelSearchElement> SetupCopyPastes()
+        private IEnumerable<NodeSearchElement> SetupCopyPastes()
         {
-            var excludes = new List<string>();
-            excludes.Add("Input");
-            excludes.Add("Output");
+            var excludes = new List<string>
+            {
+                "Input",
+                "Output"
+            };
 
-            if (ViewModel == null) return Enumerable.Empty<NodeModelSearchElement>();
+            if (ViewModel == null) return Enumerable.Empty<NodeSearchElement>();
 
             return
-                ViewModel.Model.CurrentWorkspace.Nodes.OfType<NodeModelSearchElement>()
+                ViewModel.Model.SearchModel.Search(string.Empty, ViewModel.Model.LuceneUtility)
                     .Where(x => !excludes.Contains(x.Name));
         }
     }

--- a/test/Libraries/RevitIntegrationTests/RegressionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RegressionTests.cs
@@ -100,7 +100,7 @@ namespace RevitSystemTests
             Assert.NotNull(homespace, "The current workspace is not a HomeWorkspaceModel");
 
             // Iterate through all loaded nodes in library & add Revit UI nodes to ws
-            var nodeList = Model.CurrentWorkspace.Nodes.OfType<NodeSearchElement>();
+            var nodeList = Model.SearchModel.Search(string.Empty, Model.LuceneUtility);
             foreach (var node in nodeList)
             {
                 var assembly = Path.GetFileName(node.Assembly);
@@ -159,7 +159,7 @@ namespace RevitSystemTests
             Assert.NotNull(homespace, "The current workspace is not a HomeWorkspaceModel");
 
             // Iterate through all loaded nodes in library & add Revit UI nodes to ws
-            var nodeList = Model.CurrentWorkspace.Nodes.OfType<NodeSearchElement>();
+            var nodeList = Model.SearchModel.Search(string.Empty, Model.LuceneUtility);
             foreach (var node in nodeList)
             {
                 var searchElement = node as NodeSearchElement;

--- a/test/Libraries/RevitIntegrationTests/RegressionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RegressionTests.cs
@@ -159,7 +159,7 @@ namespace RevitSystemTests
             Assert.NotNull(homespace, "The current workspace is not a HomeWorkspaceModel");
 
             // Iterate through all loaded nodes in library & add Revit UI nodes to ws
-            var nodeList = Model.SearchModel.Search(string.Empty, Model.LuceneUtility);
+            var nodeList = Model.SearchModel.Entries;
             foreach (var node in nodeList)
             {
                 var searchElement = node as NodeSearchElement;

--- a/test/Libraries/RevitIntegrationTests/RegressionTests.cs
+++ b/test/Libraries/RevitIntegrationTests/RegressionTests.cs
@@ -19,52 +19,45 @@ namespace RevitSystemTests
     [TestFixture]
     public class RegressionTest : RevitSystemTestBase
     {
-        protected static RegressionTest s_initedInstance = null;
+        //protected static RegressionTest s_initedInstance = null;
 
-        [SetUp]
-        public override void Setup()
-        {
-            if (s_initedInstance == null)
-            {
-                base.Setup();
+        //[SetUp]
+        //public override void Setup()
+        //{
+        //    if (s_initedInstance == null)
+        //    {
+        //        base.Setup();
 
-                ViewModel.Model.AddZeroTouchNodesToSearch(ViewModel.Model.LibraryServices.GetAllFunctionGroups());
+        //        ViewModel.Model.AddZeroTouchNodesToSearch(ViewModel.Model.LibraryServices.GetAllFunctionGroups());
 
-                s_initedInstance = this;
-            }
-            else
-            {
-                WrapOf(s_initedInstance);
-                CreateTemporaryFolder();
+        //        s_initedInstance = this;
+        //    }
+        //    else
+        //    {
+        //        WrapOf(s_initedInstance);
+        //        CreateTemporaryFolder();
 
-                // This is needed because TearDown will clear the Model, and TearDown
-                //  is needed in order to clear the dependencyGraph, otherwise adding
-                //  a node will take exponentially long time
-                (ViewModel.Model as RevitDynamoModel).InitializeDocumentManager();
-            }
-        }
+        //        // This is needed because TearDown will clear the Model, and TearDown
+        //        //  is needed in order to clear the dependencyGraph, otherwise adding
+        //        //  a node will take exponentially long time
+        //        (ViewModel.Model as RevitDynamoModel).InitializeDocumentManager();
+        //    }
+        //}
 
         protected override void GetLibrariesToPreload(List<string> libraries)
         {
             // Add multiple libraries to better simulate typical Dynamo application usage.
-            //libraries.Add("Analysis.dll");
-            //libraries.Add("BuiltIn.ds");
-            //libraries.Add("DesignScriptBuiltin.dll");
-            //libraries.Add("DSCoreNodes.dll");
-            //libraries.Add("DSOffice.dll");
-            //libraries.Add("DSCPython.dll");
-            //libraries.Add("DynamoConversions.dll");
-            //libraries.Add("DynamoUnits.dll");
-            //libraries.Add("FunctionObject.ds");
-            //libraries.Add("FFITarget.dll");
-            //libraries.Add("GeometryColor.dll");
-            //libraries.Add("LiveCharts.dll");
-            //libraries.Add("ProtoGeometry.dll");
-            libraries.Add(@"Revit\RevitNodes.dll");
-            libraries.Add(@"Revit\nodes\DSRevitNodesUI.dll");
-            libraries.Add(@"Revit\nodes\analytical-automation-pkg\bin\AnalyticalAutomation.dll");
-            libraries.Add(@"Revit\nodes\analytical-automation-pkg\bin\AnalyticalAutomationGUI.dll");
-            //libraries.Add("VMDataBridge.dll");
+
+            var assemblyDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            var revitNodesDirectory = Path.Combine(assemblyDirectory, "nodes");
+            var revitUINodesDll = Path.Combine(assemblyDirectory, @"nodes\DSRevitNodesUI.dll");
+            var revitAANodesDirectory = Path.Combine(assemblyDirectory, @"nodes\analytical-automation-pkg\bin");
+            var revitAANodesDll = Path.Combine(assemblyDirectory, @"nodes\analytical-automation-pkg\bin\AnalyticalAutomation.dll");
+            var revitAAUINodesDll = Path.Combine(assemblyDirectory, @"nodes\analytical-automation-pkg\bin\AnalyticalAutomationGUI.dll");
+            libraries.Add(revitNodesDirectory);
+            //libraries.Add(revitUINodesDll); // UI nodes seem to have a problem being loaded in this context
+            //libraries.Add(revitAANodesDirectory); // do not load AA nodes, they have their own tests, for now we believe this is not really needed
+            //libraries.Add(revitAANodesDll); // UI nodes seem to have a problem being loaded in this context
             base.GetLibrariesToPreload(libraries);
         }
 
@@ -76,7 +69,7 @@ namespace RevitSystemTests
         /// <param name="dynamoFilePath">The path of the dynamo workspace.</param>
         /// <param name="revitFilePath">The path of the Revit rfa or rvt file.</param>
         [Test]
-        [TestCaseSource("SetupRevitRegressionTests")]
+        [TestCaseSource(nameof(SetupRevitRegressionTests))]
         public void Regressions(RegressionTestData testData)
         {
             Exception exception = null;
@@ -125,10 +118,11 @@ namespace RevitSystemTests
             {
                 exception = ex;
             }
-            finally
-            {
-                TearDown();
-            }
+            // this is not needed anymore, NUnit ensures this happens between each test case
+            //finally
+            //{
+            //    TearDown();
+            //}
 
             if (exception != null)
             {

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -145,8 +145,6 @@ namespace RevitTestServices
         protected string emptyModelPath1;
         protected string emptyModelPath;
 
-        public static RevitSystemTestBase s_initedInstance = null;
-
         #region public methods
 
         protected void WrapOf(RevitSystemTestBase initedInstance)
@@ -170,21 +168,11 @@ namespace RevitTestServices
         [SetUp]
         public override void Setup()
         {
-            if (s_initedInstance == null)
-            {
-                base.Setup();
-                //ViewModel.Model.AddZeroTouchNodesToSearch(ViewModel.Model.LibraryServices.GetAllFunctionGroups());
+            base.Setup();
 
-                ((HomeWorkspaceModel)ViewModel.Model.CurrentWorkspace).RunSettings.RunType = RunType.Manual;
+            ((HomeWorkspaceModel)ViewModel.Model.CurrentWorkspace).RunSettings.RunType = RunType.Manual;
 
-                DocumentManager.Instance.CurrentUIApplication.ViewActivating += CurrentUIApplication_ViewActivating;
-                s_initedInstance = this;
-            }
-            else
-            {
-                WrapOf(s_initedInstance);
-                CreateTemporaryFolder();
-            }
+            DocumentManager.Instance.CurrentUIApplication.ViewActivating += CurrentUIApplication_ViewActivating;
         }
 
         [TearDown]

--- a/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
+++ b/test/Libraries/RevitTestServices/RevitSystemTestBase.cs
@@ -24,6 +24,7 @@ using RTF.Applications;
 using SystemTestServices;
 using TestServices;
 using Dynamo.Configuration;
+using RTF.Framework;
 
 namespace RevitTestServices
 {
@@ -135,11 +136,13 @@ namespace RevitTestServices
     }
 
     [TestFixture]
-    public class RevitSystemTestBase : SystemTestBase
+    public class RevitSystemTestBase : SystemTestBase, IRTFSetup
     {
         private string samplesPath;
         protected string emptyModelPath1;
         protected string emptyModelPath;
+
+        public static RevitSystemTestBase s_instance = null;
 
         #region public methods
 
@@ -151,6 +154,7 @@ namespace RevitTestServices
             ((HomeWorkspaceModel)ViewModel.Model.CurrentWorkspace).RunSettings.RunType = RunType.Manual;
 
             DocumentManager.Instance.CurrentUIApplication.ViewActivating += CurrentUIApplication_ViewActivating;
+            s_instance = this;
         }
 
         [TearDown]

--- a/test/Libraries/RevitTestServices/RevitTestServices.csproj
+++ b/test/Libraries/RevitTestServices/RevitTestServices.csproj
@@ -50,6 +50,9 @@
 			<HintPath>$(REVITAPI)\RevitAPIUI.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="RevitTestFrameworkTypes">
+		  <HintPath>..\..\..\extern\RevitTestFramework\RevitTestFrameworkTypes.dll</HintPath>
+		</Reference>
 		<Reference Include="RTFRevit, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
 			<HintPath>..\..\..\extern\RevitTestFramework\RTFRevit.dll</HintPath>
 			<SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION

### Purpose

Fix a few tests for node search that I wrongly updated when upgrading to Dynamo Core 3.0 and NUnit 3.0.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@mjkkirschner 


