### PR TITLE
DYN-6615: Optimize 'Element.GetParameterByName' node

### DIFF
--- a/src/Libraries/RevitNodes/Elements/Element.cs
+++ b/src/Libraries/RevitNodes/Elements/Element.cs
@@ -142,7 +142,7 @@ namespace Revit.Elements
                 TransactionManager.Instance.EnsureInTransaction(Document);
                 DocumentManager.Regenerate();
                 var bb = InternalElement.get_BoundingBox(null);
-                if (bb == null)
+                if (bb == null) 
                 {
                     bb = InternalElement.get_BoundingBox(Document.GetElement(InternalElement.OwnerViewId) as Autodesk.Revit.DB.View);
                 }
@@ -178,11 +178,11 @@ namespace Revit.Elements
         /// </summary>
         public bool IsPinned
         {
-            get
+            get 
             {
                 if (InternalElement == null)
                     return false;
-                return this.InternalElement.Pinned;
+                return this.InternalElement.Pinned; 
             }
         }
 
@@ -229,7 +229,7 @@ namespace Revit.Elements
                 var typeId = this.InternalElement.GetTypeId();
                 if (typeId == ElementId.InvalidElementId)
                     return null;
-
+                
                 var doc = DocumentManager.Instance.CurrentDBDocument;
                 return doc.GetElement(typeId).ToDSType(true) as ElementType;
             }
@@ -278,7 +278,7 @@ namespace Revit.Elements
             // closing homeworkspace or the element itself is frozen.
             if (DisposeLogic.IsShuttingDown || DisposeLogic.IsClosingHomeworkspace || IsFrozen)
                 return;
-
+            
             bool didRevitDelete = ElementIDLifecycleManager<long>.GetInstance().IsRevitDeleted(Id);
 
             var elementManager = ElementIDLifecycleManager<long>.GetInstance();
@@ -402,11 +402,10 @@ namespace Revit.Elements
             }
 
             // return deleted elements
-            return deletedElements;
+            return deletedElements; 
         }
 
         #region Get/Set Parameter
-
         /// <summary>
         /// Get a parameter by name of an element
         /// </summary>
@@ -431,32 +430,21 @@ namespace Revit.Elements
             // This happens when a loadable family defines a user parameter with the same name
             // as a built-in parameter.
             //
-            // Optimization: Use GetParameters(string) first which is optimized by Revit API to filter
-            // parameters by name without building the entire parameter collection. If no exact
-            // match is found, fall back to case-insensitive matching via full parameter enumeration.
+            // To resolve duplicate parameter names consistently:
+            // 1. Get all parameters matching the given name (case-sensitive)
+            // 2. Sort by ElementId to prioritize built-in parameters (ID's for built-ins are always < -1)
+            // 3. Prefer the first writable parameter, otherwise use the first read-only parameter
             //
-            // Try GetParameters first (doesn't enumerate all parameters, requires exact name match)
+            // Optimization: Use GetParameters(string) which is optimized by Revit API to filter
+            // parameters by name without enumerating the entire parameter collection. This replaces
+            // the previous manual enumeration via InternalElement.Parameters while maintaining
+            // identical behavior (both use case-sensitive comparison via string.CompareOrdinal).
             //
             var exactMatchParams = InternalElement.GetParameters(parameterName)
                 .Cast<Autodesk.Revit.DB.Parameter>()
                 .OrderBy(x => x.Id.Value);
 
-            if (exactMatchParams.Any())
-            {
-                return exactMatchParams.FirstOrDefault(x => !x.IsReadOnly) ?? exactMatchParams.FirstOrDefault();
-            }
-
-            // Fallback: Use case-insensitive matching via full parameter enumeration
-            // This handles scenarios where parameter names have mixed case and GetParameters
-            // (which requires exact match) doesn't find them.
-            var allParams =
-                InternalElement.Parameters.Cast<Autodesk.Revit.DB.Parameter>()
-                    .Where(x => string.CompareOrdinal(x.Definition.Name, parameterName) == 0)
-                    .OrderBy(x => x.Id.Value);
-
-            var param = allParams.FirstOrDefault(x => x.IsReadOnly == false) ?? allParams.FirstOrDefault();
-
-            return param;
+            return exactMatchParams.FirstOrDefault(x => !x.IsReadOnly) ?? exactMatchParams.FirstOrDefault();
         }
 
         /// <summary>
@@ -467,7 +455,7 @@ namespace Revit.Elements
         public object GetParameterValueByName(string parameterName)
         {
             var param = GetParameterByName(parameterName);
-
+            
             if (param == null || !param.HasValue)
                 return string.Empty;
 
@@ -911,7 +899,7 @@ namespace Revit.Elements
         public IEnumerable<Element> GetChildElements()
         {
             return GetElementChildren(this.InternalElement);
-
+            
         }
 
         private IEnumerable<Element> GetElementChildren(Autodesk.Revit.DB.Element element)
@@ -1201,7 +1189,7 @@ namespace Revit.Elements
             TransactionManager.Instance.TransactionTaskDone();
             return elements;
         }
