### PR TITLE
DYN-7372: Handle crash for Populate Dropdown (master)

### DIFF
--- a/src/Libraries/RevitNodesUI/GenericClasses.cs
+++ b/src/Libraries/RevitNodesUI/GenericClasses.cs
@@ -166,7 +166,7 @@ namespace DSRevitNodesUI
         /// </summary>
         public void PopulateDropDownItems()
         {
-            if (this.EnumerationType != null)
+            if (this.EnumerationType != null && this.EnumerationType.IsEnum)
             {
                 // Clear the dropdown list
                 Items.Clear();


### PR DESCRIPTION
### Purpose

https://jira.autodesk.com/browse/DYN-7372
Fix a crash where Enum.GetNames(EnumerationType) fails due to EnumerationType not being of Type Enum.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers


