### PR TITLE
Set the UI culture back to default Revit culture after Dynamo is closed.

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -1086,6 +1086,7 @@ namespace Dynamo.Applications
             //the model is shutdown when DynamoView is closed
             ModelState = RevitDynamoModelState.NotStarted;
 
+            // Once Dynamo is closed, we want to set the current UI culture back to the default thread culture.
             System.Globalization.CultureInfo.CurrentUICulture = System.Globalization.CultureInfo.DefaultThreadCurrentCulture;
         }
 

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -1085,6 +1085,8 @@ namespace Dynamo.Applications
 
             //the model is shutdown when DynamoView is closed
             ModelState = RevitDynamoModelState.NotStarted;
+
+            System.Globalization.CultureInfo.CurrentUICulture = System.Globalization.CultureInfo.DefaultThreadCurrentCulture;
         }
 
         /// <summary>


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-7472

This was introduced sometime during the 3.0 version when the locale settings were moved to Dynamo preferences object. When Dynamo is opened, it sets the locale to the one set in Dynamo but after Dynamo is closed, we want to set it back to the default culture in Revit. No changes needed on Dynamo core. 

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@Mikhinja @QilongTang @BogdanZavu 

