### PR TITLE
Avoid crash when closing splash screen

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -1079,8 +1079,11 @@ namespace Dynamo.Applications
             if(sender is Dynamo.UI.Views.SplashScreen ss && ss.CloseWasExplicit)
             {
                 DynamoRevitApp.DynamoButtonEnabled = true;
-                //the model is shutdown when splash screen is closed
-                RevitDynamoModel.State = DynamoModel.DynamoModelState.NotStarted;
+                if(RevitDynamoModel != null)
+                {
+                    //the model is shutdown when splash screen is closed
+                    RevitDynamoModel.State = DynamoModel.DynamoModelState.NotStarted;
+                }
             }
         }
 

--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -392,6 +392,12 @@ namespace Dynamo.Applications
                 // Let the host (e.g. Revit) control the rendering mode
                 var save = RenderOptions.ProcessRenderMode;
 
+                if (splashScreen == null)
+                {
+                    RevitDynamoModel.State = DynamoModel.DynamoModelState.NotStarted;
+                    DynamoRevitApp.DynamoButtonEnabled = true;
+                    return;
+                }
                 splashScreen.DynamoView = InitializeCoreView(extCommandData);
 
                 RenderOptions.ProcessRenderMode = save;
@@ -1079,7 +1085,8 @@ namespace Dynamo.Applications
             if(sender is Dynamo.UI.Views.SplashScreen ss && ss.CloseWasExplicit)
             {
                 DynamoRevitApp.DynamoButtonEnabled = true;
-                if(RevitDynamoModel != null)
+
+                if (RevitDynamoModel != null)
                 {
                     //the model is shutdown when splash screen is closed
                     RevitDynamoModel.State = DynamoModel.DynamoModelState.NotStarted;


### PR DESCRIPTION
### Purpose

When closing splash screen before initialization, RevitDynamoModel is still null, causing a crash. So checking for null when closing splash screen.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
