### PR TITLE
REVIT-220887 Change outdated node ID for CreateFamilyTypeByGeometry test

### DIFF
--- a/test/Libraries/RevitIntegrationTests/FamilyTests.cs
+++ b/test/Libraries/RevitIntegrationTests/FamilyTests.cs
@@ -359,7 +359,7 @@ namespace RevitSystemTests
 
             RunCurrentModel();
 
-            var famInst = GetPreviewValue("df1bc5da-b9de-4fb2-8c9b-9aa7c8997834");
+            var famInst = GetPreviewValue("aa018bdb2523490bbb4f8e141a342748");
             Assert.IsNotNull(famInst);
             Assert.IsTrue(typeof(Revit.Elements.FamilyType) == famInst.GetType());
             


### PR DESCRIPTION
### Purpose

The purpose is to update CreateFamilyTypeByGeometry test and add it to the Revit regression test suite in order to catch any future regressions for the FamilyType.ByGeometry node.

REVIT-220887

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

@Mikhinja 