### PR TITLE
DYN-7206: Use Dynamo Core's selection text formatting

### DIFF
--- a/src/Libraries/RevitNodesUI/Selection.cs
+++ b/src/Libraries/RevitNodesUI/Selection.cs
@@ -327,7 +327,8 @@ namespace Dynamo.Nodes
 
             var ids =
                 elements.Cast<Element>().Where(el => el.IsValidObject).Select(el => el.Id).ToArray();
-            return ids.Any() ? String.Join(" ", ids.Take(20)) : "";
+
+            return base.FormatSelectionText(ids);
         }
 
         protected override TSelection GetModelObjectFromIdentifer(string id)
@@ -502,7 +503,7 @@ namespace Dynamo.Nodes
                     .Where(el => el != null)
                     .Select(el => el.Id);
 
-            return ids.Any() ? String.Join(" ", ids.Take(20)) : "";
+            return base.FormatSelectionText(ids);
         }
 
         protected override Reference GetModelObjectFromIdentifer(string id)


### PR DESCRIPTION
### Purpose

Currently Dynamo Revit contains a copy of Dynamo's Selection node text formatting logic. This PR removes the duplicated code so that Dynamo Revit nodes use Dynamo's base selection node logic to format their textual representation (list of element ids).

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
