### PR TITLE
DYN-9845 : set categories value from id

### DIFF
--- a/src/Libraries/RevitNodesUI/RevitDropDown.cs
+++ b/src/Libraries/RevitNodesUI/RevitDropDown.cs
@@ -745,14 +745,8 @@ namespace DSRevitNodesUI
                 //In fact this should be the way to do it since display names can change with localization.
                 if (SelectedIndex < 0)
                 {
-                    var allCategories = Enum.GetValues(typeof(BuiltInCategory))
-                        .Cast<BuiltInCategory>()
-                        .Where(x => value.Equals(x.ToString(), StringComparison.OrdinalIgnoreCase));
-
-                    BuiltInCategory foundCategory = allCategories?.FirstOrDefault() ?? BuiltInCategory.INVALID;
-
-                    if (foundCategory != BuiltInCategory.INVALID)
-                    {                        
+                    if (Enum.TryParse(value, true, out BuiltInCategory foundCategory))
+                    {
                         SelectedIndex = Items.ToList().FindIndex(x => ((BuiltInCategory)x.Item) == foundCategory);
                     }
                 }


### PR DESCRIPTION
### Purpose
We want to be able to use the category built-in id if possible.
The usage context here is that the AI ( through DynamoMCP ) is aware of the built-in ids but it is more error prone when it comes to categories names since those are localized.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.

### Reviewers
@Mikhinja 

### FYIs
@johnpierson 
