### PR TITLE
[DYN-7785] Avoid indefinite marshalling for CPythonEvaluator

### DIFF
--- a/src/DynamoRevit/Models/RevitDynamoModel.cs
+++ b/src/DynamoRevit/Models/RevitDynamoModel.cs
@@ -511,6 +511,13 @@ namespace Dynamo.Applications.Models
                                         }
                                     }
                                     var unmarshalled = pyObj.AsManagedObject(typeof(object));
+
+                                    // Avoid calling this marshaler infinitely.
+                                    if (unmarshalled is Python.Runtime.PyObject)
+                                    {
+                                        return unmarshalled;
+                                    }
+
                                     return UnwrapElementMarshaler.Marshal(unmarshalled);
                                 }
                             }


### PR DESCRIPTION
### Purpose

Fixes the crash here https://jira.autodesk.com/browse/DYN-7785 when using CPython3. This is to fix the Dynamo 3.3 version on Revit 2025.

For Dynamo 3.5, we have it handled inside DynamoCore: https://github.com/DynamoDS/Dynamo/blob/9c9262e21951b779bd44837e77f5f9286f03ed15/src/Libraries/DSCPython/CPythonEvaluator.cs#L489


### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@Mikhinja @twastvedt 
