### PR TITLE
Fix CurtainPanel.ByElements node returning null as soon as curtain wall contains doors or windows

### DIFF
--- a/src/Libraries/RevitNodes/Elements/CurtainPanel.cs
+++ b/src/Libraries/RevitNodes/Elements/CurtainPanel.cs
@@ -18,463 +18,471 @@ namespace Revit.Elements
     /// A Revit CurtainPanel
     /// </summary>
     public class CurtainPanel : AbstractFamilyInstance
-   {
-      #region Properties
+    {
+        #region Properties
 
-      protected CurveArrArray PanelBoundaries
-      {
-         get
-         {
-            // This creates a new wall and deletes the old one
-            TransactionManager.Instance.EnsureInTransaction(Document);
+        protected CurveArrArray PanelBoundaries
+        {
+            get
+            {
+                // This creates a new wall and deletes the old one
+                TransactionManager.Instance.EnsureInTransaction(Document);
 
+                var elementAsPanel = InternalElement as Autodesk.Revit.DB.Panel;
+                if (elementAsPanel == null)
+                    throw new Exception(Properties.Resources.CurtainPanelInternalElementError);
+
+                var host = elementAsPanel.Host;
+
+                CurtainGrid hostingGrid = null;
+                Autodesk.Revit.DB.CurtainGrid grid = null;
+                if (host is Autodesk.Revit.DB.Wall)
+                {
+                    hostingGrid = CurtainGrid.ByElement(UnknownElement.FromExisting(host, true));
+                }
+                else
+                {
+                    var gridSet = CurtainGrid.AllCurtainGrids(host);
+                    var enumGrid = gridSet.GetEnumerator();
+                    bool found = false;
+                    for (; enumGrid.MoveNext();)
+                    {
+                        grid = (Autodesk.Revit.DB.CurtainGrid)enumGrid.Current;
+                        if (grid.GetPanelIds().Contains(elementAsPanel.Id))
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found)
+                        throw new Exception(Properties.Resources.CellForPanelNotFound);
+                }
+
+                ElementId uGridId = ElementId.InvalidElementId;
+                ElementId vGridId = ElementId.InvalidElementId;
+                elementAsPanel.GetRefGridLines(ref uGridId, ref vGridId);
+
+                if (grid == null && hostingGrid == null)
+                    throw new Exception(Properties.Resources.CellForPanelNotFound);
+
+                CurtainCell cell = hostingGrid != null
+                   ? hostingGrid.InternalCurtainGrid.GetCell(uGridId, vGridId)
+                   : grid.GetCell(uGridId, vGridId);
+
+                TransactionManager.Instance.TransactionTaskDone();
+
+                if (cell == null)
+                    throw new Exception(Properties.Resources.CellForPanelNotFound);
+                return cell.CurveLoops;
+            }
+        }
+
+        private PolyCurve[] boundsCache = null;
+        /// <summary>
+        /// Gets curtain panel boundaries
+        /// </summary>
+        public PolyCurve[] Boundaries
+        {
+            get
+            {
+                if (boundsCache != null)
+                    return boundsCache;
+                var enumCurveLoops = PanelBoundaries.GetEnumerator();
+                var bounds = new List<PolyCurve>();
+
+                for (; enumCurveLoops.MoveNext();)
+                {
+                    var crvs = new CurveArray();
+                    var crvArr = (CurveArray)enumCurveLoops.Current;
+                    var enumCurves = crvArr.GetEnumerator();
+                    for (; enumCurves.MoveNext();)
+                    {
+                        var crv = (Autodesk.Revit.DB.Curve)enumCurves.Current;
+                        crvs.Append(crv);
+                    }
+                    //try
+                    //{
+                    bounds.Add(Revit.GeometryConversion.RevitToProtoCurve.ToProtoType(crvs));
+                    //}
+                    /* debugging code
+                    catch (Exception e)
+                    {
+                       var cl = new CurveLoop();
+                       var enumCurvesCl = crvArr.GetEnumerator();
+                       for (; enumCurvesCl.MoveNext(); )
+                       {
+                          var crv = (Autodesk.Revit.DB.Curve)enumCurvesCl.Current;
+                          cl.Append(crv);
+                       }
+                       double len = cl.GetExactLength();
+                       len = len/1.0;
+                    }
+                    end of debugging code */
+                }
+                boundsCache = bounds.ToArray();
+                return boundsCache;
+            }
+        }
+        /// <summary>
+        /// Checks if the specific curtain panel is planar
+        /// </summary>
+        public bool HasPlane
+        {
+            get
+            {
+                var enumCurveLoops = PanelBoundaries.GetEnumerator();
+                Autodesk.Revit.DB.Plane plane = null;
+                for (; enumCurveLoops.MoveNext();)
+                {
+                    var cLoop = new CurveLoop();
+                    var crvArr = (CurveArray)enumCurveLoops.Current;
+                    var enumCurves = crvArr.GetEnumerator();
+                    for (; enumCurves.MoveNext();)
+                    {
+                        var crv = (Autodesk.Revit.DB.Curve)enumCurves.Current;
+                        cLoop.Append(crv);
+                    }
+                    if (!cLoop.HasPlane())
+                        return false;
+                    var thisPlane = cLoop.GetPlane();
+                    if (plane == null)
+                        plane = thisPlane;
+                    else if (Math.Abs(plane.Normal.DotProduct(thisPlane.Normal)) < 1.0 - 1.0e-9)
+                        return false;
+                    else
+                    {
+                        if (Math.Abs((plane.Origin - thisPlane.Origin).DotProduct(plane.Normal)) > 1.0e-9)
+                            return false;
+                    }
+                }
+                return true;
+            }
+        }
+        /// <summary>
+        /// Gets a plane of the given curtain panel, if it is planar
+        /// </summary>
+        public Plane PanelPlane
+        {
+            get
+            {
+                var enumCurveLoops = PanelBoundaries.GetEnumerator();
+                Autodesk.Revit.DB.Plane plane = null;
+                for (; enumCurveLoops.MoveNext();)
+                {
+                    var cLoop = new CurveLoop();
+                    var crvArr = (CurveArray)enumCurveLoops.Current;
+                    var enumCurves = crvArr.GetEnumerator();
+                    for (; enumCurves.MoveNext();)
+                    {
+                        var crv = (Autodesk.Revit.DB.Curve)enumCurves.Current;
+                        cLoop.Append(crv);
+                    }
+                    if (!cLoop.HasPlane())
+                        throw new Exception(Properties.Resources.CurtainPanelIsNotPlanar);
+                    var thisPlane = cLoop.GetPlane();
+                    if (plane == null)
+                        plane = thisPlane;
+                    else if (Math.Abs(plane.Normal.DotProduct(thisPlane.Normal)) < 1.0 - 1.0e-9)
+                        throw new Exception(Properties.Resources.CurtainPanelIsNotPlanar);
+                    else
+                    {
+                        if (Math.Abs((plane.Origin - thisPlane.Origin).DotProduct(plane.Normal)) > 1.0e-9)
+                            throw new Exception(Properties.Resources.CurtainPanelIsNotPlanar);
+                    }
+                }
+                if (plane == null)
+                    throw new Exception(Properties.Resources.CurtainPanelIsNotPlanar);
+
+                return plane.ToPlane();
+            }
+        }
+        /// <summary>
+        /// Gets the length of the specific curtain panel boundaries
+        /// </summary>
+        public double Length
+        {
+            get
+            {
+                double lengthVal = 0.0;
+                var enumCurveLoops = PanelBoundaries.GetEnumerator();
+                for (; enumCurveLoops.MoveNext();)
+                {
+                    var crvArr = (CurveArray)enumCurveLoops.Current;
+                    var enumCurves = crvArr.GetEnumerator();
+                    for (; enumCurves.MoveNext();)
+                    {
+                        var crv = (Autodesk.Revit.DB.Curve)enumCurves.Current;
+                        lengthVal += crv.Length;
+                    }
+                }
+                return lengthVal * UnitConverter.HostToDynamoFactor(SpecTypeId.Length);
+            }
+        }
+
+        /// <summary>
+        /// Checks whether the specific curtain panel is rectangular. Returns 
+        /// true if the curtain panel is rectangular. Otherwise returns false
+        /// </summary>
+        public bool IsRectangular
+        {
+            get
+            {
+                var enumCurveLoops = PanelBoundaries.GetEnumerator();
+                int num = 0;
+                bool result = false;
+                for (; enumCurveLoops.MoveNext();)
+                {
+                    if (num > 0)
+                        return false;
+                    num++;
+                    var cLoop = new CurveLoop();
+                    var crvArr = (CurveArray)enumCurveLoops.Current;
+                    var enumCurves = crvArr.GetEnumerator();
+                    for (; enumCurves.MoveNext();)
+                    {
+                        var crv = (Autodesk.Revit.DB.Curve)enumCurves.Current;
+                        cLoop.Append(crv);
+                    }
+                    if (!cLoop.HasPlane())
+                        return false;
+                    result = cLoop.IsRectangular(cLoop.GetPlane());
+                }
+                return result;
+            }
+        }
+        /// <summary>
+        /// Gets the width of the specific curtain panel, if it's rectangular
+        /// </summary>
+        public double Width
+        {
+            get
+            {
+                var enumCurveLoops = PanelBoundaries.GetEnumerator();
+                int num = 0;
+                double result = 0.0;
+                for (; enumCurveLoops.MoveNext();)
+                {
+                    if (num > 0)
+                        throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
+                    num++;
+                    var cLoop = new CurveLoop();
+                    var crvArr = (CurveArray)enumCurveLoops.Current;
+                    var enumCurves = crvArr.GetEnumerator();
+                    for (; enumCurves.MoveNext();)
+                    {
+                        var crv = (Autodesk.Revit.DB.Curve)enumCurves.Current;
+                        cLoop.Append(crv);
+                    }
+                    if (!cLoop.HasPlane())
+                        throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
+                    if (!cLoop.IsRectangular(cLoop.GetPlane()))
+                        throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
+                    result = cLoop.GetRectangularWidth(cLoop.GetPlane());
+                }
+                return result * UnitConverter.HostToDynamoFactor(SpecTypeId.Length);
+            }
+        }
+        /// <summary>
+        /// Gets the height of the specific curtain panel, if it's rectangular
+        /// </summary>
+        public double Height
+        {
+            get
+            {
+                var enumCurveLoops = PanelBoundaries.GetEnumerator();
+                int num = 0;
+                double result = 0.0;
+                for (; enumCurveLoops.MoveNext();)
+                {
+                    if (num > 0)
+                        throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
+                    num++;
+                    var cLoop = new CurveLoop();
+                    var crvArr = (CurveArray)enumCurveLoops.Current;
+                    var enumCurves = crvArr.GetEnumerator();
+                    for (; enumCurves.MoveNext();)
+                    {
+                        var crv = (Autodesk.Revit.DB.Curve)enumCurves.Current;
+                        cLoop.Append(crv);
+                    }
+                    if (!cLoop.HasPlane())
+                        throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
+                    if (!cLoop.IsRectangular(cLoop.GetPlane()))
+                        throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
+                    result = cLoop.GetRectangularHeight(cLoop.GetPlane());
+                }
+                return result * UnitConverter.HostToDynamoFactor(SpecTypeId.Length);
+            }
+        }
+
+        #endregion
+
+        #region Private constructors
+
+        /// <summary>
+        /// Create from an existing Revit Element
+        /// </summary>
+        /// <param name="panelElement"></param>
+        protected CurtainPanel(Autodesk.Revit.DB.Panel panelElement)
+        {
+            SafeInit(() => InitCurtainPanel(panelElement), true);
+        }
+
+        #endregion
+
+        #region Helper for private constructors
+
+        /// <summary>
+        /// Initialize a CurtainPanel element
+        /// </summary>
+        /// <param name="panelElement"></param>
+        private void InitCurtainPanel(Autodesk.Revit.DB.Panel panelElement)
+        {
+            InternalSetFamilyInstance(panelElement);
+            boundsCache = null;
+        }
+
+        #endregion
+
+        #region Static constructors
+
+        /// <summary>
+        ///get curtain panel from element  
+        /// </summary>
+        /// <param name="panelElement"></param>
+
+        internal static CurtainPanel ByElement(CurtainPanel panelElement)
+        {
+            var elementAsPanel = panelElement.InternalElement as Autodesk.Revit.DB.Panel;
+            if (elementAsPanel == null)
+                throw new Exception("Curtain Panel should represent Revit panel");
+            return new CurtainPanel(elementAsPanel);
+        }
+
+        /// <summary>
+        ///get all panels of curtain wall, system or slope glazing roof
+        /// </summary>
+        /// <param name="hostingElement"></param>
+        public static CurtainPanel[] ByElement(Element hostingElement)
+        {
+            CurtainGridSet thisSet = CurtainGrid.AllCurtainGrids(hostingElement.InternalElement);
+            var result = new List<CurtainPanel>();
+
+            var enumGrid = thisSet.GetEnumerator();
+            for (; enumGrid.MoveNext();)
+            {
+                var grid = (Autodesk.Revit.DB.CurtainGrid)enumGrid.Current;
+                var ids = grid.GetPanelIds();
+                var idEnum = ids.GetEnumerator();
+                for (; idEnum.MoveNext();)
+                {
+                    var idPanel = idEnum.Current;
+                    var panel = DocumentManager.Instance.CurrentDBDocument.GetElement(idPanel);
+                    if (panel is Autodesk.Revit.DB.Panel)
+                    {
+                        result.Add(CurtainPanel.FromExisting(panel as Autodesk.Revit.DB.Panel, true));
+                    }
+                    else
+                    {
+                        result.Add(null);
+                    }
+                
+                }
+            }
+            return result.ToArray();
+        }
+
+        /// <summary>
+        /// Construct this type from an existing Revit element.
+        /// </summary>
+        /// <param name="panel"></param>
+        /// <param name="isRevitOwned"></param>
+        /// <returns></returns>
+        internal static CurtainPanel FromExisting(Autodesk.Revit.DB.Panel panel, bool isRevitOwned)
+        {
+            if (panel == null)
+            {
+                throw new ArgumentNullException("panel");
+            }
+
+            return new CurtainPanel(panel)
+            {
+                IsRevitOwned = true //making panels in Dynamo is not implemented
+            };
+        }
+
+        #endregion
+
+        #region public methods
+        /// <summary>
+        /// Gets Mullions hosting the specified curtain panel
+        /// </summary>
+        /// <returns></returns>
+        public Mullion[] SupportingMullions()
+        {
             var elementAsPanel = InternalElement as Autodesk.Revit.DB.Panel;
             if (elementAsPanel == null)
-               throw new Exception(Properties.Resources.CurtainPanelInternalElementError);
+                throw new Exception(Properties.Resources.CurtainPanelShouldRepresentRevitPanel);
+            var bounds = this.Boundaries;
 
             var host = elementAsPanel.Host;
 
-            CurtainGrid hostingGrid = null;
-            Autodesk.Revit.DB.CurtainGrid grid = null;
-            if (host is Autodesk.Revit.DB.Wall)
+            //var hostingGrid = CurtainGrid.ByElement(UnknownElement.FromExisting(host));
+
+            var mullions = Mullion.ByElement(UnknownElement.FromExisting(host, true));//hostingGrid.GetMullions();
+            int numberMullions = mullions.Length;
+            var result = new List<Mullion>();
+
+            for (int index = 0; index < numberMullions; index++)
             {
-               hostingGrid = CurtainGrid.ByElement(UnknownElement.FromExisting(host, true));
+                var mullionAtIndex = mullions[index] as Mullion;
+                if (mullionAtIndex == null)
+                    continue;
+
+                var thisCurve = mullionAtIndex.LocationCurve;
+
+                var enumBounds = bounds.GetEnumerator();
+                bool neighbor = false;
+                for (; enumBounds.MoveNext() && !neighbor;)
+                {
+                    var polycrv = enumBounds.Current as PolyCurve;
+                    if (polycrv == null)
+                        continue;
+                    var bndCrvs = polycrv.Curves();
+                    var enumCrv = bndCrvs.GetEnumerator();
+                    for (; enumCrv.MoveNext();)
+                    {
+                        var crv = enumCrv.Current as Autodesk.DesignScript.Geometry.Curve;
+                        if (crv == null)
+                            continue;
+                        var midPoint = crv.PointAtParameter(0.5);
+                        if (midPoint.DistanceTo(thisCurve) < 1.0e-7)
+                        {
+                            neighbor = true;
+                            break;
+                        }
+                    }
+                }
+                if (neighbor)
+                    result.Add(mullionAtIndex);
             }
-            else
-            {
-               var gridSet = CurtainGrid.AllCurtainGrids(host);
-               var enumGrid = gridSet.GetEnumerator();
-               bool found = false;
-               for (; enumGrid.MoveNext();)
-               {
-                  grid = (Autodesk.Revit.DB.CurtainGrid)enumGrid.Current;
-                  if (grid.GetPanelIds().Contains(elementAsPanel.Id))
-                  {
-                     found = true;
-                     break;
-                  }
-               }
-               if (!found)
-                  throw new Exception(Properties.Resources.CellForPanelNotFound);
-            }
+            return result.ToArray();
+        }
+        /// <summary>
+        /// Gets family instance from curtain Panel
+        /// </summary>
+        /// <returns></returns>
+        public FamilyInstance AsFamilyInstance()
+        {
+            return FamilyInstance.FromExisting(InternalElement as Autodesk.Revit.DB.FamilyInstance, true);
+        }
 
-            ElementId uGridId = ElementId.InvalidElementId;
-            ElementId vGridId = ElementId.InvalidElementId;
-            elementAsPanel.GetRefGridLines(ref uGridId, ref vGridId);
+        public override string ToString()
+        {
+            return "Curtain Panel";
+        }
 
-            if (grid == null && hostingGrid == null)
-               throw new Exception(Properties.Resources.CellForPanelNotFound);
+        #endregion
 
-            CurtainCell cell = hostingGrid != null
-               ? hostingGrid.InternalCurtainGrid.GetCell(uGridId, vGridId)
-               : grid.GetCell(uGridId, vGridId);
-
-            TransactionManager.Instance.TransactionTaskDone();
-
-            if (cell == null)
-               throw new Exception(Properties.Resources.CellForPanelNotFound);
-            return cell.CurveLoops;
-         }
-      }
-
-      private PolyCurve[] boundsCache = null;
-       /// <summary>
-       /// Gets curtain panel boundaries
-       /// </summary>
-      public PolyCurve[] Boundaries
-      {
-         get
-         {
-            if (boundsCache != null)
-               return boundsCache;
-            var enumCurveLoops = PanelBoundaries.GetEnumerator();
-            var bounds = new List<PolyCurve>();
-
-            for (; enumCurveLoops.MoveNext();)
-            {
-               var crvs = new CurveArray();
-               var crvArr = (CurveArray) enumCurveLoops.Current;
-               var enumCurves = crvArr.GetEnumerator();
-               for (; enumCurves.MoveNext();)
-               {
-                  var crv = (Autodesk.Revit.DB.Curve) enumCurves.Current;
-                  crvs.Append(crv);
-               }
-               //try
-               //{
-                  bounds.Add(Revit.GeometryConversion.RevitToProtoCurve.ToProtoType(crvs));
-               //}
-               /* debugging code
-               catch (Exception e)
-               {
-                  var cl = new CurveLoop();
-                  var enumCurvesCl = crvArr.GetEnumerator();
-                  for (; enumCurvesCl.MoveNext(); )
-                  {
-                     var crv = (Autodesk.Revit.DB.Curve)enumCurvesCl.Current;
-                     cl.Append(crv);
-                  }
-                  double len = cl.GetExactLength();
-                  len = len/1.0;
-               }
-               end of debugging code */
-            }
-            boundsCache = bounds.ToArray();
-            return boundsCache;
-         }
-      }
-       /// <summary>
-       /// Checks if the specific curtain panel is planar
-       /// </summary>
-      public bool HasPlane
-      {
-         get
-         {
-            var enumCurveLoops = PanelBoundaries.GetEnumerator();
-            Autodesk.Revit.DB.Plane plane = null;
-            for (; enumCurveLoops.MoveNext();)
-            {
-               var cLoop = new CurveLoop();
-               var crvArr = (CurveArray) enumCurveLoops.Current;
-               var enumCurves = crvArr.GetEnumerator();
-               for (; enumCurves.MoveNext();)
-               {
-                  var crv = (Autodesk.Revit.DB.Curve) enumCurves.Current;
-                  cLoop.Append(crv);
-               }
-               if (!cLoop.HasPlane())
-                  return false;
-               var thisPlane = cLoop.GetPlane();
-               if (plane == null)
-                  plane = thisPlane;
-               else if (Math.Abs(plane.Normal.DotProduct(thisPlane.Normal)) < 1.0 - 1.0e-9)
-                  return false;
-               else
-               {
-                  if (Math.Abs((plane.Origin - thisPlane.Origin).DotProduct(plane.Normal)) > 1.0e-9)
-                     return false;
-               }
-            }
-            return true;
-         }
-      }
-       /// <summary>
-       /// Gets a plane of the given curtain panel, if it is planar
-       /// </summary>
-      public Plane PanelPlane
-      {
-         get
-         {
-            var enumCurveLoops = PanelBoundaries.GetEnumerator();
-            Autodesk.Revit.DB.Plane plane = null;
-            for (; enumCurveLoops.MoveNext();)
-            {
-               var cLoop = new CurveLoop();
-               var crvArr = (CurveArray) enumCurveLoops.Current;
-               var enumCurves = crvArr.GetEnumerator();
-               for (; enumCurves.MoveNext();)
-               {
-                  var crv = (Autodesk.Revit.DB.Curve) enumCurves.Current;
-                  cLoop.Append(crv);
-               }
-               if (!cLoop.HasPlane())
-                  throw new Exception(Properties.Resources.CurtainPanelIsNotPlanar);
-               var thisPlane = cLoop.GetPlane();
-               if (plane == null)
-                  plane = thisPlane;
-               else if (Math.Abs(plane.Normal.DotProduct(thisPlane.Normal)) < 1.0 - 1.0e-9)
-                   throw new Exception(Properties.Resources.CurtainPanelIsNotPlanar);
-               else
-               {
-                  if (Math.Abs((plane.Origin - thisPlane.Origin).DotProduct(plane.Normal)) > 1.0e-9)
-                      throw new Exception(Properties.Resources.CurtainPanelIsNotPlanar);
-               }
-            }
-            if (plane == null)
-                throw new Exception(Properties.Resources.CurtainPanelIsNotPlanar);
-
-             return plane.ToPlane();
-         }
-      }
-       /// <summary>
-       /// Gets the length of the specific curtain panel boundaries
-       /// </summary>
-      public double Length
-      {
-         get
-         {
-            double lengthVal = 0.0;
-            var enumCurveLoops = PanelBoundaries.GetEnumerator();
-            for (; enumCurveLoops.MoveNext();)
-            {
-               var crvArr = (CurveArray) enumCurveLoops.Current;
-               var enumCurves = crvArr.GetEnumerator();
-               for (; enumCurves.MoveNext();)
-               {
-                  var crv = (Autodesk.Revit.DB.Curve) enumCurves.Current;
-                  lengthVal += crv.Length;
-               }
-            }
-            return lengthVal * UnitConverter.HostToDynamoFactor(SpecTypeId.Length);
-         }
-      }
-
-       /// <summary>
-       /// Checks whether the specific curtain panel is rectangular. Returns 
-       /// true if the curtain panel is rectangular. Otherwise returns false
-       /// </summary>
-      public bool IsRectangular
-      {
-         get
-         {
-            var enumCurveLoops = PanelBoundaries.GetEnumerator();
-            int num = 0;
-            bool result = false;
-            for (; enumCurveLoops.MoveNext();)
-            {
-               if (num > 0)
-                  return false;
-               num++;
-               var cLoop = new CurveLoop();
-               var crvArr = (CurveArray) enumCurveLoops.Current;
-               var enumCurves = crvArr.GetEnumerator();
-               for (; enumCurves.MoveNext();)
-               {
-                  var crv = (Autodesk.Revit.DB.Curve) enumCurves.Current;
-                  cLoop.Append(crv);
-               }
-               if (!cLoop.HasPlane())
-                  return false;
-               result = cLoop.IsRectangular(cLoop.GetPlane());
-            }
-            return result;
-         }
-      }
-       /// <summary>
-      /// Gets the width of the specific curtain panel, if it's rectangular
-       /// </summary>
-      public double Width
-      {
-         get
-         {
-            var enumCurveLoops = PanelBoundaries.GetEnumerator();
-            int num = 0;
-            double result = 0.0;
-            for (; enumCurveLoops.MoveNext();)
-            {
-               if (num > 0)
-                  throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
-               num++;
-               var cLoop = new CurveLoop();
-               var crvArr = (CurveArray) enumCurveLoops.Current;
-               var enumCurves = crvArr.GetEnumerator();
-               for (; enumCurves.MoveNext();)
-               {
-                  var crv = (Autodesk.Revit.DB.Curve) enumCurves.Current;
-                  cLoop.Append(crv);
-               }
-               if (!cLoop.HasPlane())
-                   throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
-               if (!cLoop.IsRectangular(cLoop.GetPlane()))
-                   throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
-               result = cLoop.GetRectangularWidth(cLoop.GetPlane());
-            }
-            return result * UnitConverter.HostToDynamoFactor(SpecTypeId.Length);
-         }
-      }
-       /// <summary>
-       /// Gets the height of the specific curtain panel, if it's rectangular
-       /// </summary>
-      public double Height
-      {
-         get
-         {
-            var enumCurveLoops = PanelBoundaries.GetEnumerator();
-            int num = 0;
-            double result = 0.0;
-            for (; enumCurveLoops.MoveNext();)
-            {
-               if (num > 0)
-                   throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
-               num++;
-               var cLoop = new CurveLoop();
-               var crvArr = (CurveArray) enumCurveLoops.Current;
-               var enumCurves = crvArr.GetEnumerator();
-               for (; enumCurves.MoveNext();)
-               {
-                  var crv = (Autodesk.Revit.DB.Curve) enumCurves.Current;
-                  cLoop.Append(crv);
-               }
-               if (!cLoop.HasPlane())
-                   throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
-               if (!cLoop.IsRectangular(cLoop.GetPlane()))
-                   throw new Exception(Properties.Resources.CurtainPanelIsNotRectangular);
-               result = cLoop.GetRectangularHeight(cLoop.GetPlane());
-            }
-            return result * UnitConverter.HostToDynamoFactor(SpecTypeId.Length);
-         }
-      }
-
-      #endregion
-
-      #region Private constructors
-
-      /// <summary>
-      /// Create from an existing Revit Element
-      /// </summary>
-      /// <param name="panelElement"></param>
-      protected CurtainPanel(Autodesk.Revit.DB.Panel panelElement)
-      {
-          SafeInit(() => InitCurtainPanel(panelElement), true);
-      }
-
-      #endregion
-
-      #region Helper for private constructors
-
-      /// <summary>
-      /// Initialize a CurtainPanel element
-      /// </summary>
-      /// <param name="panelElement"></param>
-      private void InitCurtainPanel(Autodesk.Revit.DB.Panel panelElement)
-      {
-          InternalSetFamilyInstance(panelElement);
-          boundsCache = null;
-      }
-
-      #endregion
-
-      #region Static constructors
-
-      /// <summary>
-      ///get curtain panel from element  
-      /// </summary>
-      /// <param name="panelElement"></param>
-
-      internal static CurtainPanel ByElement(CurtainPanel panelElement)
-      {
-         var elementAsPanel = panelElement.InternalElement as Autodesk.Revit.DB.Panel;
-         if (elementAsPanel == null)
-            throw new Exception("Curtain Panel should represent Revit panel");
-         return new CurtainPanel(elementAsPanel);
-      }
-
-      /// <summary>
-      ///get all panels of curtain wall, system or slope glazing roof
-      /// </summary>
-      /// <param name="hostingElement"></param>
-      public static CurtainPanel[] ByElement(Element hostingElement)
-      {
-         CurtainGridSet thisSet = CurtainGrid.AllCurtainGrids(hostingElement.InternalElement);
-         var result = new List<CurtainPanel>();
-
-         var enumGrid = thisSet.GetEnumerator();
-         for (; enumGrid.MoveNext(); )
-         {
-            var grid = (Autodesk.Revit.DB.CurtainGrid)enumGrid.Current;
-            var ids = grid.GetPanelIds();
-            var idEnum = ids.GetEnumerator();
-            for (; idEnum.MoveNext(); )
-            {
-               var idPanel = idEnum.Current;
-               var panel = DocumentManager.Instance.CurrentDBDocument.GetElement(idPanel);
-               result.Add(CurtainPanel.FromExisting(panel as Autodesk.Revit.DB.Panel, true));
-            }
-         }
-         return result.ToArray();
-      }
-
-      /// <summary>
-      /// Construct this type from an existing Revit element.
-      /// </summary>
-      /// <param name="panel"></param>
-      /// <param name="isRevitOwned"></param>
-      /// <returns></returns>
-      internal static CurtainPanel FromExisting(Autodesk.Revit.DB.Panel panel, bool isRevitOwned)
-      {
-         if (panel == null)
-         {
-            throw new ArgumentNullException("panel");
-         }
-         
-         return new CurtainPanel(panel)
-         {
-            IsRevitOwned = true //making panels in Dynamo is not implemented
-         };
-      }
-
-      #endregion
-
-      #region public methods
-       /// <summary>
-       /// Gets Mullions hosting the specified curtain panel
-       /// </summary>
-       /// <returns></returns>
-      public Mullion[] SupportingMullions()
-      {
-         var elementAsPanel = InternalElement as Autodesk.Revit.DB.Panel;
-         if (elementAsPanel == null)
-            throw new Exception(Properties.Resources.CurtainPanelShouldRepresentRevitPanel);
-         var bounds = this.Boundaries;
-
-         var host = elementAsPanel.Host;
-
-         //var hostingGrid = CurtainGrid.ByElement(UnknownElement.FromExisting(host));
-
-         var mullions = Mullion.ByElement(UnknownElement.FromExisting(host, true));//hostingGrid.GetMullions();
-         int numberMullions = mullions.Length;
-         var result = new List<Mullion>();
-
-         for (int index = 0; index < numberMullions; index++)
-         {
-            var mullionAtIndex = mullions[index] as Mullion;
-            if (mullionAtIndex == null)
-               continue;
-
-            var thisCurve = mullionAtIndex.LocationCurve;
-
-            var enumBounds = bounds.GetEnumerator();
-            bool neighbor = false;
-            for (; enumBounds.MoveNext() && !neighbor; )
-            {
-               var polycrv = enumBounds.Current as PolyCurve;
-               if (polycrv == null)
-                  continue;
-               var bndCrvs = polycrv.Curves();
-               var enumCrv = bndCrvs.GetEnumerator();
-               for (; enumCrv.MoveNext(); )
-               {
-                  var crv = enumCrv.Current as Autodesk.DesignScript.Geometry.Curve;
-                  if (crv == null)
-                     continue;
-                  var midPoint = crv.PointAtParameter(0.5);
-                  if (midPoint.DistanceTo(thisCurve) < 1.0e-7)
-                  {
-                     neighbor = true;
-                     break;
-                  }
-               }
-            }
-            if (neighbor)
-               result.Add(mullionAtIndex);
-         }
-         return result.ToArray();
-      }
-      /// <summary>
-      /// Gets family instance from curtain Panel
-      /// </summary>
-      /// <returns></returns>
-      public FamilyInstance AsFamilyInstance()
-      {
-         return FamilyInstance.FromExisting(InternalElement as Autodesk.Revit.DB.FamilyInstance, true);
-      }
-
-      public override string ToString()
-      {
-         return "Curtain Panel";
-      }
-
-      #endregion
-
-   }
+    }
 }


### PR DESCRIPTION
### Purpose

This is a quick fix [for this issue ](https://github.com/DynamoDS/DynamoRevit/issues/3043) in which CurtainPanel.ByElements node returns null if the curtain wall has doors or windows. This change fixes only part of the problem, meaning that now the node will display the list of curtain panels, while curtain windows or curtain door elements will be displayed as null values in that list. Returning doors and windows as well will be treated as a separate issue.

This PR has a lot of changes because of reformatting the file according to current coding standards. 

REVIT-219424 

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@Mikhinja 