### PR TITLE
DYN-6775 Localizing SplashScreen

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -394,6 +394,7 @@ namespace Dynamo.Applications
         {
             // create core data models
             RevitDynamoModel = InitializeCoreModel(extCommandData);
+            RevitDynamoModel.OnDetectLanguage();
             RevitDynamoModel.Logger.Log("SYSTEM", string.Format("Environment Path:{0}", Environment.GetEnvironmentVariable("PATH")));
 
             // handle initialization steps after RevitDynamoModel is created.


### PR DESCRIPTION

### Purpose

The buttons from the Static SplashScreen are being localized in DynamoSandbox but in Revit 2026 were not being localized due that the function OnDetectLanguage() was not being called. Then my fix was just calling this method so the SetLabels methods will be also called and the buttons will be in the expected language.

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

@QilongTang 

### FYIs