-
+        
         /// <summary>
         /// Sets the order in which the geometry of two elements is joined.
         /// </summary>
@@ -1217,13 +1205,13 @@ namespace Revit.Elements
             if (JoinGeometryUtils.IsCuttingElementInJoin(Document, cuttingElement.InternalElement, otherElement.InternalElement))
             {
                 return new List<Element>() { cuttingElement, otherElement };
-            }
+            }         
             TransactionManager.Instance.EnsureInTransaction(Document);
             JoinGeometryUtils.SwitchJoinOrder(Document, cuttingElement.InternalElement, otherElement.InternalElement);
             TransactionManager.Instance.TransactionTaskDone();
             return new List<Element>() { cuttingElement, otherElement };
         }
-
+        
         /// <summary>
         /// Joins the geometry of two elements, if they are intersecting.
         /// </summary>


### PR DESCRIPTION
### Purpose

This PR addresses [DYN-6615](https://jira.autodesk.com/browse/DYN-6615) by optimizing `Element.GetParameterByName` to fix a significant performance bottleneck when processing large numbers of elements (50K+). The issue was identified through profiling which revealed that 58% of execution time was spent in Revit API's `ParameterSet.Insert` operations, triggered by enumerating all parameters via `InternalElement.Parameters` on every call.

**Root Cause Analysis:**

-   `Element.GetParameterByName` was called 50K+ times during graph execution
-   Each call enumerated all parameters via `InternalElement.Parameters`, which triggers expensive Revit API `ParameterSet.Insert` operations
-   Profiling showed this was the primary hot path (58% of total execution time)

**Solution:**

The optimization replaces manual parameter enumeration (`InternalElement.Parameters`) with `GetParameters(string name)`, which is optimized by the Revit API to filter parameters by name without building the entire parameter collection. This avoids the expensive `ParameterSet.Insert` operations that occur when enumerating all parameters. Both the original implementation and `GetParameters(string)` use case-sensitive comparison (`string.CompareOrdinal`), ensuring identical behavior while providing significant performance improvements.

**Performance Impact:**

Performance testing was conducted using Dynamo TuneUp extension (end-to-end node execution including Dynamo engine/DesignScript VM overhead) with 50,000 element operations. Three approaches were evaluated:

-   **Unoptimized**: Manual enumeration via `InternalElement.Parameters` with LINQ filtering (original implementation)
-   **LookupParameter**: Using `InternalElement.LookupParameter(string)` for direct parameter lookup
-   **GetParameters**: Using `InternalElement.GetParameters(string)` to filter parameters by name (chosen solution)

| Method              | Run 1 (ms) | Run 2 (ms) | Run 3 (ms) | Average (ms)  | Improvement vs Unoptimized | Speedup Factor |
| ------------------- | ---------- | ---------- | ---------- | ------------- | -------------------------- | -------------- |
| **Unoptimized**     | 66,288     | 65,438     | 66,710     | **66,145.33** | Baseline                   | 1.0x           |
| **LookupParameter** | 3,800      | 3,824      | 3,810      | **3,811.33**  | **94.2% faster**           | **17.4x**      |
| **GetParameters**   | 3,958      | 3,983      | 3,963      | **3,968.00**  | **94.0% faster**           | **16.7x**      |

**Summary:**

-   **~17x faster** using `GetParameters(string)` compared to manual enumeration
-   **~94% reduction** in execution time
-   **~62 seconds saved** per 50K element operation
-   `GetParameters(string)` was chosen over `LookupParameter(string)` as both show virtually identical performance (~3.8-4.0 seconds vs ~66 seconds), and `GetParameters` provides better handling of duplicate parameter names
-   **Backward compatibility maintained**: Both the original implementation and `GetParameters` use case-sensitive comparison (`string.CompareOrdinal`), ensuring identical behavior and no regression for existing graphs

The implementation maintains backward compatibility by preserving the original behavior (case-sensitive matching, duplicate parameter names, read-only parameter handling) while optimizing performance through the Revit API's efficient parameter filtering.

### Declarations

Check these if you believe they are true

-   [x] The code base is in a better state after this PR
-   [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
-   [x] The level of testing this PR includes is appropriate
-   [x] User facing strings, if any, are extracted into `*.resx` files
-   [ ] Snapshot of UI changes, if any. (N/A - No UI changes)

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

**Test Methodology:**

-   Performance testing was conducted with 50,000 element operations
-   Multiple test runs were performed to ensure consistency
-   Results are documented in `logs/notes.md`

**Implementation Details:**

-   Uses `GetParameters(string)` which is optimized by Revit API to filter by parameter name
-   Maintains case-sensitive comparison (same as original `string.CompareOrdinal` behavior)
-   Handles duplicate parameter names and read-only parameters correctly (prefers writable parameters)
-   Maintains identical behavior and return values with the original implementation

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
