### PR TITLE
DYN-6390 Fix Levels and Family wrapper names

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Family.cs
+++ b/src/Libraries/RevitNodes/Elements/Family.cs
@@ -166,7 +166,7 @@ namespace Revit.Elements
 
         public override string ToString()
         {
-            return String.Format("Family: {0}", InternalFamily.Name);
+            return InternalFamily.IsValidObject ? String.Format("Family: {0}", InternalFamily.Name) : "empty";
         }
 
         #endregion

--- a/src/Libraries/RevitNodes/Elements/Level.cs
+++ b/src/Libraries/RevitNodes/Elements/Level.cs
@@ -324,7 +324,7 @@ namespace Revit.Elements
 
         public override string ToString()
         {
-            return string.Format("Level(Name={0}, Elevation={1})", Name, Elevation);
+            return InternalLevel.IsValidObject ? string.Format("Level(Name={0}, Elevation={1})", Name, Elevation) : "empty";
         }
 
     }


### PR DESCRIPTION
### Purpose

Fix Revit crashing described in https://jira.autodesk.com/browse/DYN-6390

The fix addresses issues with two classes **(Level, Family)** that display the name of the element in the preview. 

![image](https://github.com/DynamoDS/DynamoRevit/assets/43077096/16b00fe9-577d-42d1-bc76-20de366c5927)

The fix adds an extra check for valid element and displays 'empty' instead of crashing. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@Mikhinja 

### FYIs

@dnenov @Amoursol 
