### PR TITLE
DYN-8749 Avoid crash when closing splash screen 

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -397,6 +397,12 @@ namespace Dynamo.Applications
                 // Let the host (e.g. Revit) control the rendering mode
                 var save = RenderOptions.ProcessRenderMode;
 
+                if (splashScreen == null)
+                {
+                    RevitDynamoModel.State = DynamoModel.DynamoModelState.NotStarted;
+                    DynamoRevitApp.DynamoButtonEnabled = true;
+                    return;
+                }
                 splashScreen.DynamoView = InitializeCoreView(extCommandData);
 
                 RenderOptions.ProcessRenderMode = save;
@@ -1085,8 +1091,11 @@ namespace Dynamo.Applications
             if (sender is Dynamo.UI.Views.SplashScreen ss && ss.CloseWasExplicit)
             {
                 DynamoRevitApp.DynamoButtonEnabled = true;
-                //the model is shutdown when splash screen is closed
-                RevitDynamoModel.State = DynamoModel.DynamoModelState.NotStarted;
+                if (RevitDynamoModel != null)
+                {
+                    //the model is shutdown when splash screen is closed
+                    RevitDynamoModel.State = DynamoModel.DynamoModelState.NotStarted;
+                }
             }
 
             splashScreen = null;


### PR DESCRIPTION
### Purpose

When closing splash screen before initialization, RevitDynamoModel is still null, causing a crash. So checking for null when closing splash screen.

I created another PR https://github.com/DynamoDS/DynamoRevit/pull/3161 earlier for 2026.1 (assuming Revit2026 branch will be used for that), if that is not needed and changes in master will end up in 2026.1, feel free to close that.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
