### PR TITLE
Add PropertyLine and PropertyTableEntry nodes

### DIFF
--- a/src/DynamoRevit/Resources/LayoutSpecs.json
+++ b/src/DynamoRevit/Resources/LayoutSpecs.json
@@ -215,6 +215,12 @@
                   "path": "RevitNodes.Revit.Elements.Mullion"
                 },
                 {
+                  "path": "RevitNodes.Revit.Elements.PropertyLine"
+                },
+                {
+                  "path": "RevitNodes.Revit.Elements.PropertyTableEntry"
+                },
+                {
                   "path": "RevitNodes.Revit.Elements.ReferencePlane"
                 },
                 {

--- a/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
+++ b/src/Libraries/RevitNodes/Elements/InternalUtilities/ElementWrapper.cs
@@ -249,6 +249,11 @@ namespace Revit.Elements
             return ToposolidType.FromExisting(toposolidType, isRevitOwned);
         }
 
+        public static PropertyLine Wrap(Autodesk.Revit.DB.PropertyLine propertyLine, bool isRevitOwned)
+        {
+            return PropertyLine.FromExisting(propertyLine, isRevitOwned);
+        }
+
         public static object Wrap(Autodesk.Revit.DB.Panel ele, bool isRevitOwned)
         {
             if (AdaptiveComponentInstanceUtils.IsAdaptiveFamilySymbol(ele.Symbol))

--- a/src/Libraries/RevitNodes/Elements/PropertyLine.cs
+++ b/src/Libraries/RevitNodes/Elements/PropertyLine.cs
@@ -1,0 +1,474 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.DesignScript.Geometry;
+using Autodesk.DesignScript.Runtime;
+using Autodesk.Revit.DB;
+using Revit.GeometryConversion;
+using RevitServices.Persistence;
+using RevitServices.Transactions;
+using Curve = Autodesk.DesignScript.Geometry.Curve;
+using DBPropertyLine = Autodesk.Revit.DB.PropertyLine;
+using Pt = Autodesk.DesignScript.Geometry.Point;
+
+namespace Revit.Elements
+{
+    /// <summary>
+    /// A Revit PropertyLine element. PropertyLine elements describe site boundaries
+    /// either by an arbitrary set of horizontal sketch curves, or by a table of
+    /// distance/bearing entries.
+    /// </summary>
+    public class PropertyLine : Element
+    {
+        #region Internal properties
+
+        /// <summary>
+        /// Internal handle on the Revit PropertyLine.
+        /// </summary>
+        internal DBPropertyLine InternalPropertyLine
+        {
+            get; private set;
+        }
+
+        /// <summary>
+        /// Reference to the wrapped element.
+        /// </summary>
+        [SupressImportIntoVM]
+        public override Autodesk.Revit.DB.Element InternalElement
+        {
+            get { return InternalPropertyLine; }
+        }
+
+        #endregion
+
+        #region Private constructors
+
+        private PropertyLine(DBPropertyLine propertyLine)
+        {
+            SafeInit(() => InitPropertyLine(propertyLine), true);
+        }
+
+        private PropertyLine(IList<CurveLoop> curveLoops)
+        {
+            SafeInit(() => InitPropertyLine(curveLoops));
+        }
+
+        private PropertyLine(IList<Autodesk.Revit.DB.PropertyTableEntry> entries)
+        {
+            SafeInit(() => InitPropertyLine(entries));
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        private void InitPropertyLine(DBPropertyLine propertyLine)
+        {
+            InternalSetPropertyLine(propertyLine);
+        }
+
+        private void InitPropertyLine(IList<CurveLoop> curveLoops)
+        {
+            TransactionManager.Instance.EnsureInTransaction(Document);
+
+            DBPropertyLine propertyLine = DBPropertyLine.Create(Document, curveLoops);
+            InternalSetPropertyLine(propertyLine);
+
+            TransactionManager.Instance.TransactionTaskDone();
+
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalPropertyLine);
+        }
+
+        private void InitPropertyLine(IList<Autodesk.Revit.DB.PropertyTableEntry> entries)
+        {
+            TransactionManager.Instance.EnsureInTransaction(Document);
+
+            DBPropertyLine propertyLine = DBPropertyLine.Create(Document, entries);
+            InternalSetPropertyLine(propertyLine);
+
+            TransactionManager.Instance.TransactionTaskDone();
+
+            ElementBinder.CleanupAndSetElementForTrace(Document, InternalPropertyLine);
+        }
+
+        #endregion
+
+        #region Private mutators
+
+        private void InternalSetPropertyLine(DBPropertyLine propertyLine)
+        {
+            InternalPropertyLine = propertyLine;
+            InternalElementId = propertyLine.Id;
+            InternalUniqueId = propertyLine.UniqueId;
+        }
+
+        #endregion
+
+        #region Public properties
+
+        /// <summary>
+        /// Returns the boundary curve loops of a sketch-based PropertyLine as PolyCurves.
+        /// Throws when invoked on a table-based PropertyLine.
+        /// </summary>
+        public PolyCurve[] Boundary
+        {
+            get
+            {
+                IList<CurveLoop> loops = InternalPropertyLine.GetBoundary();
+                return loops.Select(ConvertCurveLoopToPolyCurve).ToArray();
+            }
+        }
+
+        /// <summary>
+        /// The start point of the PropertyLine, in Dynamo units.
+        /// </summary>
+        public Pt Start
+        {
+            get { return InternalPropertyLine.GetStart().ToPoint(); }
+        }
+
+        /// <summary>
+        /// The PropertyTableEntry rows of a table-based PropertyLine.
+        /// Throws when invoked on a sketch-based PropertyLine.
+        /// </summary>
+        public PropertyTableEntry[] PropertyTable
+        {
+            get
+            {
+                IList<Autodesk.Revit.DB.PropertyTableEntry> entries = InternalPropertyLine.GetPropertyTable();
+                return entries.Select(PropertyTableEntry.FromExisting).ToArray();
+            }
+        }
+
+        /// <summary>
+        /// The area of the PropertyLine. Returns -1 when the PropertyLine is not a closed loop.
+        /// </summary>
+        public double Area => InternalPropertyLine.Area;
+
+        /// <summary>
+        /// True when the PropertyLine forms a closed loop.
+        /// </summary>
+        public bool IsClosedLoop => InternalPropertyLine.IsClosedLoop();
+
+        /// <summary>
+        /// True when the PropertyLine is sketch-based; false when it is table-based.
+        /// </summary>
+        public bool IsSketchBased => InternalPropertyLine.IsSketchBased();
+
+        /// <summary>
+        /// True when a sketch-based PropertyLine can be converted to a table-based one
+        /// (i.e. its sketch only contains lines and arcs).
+        /// </summary>
+        public bool IsValidToConvert => InternalPropertyLine.IsValidToConvert();
+
+        /// <summary>
+        /// The Sketch element backing a sketch-based PropertyLine, or null for a table-based one.
+        /// </summary>
+        public Element Sketch
+        {
+            get
+            {
+                ElementId sketchId = InternalPropertyLine.SketchId;
+                if (sketchId == null || sketchId == ElementId.InvalidElementId)
+                {
+                    return null;
+                }
+
+                Autodesk.Revit.DB.Element revitElement = Document.GetElement(sketchId);
+                return revitElement?.ToDSType(true) as Element;
+            }
+        }
+
+        #endregion
+
+        #region Public static constructors
+
+        /// <summary>
+        /// Creates a sketch-based PropertyLine from a single PolyCurve outline.
+        /// The outline does not need to be closed, but it must lie on a plane parallel to the XY plane.
+        /// </summary>
+        public static PropertyLine ByCurveLoops(PolyCurve outline)
+        {
+            if (outline == null)
+            {
+                throw new ArgumentNullException(nameof(outline));
+            }
+
+            return ByPolyCurves(new[] { outline });
+        }
+
+        /// <summary>
+        /// Creates a sketch-based PropertyLine from a list of curves that will be joined into a single
+        /// PolyCurve outline.
+        /// </summary>
+        public static PropertyLine ByCurveLoops(Curve[] outlineCurves)
+        {
+            if (outlineCurves == null)
+            {
+                throw new ArgumentNullException(nameof(outlineCurves));
+            }
+
+            PolyCurve outline = PolyCurve.ByJoinedCurves(outlineCurves, 0.001, false);
+            return ByCurveLoops(outline);
+        }
+
+        /// <summary>
+        /// Creates a sketch-based PropertyLine from one or more PolyCurve outlines.
+        /// Each outline must be planar and lie on a plane parallel to the XY plane; the outlines
+        /// must not intersect each other.
+        /// </summary>
+        public static PropertyLine ByPolyCurves(PolyCurve[] outlines)
+        {
+            if (outlines == null)
+            {
+                throw new ArgumentNullException(nameof(outlines));
+            }
+
+            if (outlines.Length == 0)
+            {
+                throw new ArgumentException(Properties.Resources.PropertyLineInvalidBoundary, nameof(outlines));
+            }
+
+            List<CurveLoop> loops = ConvertOutlinesToCurveLoops(outlines);
+
+            if (!DBPropertyLine.IsValidBoundary(loops))
+            {
+                throw new ArgumentException(Properties.Resources.PropertyLineInvalidBoundary, nameof(outlines));
+            }
+
+            var propertyLine = new PropertyLine(loops);
+            DocumentManager.Regenerate();
+            return propertyLine;
+        }
+
+        /// <summary>
+        /// Creates a table-based PropertyLine from a sequence of PropertyTableEntry rows.
+        /// </summary>
+        public static PropertyLine ByPropertyTableEntries(PropertyTableEntry[] entries)
+        {
+            if (entries == null)
+            {
+                throw new ArgumentNullException(nameof(entries));
+            }
+
+            if (entries.Length == 0)
+            {
+                throw new ArgumentException(Properties.Resources.PropertyLineInvalidPropertyTable, nameof(entries));
+            }
+
+            List<Autodesk.Revit.DB.PropertyTableEntry> revitEntries =
+                entries.Select(e => e?.InternalPropertyTableEntry
+                                    ?? throw new ArgumentException(Properties.Resources.PropertyLineInvalidPropertyTable, nameof(entries)))
+                       .ToList();
+
+            if (!DBPropertyLine.IsValidPropertyTable(Document, revitEntries))
+            {
+                throw new ArgumentException(Properties.Resources.PropertyLineInvalidPropertyTable, nameof(entries));
+            }
+
+            var propertyLine = new PropertyLine(revitEntries);
+            DocumentManager.Regenerate();
+            return propertyLine;
+        }
+
+        /// <summary>
+        /// Returns true when the supplied PolyCurves form a valid PropertyLine boundary
+        /// (planar, horizontal, non-self-intersecting, no unbounded circles or ellipses).
+        /// </summary>
+        public static bool IsValidBoundary(PolyCurve[] outlines)
+        {
+            if (outlines == null || outlines.Length == 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                List<CurveLoop> loops = ConvertOutlinesToCurveLoops(outlines);
+                return DBPropertyLine.IsValidBoundary(loops);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true when the supplied PropertyTableEntry rows form a valid table-based PropertyLine.
+        /// </summary>
+        public static bool IsValidPropertyTable(PropertyTableEntry[] entries)
+        {
+            if (entries == null || entries.Length == 0 || entries.Any(e => e == null))
+            {
+                return false;
+            }
+
+            List<Autodesk.Revit.DB.PropertyTableEntry> revitEntries =
+                entries.Select(e => e.InternalPropertyTableEntry).ToList();
+            return DBPropertyLine.IsValidPropertyTable(Document, revitEntries);
+        }
+
+        #endregion
+
+        #region Public mutators
+
+        /// <summary>
+        /// Replaces the boundary of a sketch-based PropertyLine with the supplied outlines.
+        /// </summary>
+        public PropertyLine SetBoundary(PolyCurve[] outlines)
+        {
+            if (outlines == null)
+            {
+                throw new ArgumentNullException(nameof(outlines));
+            }
+
+            List<CurveLoop> loops = ConvertOutlinesToCurveLoops(outlines);
+
+            if (!DBPropertyLine.IsValidBoundary(loops))
+            {
+                throw new ArgumentException(Properties.Resources.PropertyLineInvalidBoundary, nameof(outlines));
+            }
+
+            TransactionManager.Instance.EnsureInTransaction(Document);
+            InternalPropertyLine.SetBoundary(loops);
+            TransactionManager.Instance.TransactionTaskDone();
+
+            DocumentManager.Regenerate();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the start point of a table-based PropertyLine.
+        /// Throws when invoked on a sketch-based PropertyLine.
+        /// </summary>
+        public PropertyLine SetStart(Pt start)
+        {
+            if (start == null)
+            {
+                throw new ArgumentNullException(nameof(start));
+            }
+
+            if (InternalPropertyLine.IsSketchBased())
+            {
+                throw new InvalidOperationException(Properties.Resources.PropertyLineNotTableBased);
+            }
+
+            TransactionManager.Instance.EnsureInTransaction(Document);
+            InternalPropertyLine.SetStart(start.ToXyz());
+            TransactionManager.Instance.TransactionTaskDone();
+
+            DocumentManager.Regenerate();
+            return this;
+        }
+
+        /// <summary>
+        /// Replaces the table entries of a table-based PropertyLine.
+        /// Throws when invoked on a sketch-based PropertyLine.
+        /// </summary>
+        public PropertyLine SetPropertyTable(PropertyTableEntry[] entries)
+        {
+            if (entries == null)
+            {
+                throw new ArgumentNullException(nameof(entries));
+            }
+
+            if (InternalPropertyLine.IsSketchBased())
+            {
+                throw new InvalidOperationException(Properties.Resources.PropertyLineNotTableBased);
+            }
+
+            List<Autodesk.Revit.DB.PropertyTableEntry> revitEntries =
+                entries.Select(e => e?.InternalPropertyTableEntry
+                                    ?? throw new ArgumentException(Properties.Resources.PropertyLineInvalidPropertyTable, nameof(entries)))
+                       .ToList();
+
+            TransactionManager.Instance.EnsureInTransaction(Document);
+            InternalPropertyLine.SetPropertyTable(revitEntries);
+            TransactionManager.Instance.TransactionTaskDone();
+
+            DocumentManager.Regenerate();
+            return this;
+        }
+
+        /// <summary>
+        /// Converts a sketch-based PropertyLine to a table-based PropertyLine. The underlying sketch
+        /// must contain only lines and arcs (see <see cref="IsValidToConvert"/>).
+        /// </summary>
+        public PropertyLine ConvertToTable()
+        {
+            if (!InternalPropertyLine.IsSketchBased())
+            {
+                throw new InvalidOperationException(Properties.Resources.PropertyLineConvertFailed);
+            }
+
+            if (!InternalPropertyLine.IsValidToConvert())
+            {
+                throw new InvalidOperationException(Properties.Resources.PropertyLineConvertFailed);
+            }
+
+            TransactionManager.Instance.EnsureInTransaction(Document);
+            InternalPropertyLine.ConvertToTable();
+            TransactionManager.Instance.TransactionTaskDone();
+
+            DocumentManager.Regenerate();
+            return this;
+        }
+
+        #endregion
+
+        #region Internal static constructors
+
+        /// <summary>
+        /// Wraps a Revit-owned PropertyLine in the Dynamo PropertyLine wrapper.
+        /// </summary>
+        internal static PropertyLine FromExisting(DBPropertyLine propertyLine, bool isRevitOwned)
+        {
+            return new PropertyLine(propertyLine)
+            {
+                IsRevitOwned = isRevitOwned
+            };
+        }
+
+        #endregion
+
+        #region Geometry helpers
+
+        private static List<CurveLoop> ConvertOutlinesToCurveLoops(PolyCurve[] outlines)
+        {
+            var loops = new List<CurveLoop>(outlines.Length);
+            foreach (PolyCurve outline in outlines)
+            {
+                if (outline == null)
+                {
+                    throw new ArgumentException(Properties.Resources.PropertyLineInvalidBoundary, nameof(outlines));
+                }
+
+                var loop = new CurveLoop();
+                foreach (Curve curve in outline.Curves())
+                {
+                    loop.Append(curve.ToRevitType());
+                }
+                loops.Add(loop);
+            }
+            return loops;
+        }
+
+        private static PolyCurve ConvertCurveLoopToPolyCurve(CurveLoop loop)
+        {
+            var protoCurves = loop.Select(c => c.ToProtoType(true)).ToArray();
+            try
+            {
+                return PolyCurve.ByJoinedCurves(protoCurves, 0.001, false);
+            }
+            finally
+            {
+                foreach (Curve c in protoCurves)
+                {
+                    c.Dispose();
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Libraries/RevitNodes/Elements/PropertyTableEntry.cs
+++ b/src/Libraries/RevitNodes/Elements/PropertyTableEntry.cs
@@ -1,0 +1,171 @@
+using System;
+using Autodesk.DesignScript.Runtime;
+using DBPropertyTableEntry = Autodesk.Revit.DB.PropertyTableEntry;
+using DBCurveType = Autodesk.Revit.DB.PropertyTableEntryCurveType;
+using DBArcDirection = Autodesk.Revit.DB.PropertyTableEntryArcDirection;
+
+namespace Revit.Elements
+{
+    /// <summary>
+    /// A row of a table-driven Revit PropertyLine element.
+    /// </summary>
+    public class PropertyTableEntry
+    {
+        #region Internal properties
+
+        /// <summary>
+        /// Internal handle on the underlying Revit PropertyTableEntry.
+        /// </summary>
+        [SupressImportIntoVM]
+        internal DBPropertyTableEntry InternalPropertyTableEntry { get; private set; }
+
+        #endregion
+
+        #region Private constructors
+
+        private PropertyTableEntry(DBPropertyTableEntry entry)
+        {
+            InternalPropertyTableEntry = entry;
+        }
+
+        private PropertyTableEntry(double distance, double bearing, DBCurveType curveType, double arcRadius, DBArcDirection arcDirection, int id)
+        {
+            if (!DBPropertyTableEntry.IsValidPropertyTableEntry(distance, bearing, curveType, arcRadius, arcDirection))
+            {
+                throw new ArgumentException(Properties.Resources.PropertyTableEntryInvalid);
+            }
+
+            InternalPropertyTableEntry = DBPropertyTableEntry.Create(distance, bearing, curveType, arcRadius, arcDirection, id);
+        }
+
+        #endregion
+
+        #region Public properties
+
+        /// <summary>
+        /// The distance, in feet, between the start and end points of this entry.
+        /// </summary>
+        public double Distance => InternalPropertyTableEntry.Distance;
+
+        /// <summary>
+        /// The bearing angle, in radians (0 to 2*PI), of this entry.
+        /// </summary>
+        public double Bearing => InternalPropertyTableEntry.Bearing;
+
+        /// <summary>
+        /// The arc radius, in feet, when this entry is an arc. Unused for line entries.
+        /// </summary>
+        public double Radius => InternalPropertyTableEntry.Radius;
+
+        /// <summary>
+        /// The curve type represented by this entry, either Line or Arc.
+        /// </summary>
+        public DBCurveType CurveType => InternalPropertyTableEntry.CurveType;
+
+        /// <summary>
+        /// For arc entries, indicates whether the arc bulges to the Left or the Right of the line segment.
+        /// </summary>
+        public DBArcDirection ArcDirection => InternalPropertyTableEntry.ArcDirection;
+
+        /// <summary>
+        /// The unique identifier of this entry within its property table.
+        /// </summary>
+        public int Id => InternalPropertyTableEntry.Id;
+
+        #endregion
+
+        #region Public static constructors
+
+        /// <summary>
+        /// Creates a line-segment PropertyTableEntry.
+        /// </summary>
+        /// <param name="distance">Distance, in feet, between the segment's start and end points.</param>
+        /// <param name="bearing">Bearing angle, in radians (0 to 2*PI).</param>
+        /// <param name="id">Optional unique identifier for this entry; defaults to -1.</param>
+        public static PropertyTableEntry ByLine(double distance, double bearing, int id = -1)
+        {
+            return new PropertyTableEntry(distance, bearing, DBCurveType.Line, 0.0, DBArcDirection.Right, id);
+        }
+
+        /// <summary>
+        /// Creates an arc-segment PropertyTableEntry.
+        /// </summary>
+        /// <param name="distance">Distance, in feet, between the segment's start and end points.</param>
+        /// <param name="bearing">Bearing angle, in radians (0 to 2*PI), of the chord.</param>
+        /// <param name="radius">Arc radius, in feet. Must be greater than half of <paramref name="distance"/>.</param>
+        /// <param name="direction">"Left" or "Right" — which side of the chord the arc bulges towards.</param>
+        /// <param name="id">Optional unique identifier for this entry; defaults to -1.</param>
+        public static PropertyTableEntry ByArc(double distance, double bearing, double radius, string direction = "Right", int id = -1)
+        {
+            if (string.IsNullOrEmpty(direction))
+            {
+                throw new ArgumentNullException(nameof(direction));
+            }
+
+            if (!Enum.TryParse(direction, true, out DBArcDirection parsedDirection))
+            {
+                throw new ArgumentException(Properties.Resources.PropertyTableEntryInvalid, nameof(direction));
+            }
+
+            return new PropertyTableEntry(distance, bearing, DBCurveType.Arc, radius, parsedDirection, id);
+        }
+
+        /// <summary>
+        /// Creates a PropertyTableEntry by explicitly specifying every Revit-API field.
+        /// </summary>
+        /// <param name="distance">Distance, in feet, between the segment's start and end points.</param>
+        /// <param name="bearing">Bearing angle, in radians (0 to 2*PI).</param>
+        /// <param name="curveType">Curve type for this entry.</param>
+        /// <param name="arcRadius">Arc radius, in feet (only used when <paramref name="curveType"/> is Arc).</param>
+        /// <param name="arcDirection">Arc direction (only used when <paramref name="curveType"/> is Arc).</param>
+        /// <param name="id">Optional unique identifier for this entry; defaults to -1.</param>
+        public static PropertyTableEntry ByValues(
+            double distance,
+            double bearing,
+            DBCurveType curveType,
+            double arcRadius = 0.0,
+            DBArcDirection arcDirection = DBArcDirection.Right,
+            int id = -1)
+        {
+            return new PropertyTableEntry(distance, bearing, curveType, arcRadius, arcDirection, id);
+        }
+
+        /// <summary>
+        /// Returns true if the supplied values would form a valid PropertyTableEntry.
+        /// </summary>
+        public static bool IsValid(
+            double distance,
+            double bearing,
+            DBCurveType curveType,
+            double arcRadius = 0.0,
+            DBArcDirection arcDirection = DBArcDirection.Right)
+        {
+            return DBPropertyTableEntry.IsValidPropertyTableEntry(distance, bearing, curveType, arcRadius, arcDirection);
+        }
+
+        #endregion
+
+        #region Internal helpers
+
+        [SupressImportIntoVM]
+        internal static PropertyTableEntry FromExisting(DBPropertyTableEntry entry)
+        {
+            if (entry == null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            return new PropertyTableEntry(entry);
+        }
+
+        #endregion
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return CurveType == DBCurveType.Arc
+                ? $"PropertyTableEntry(Arc, Distance={Distance}, Bearing={Bearing}, Radius={Radius}, ArcDirection={ArcDirection}, Id={Id})"
+                : $"PropertyTableEntry(Line, Distance={Distance}, Bearing={Bearing}, Id={Id})";
+        }
+    }
+}

--- a/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
+++ b/src/Libraries/RevitNodes/Properties/Resources.Designer.cs
@@ -1240,6 +1240,51 @@ namespace Revit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to convert the PropertyLine to a table-based representation. The PropertyLine must already be sketch-based and its sketch must contain only lines and arcs..
+        /// </summary>
+        internal static string PropertyLineConvertFailed {
+            get {
+                return ResourceManager.GetString("PropertyLineConvertFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The provided curve loops are not a valid PropertyLine boundary. Each loop must be planar, lie on a plane parallel to the XY plane, and must not self-intersect or contain unbounded circles or ellipses..
+        /// </summary>
+        internal static string PropertyLineInvalidBoundary {
+            get {
+                return ResourceManager.GetString("PropertyLineInvalidBoundary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The provided PropertyTable entries are not valid for creating a PropertyLine. Check that distances are not too short and that arc radii are greater than half their segment distance..
+        /// </summary>
+        internal static string PropertyLineInvalidPropertyTable {
+            get {
+                return ResourceManager.GetString("PropertyLineInvalidPropertyTable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This operation is only valid on table-based PropertyLine elements..
+        /// </summary>
+        internal static string PropertyLineNotTableBased {
+            get {
+                return ResourceManager.GetString("PropertyLineNotTableBased", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The provided distance, bearing, radius, and direction do not form a valid PropertyTableEntry..
+        /// </summary>
+        internal static string PropertyTableEntryInvalid {
+            get {
+                return ResourceManager.GetString("PropertyTableEntryInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Revit can only create a ReferenceCurve in a Family Document..
         /// </summary>
         internal static string ReferenceCurveCreationFailure {

--- a/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.en-US.resx
@@ -426,6 +426,21 @@
   <data name="PolyCurvesConversionError" xml:space="preserve">
     <value>Revit does not support turning PolyCurves into ModelCurves. Try exploding your PolyCurve into multiple Curves.</value>
   </data>
+  <data name="PropertyLineConvertFailed" xml:space="preserve">
+    <value>Failed to convert the PropertyLine to a table-based representation. The PropertyLine must already be sketch-based and its sketch must contain only lines and arcs.</value>
+  </data>
+  <data name="PropertyLineInvalidBoundary" xml:space="preserve">
+    <value>The provided curve loops are not a valid PropertyLine boundary. Each loop must be planar, lie on a plane parallel to the XY plane, and must not self-intersect or contain unbounded circles or ellipses.</value>
+  </data>
+  <data name="PropertyLineInvalidPropertyTable" xml:space="preserve">
+    <value>The provided PropertyTable entries are not valid for creating a PropertyLine. Check that distances are not too short and that arc radii are greater than half their segment distance.</value>
+  </data>
+  <data name="PropertyLineNotTableBased" xml:space="preserve">
+    <value>This operation is only valid on table-based PropertyLine elements.</value>
+  </data>
+  <data name="PropertyTableEntryInvalid" xml:space="preserve">
+    <value>The provided distance, bearing, radius, and direction do not form a valid PropertyTableEntry.</value>
+  </data>
   <data name="ReferenceCurveCreationFailure" xml:space="preserve">
     <value>Revit can only create a ReferenceCurve in a Family Document.</value>
   </data>

--- a/src/Libraries/RevitNodes/Properties/Resources.resx
+++ b/src/Libraries/RevitNodes/Properties/Resources.resx
@@ -441,6 +441,21 @@
   <data name="PolyCurvesConversionError" xml:space="preserve">
     <value>Revit does not support turning PolyCurves into ModelCurves. Try exploding your PolyCurve into multiple Curves.</value>
   </data>
+  <data name="PropertyLineConvertFailed" xml:space="preserve">
+    <value>Failed to convert the PropertyLine to a table-based representation. The PropertyLine must already be sketch-based and its sketch must contain only lines and arcs.</value>
+  </data>
+  <data name="PropertyLineInvalidBoundary" xml:space="preserve">
+    <value>The provided curve loops are not a valid PropertyLine boundary. Each loop must be planar, lie on a plane parallel to the XY plane, and must not self-intersect or contain unbounded circles or ellipses.</value>
+  </data>
+  <data name="PropertyLineInvalidPropertyTable" xml:space="preserve">
+    <value>The provided PropertyTable entries are not valid for creating a PropertyLine. Check that distances are not too short and that arc radii are greater than half their segment distance.</value>
+  </data>
+  <data name="PropertyLineNotTableBased" xml:space="preserve">
+    <value>This operation is only valid on table-based PropertyLine elements.</value>
+  </data>
+  <data name="PropertyTableEntryInvalid" xml:space="preserve">
+    <value>The provided distance, bearing, radius, and direction do not form a valid PropertyTableEntry.</value>
+  </data>
   <data name="ReferenceCurveCreationFailure" xml:space="preserve">
     <value>Revit can only create a ReferenceCurve in a Family Document.</value>
   </data>

--- a/test/Libraries/RevitNodesTests/Elements/PropertyLineTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/PropertyLineTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Linq;
+using Autodesk.DesignScript.Geometry;
+using NUnit.Framework;
+using Revit.Elements;
+using RevitTestServices;
+using RTF.Framework;
+using DBArcDirection = Autodesk.Revit.DB.PropertyTableEntryArcDirection;
+using DBCurveType = Autodesk.Revit.DB.PropertyTableEntryCurveType;
+
+namespace RevitNodesTests.Elements
+{
+    [TestFixture]
+    public class PropertyLineTests : RevitNodeTestBase
+    {
+        private const double Tolerance = 1e-6;
+
+        private static PolyCurve MakeSquareOutline(double size = 100)
+        {
+            var lines = new[]
+            {
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 0, 0), Point.ByCoordinates(size, 0, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(size, 0, 0), Point.ByCoordinates(size, size, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(size, size, 0), Point.ByCoordinates(0, size, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, size, 0), Point.ByCoordinates(0, 0, 0))
+            };
+            return PolyCurve.ByJoinedCurves(lines, 0.001, false);
+        }
+
+        private static PolyCurve MakeVerticalSquare(double size = 100)
+        {
+            var lines = new[]
+            {
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 0, 0), Point.ByCoordinates(size, 0, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(size, 0, 0), Point.ByCoordinates(size, 0, size)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(size, 0, size), Point.ByCoordinates(0, 0, size)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 0, size), Point.ByCoordinates(0, 0, 0))
+            };
+            return PolyCurve.ByJoinedCurves(lines, 0.001, false);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByCurveLoops_PolyCurve_CreatesSketchBasedPropertyLine()
+        {
+            var outline = MakeSquareOutline();
+
+            var propertyLine = PropertyLine.ByCurveLoops(outline);
+
+            Assert.NotNull(propertyLine);
+            Assert.IsTrue(propertyLine.IsSketchBased);
+            Assert.IsTrue(propertyLine.IsClosedLoop);
+            Assert.AreEqual(1, propertyLine.Boundary.Length);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByCurveLoops_CurveArray_CreatesSketchBasedPropertyLine()
+        {
+            var outline = new[]
+            {
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 0, 0), Point.ByCoordinates(100, 0, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(100, 0, 0), Point.ByCoordinates(100, 100, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(100, 100, 0), Point.ByCoordinates(0, 100, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 100, 0), Point.ByCoordinates(0, 0, 0))
+            };
+
+            var propertyLine = PropertyLine.ByCurveLoops(outline);
+
+            Assert.NotNull(propertyLine);
+            Assert.IsTrue(propertyLine.IsSketchBased);
+            Assert.IsTrue(propertyLine.IsClosedLoop);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByCurveLoops_NullArguments_Throw()
+        {
+            Assert.Throws<ArgumentNullException>(() => PropertyLine.ByCurveLoops((PolyCurve)null));
+            Assert.Throws<ArgumentNullException>(() => PropertyLine.ByCurveLoops((Curve[])null));
+            Assert.Throws<ArgumentNullException>(() => PropertyLine.ByPolyCurves(null));
+            Assert.Throws<ArgumentException>(() => PropertyLine.ByPolyCurves(Array.Empty<PolyCurve>()));
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void IsValidBoundary_ReturnsFalseForVerticalLoop()
+        {
+            var verticalOutline = MakeVerticalSquare();
+
+            Assert.IsFalse(PropertyLine.IsValidBoundary(new[] { verticalOutline }));
+            Assert.IsFalse(PropertyLine.IsValidBoundary(null));
+            Assert.IsFalse(PropertyLine.IsValidBoundary(Array.Empty<PolyCurve>()));
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void IsValidBoundary_ReturnsTrueForHorizontalSquare()
+        {
+            var outline = MakeSquareOutline();
+
+            Assert.IsTrue(PropertyLine.IsValidBoundary(new[] { outline }));
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByPropertyTableEntries_FourLines_CreatesTableBasedPropertyLine()
+        {
+            // Bearings are in radians; build a closed square: east, north, west, south.
+            var entries = new[]
+            {
+                PropertyTableEntry.ByLine(50.0, Math.PI / 2),
+                PropertyTableEntry.ByLine(50.0, 0.0),
+                PropertyTableEntry.ByLine(50.0, 3 * Math.PI / 2),
+                PropertyTableEntry.ByLine(50.0, Math.PI)
+            };
+
+            var propertyLine = PropertyLine.ByPropertyTableEntries(entries);
+
+            Assert.NotNull(propertyLine);
+            Assert.IsFalse(propertyLine.IsSketchBased);
+            Assert.AreEqual(4, propertyLine.PropertyTable.Length);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ByPropertyTableEntries_NullOrEmpty_Throw()
+        {
+            Assert.Throws<ArgumentNullException>(() => PropertyLine.ByPropertyTableEntries(null));
+            Assert.Throws<ArgumentException>(() => PropertyLine.ByPropertyTableEntries(Array.Empty<PropertyTableEntry>()));
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void IsValidPropertyTable_ReturnsTrueForValidEntries()
+        {
+            var entries = new[]
+            {
+                PropertyTableEntry.ByLine(50.0, Math.PI / 2),
+                PropertyTableEntry.ByLine(50.0, 0.0),
+                PropertyTableEntry.ByLine(50.0, 3 * Math.PI / 2),
+                PropertyTableEntry.ByLine(50.0, Math.PI)
+            };
+
+            Assert.IsTrue(PropertyLine.IsValidPropertyTable(entries));
+            Assert.IsFalse(PropertyLine.IsValidPropertyTable(null));
+            Assert.IsFalse(PropertyLine.IsValidPropertyTable(Array.Empty<PropertyTableEntry>()));
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void PropertyTableEntry_ByLine_RoundTripsValues()
+        {
+            const double distance = 75.0;
+            const double bearing = Math.PI / 3;
+            const int id = 7;
+
+            var entry = PropertyTableEntry.ByLine(distance, bearing, id);
+
+            Assert.AreEqual(distance, entry.Distance, Tolerance);
+            Assert.AreEqual(bearing, entry.Bearing, Tolerance);
+            Assert.AreEqual(id, entry.Id);
+            Assert.AreEqual(DBCurveType.Line, entry.CurveType);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void PropertyTableEntry_ByArc_RoundTripsValues()
+        {
+            const double distance = 40.0;
+            const double bearing = Math.PI / 4;
+            const double radius = 30.0;
+            const int id = 11;
+
+            var entry = PropertyTableEntry.ByArc(distance, bearing, radius, "Left", id);
+
+            Assert.AreEqual(distance, entry.Distance, Tolerance);
+            Assert.AreEqual(bearing, entry.Bearing, Tolerance);
+            Assert.AreEqual(radius, entry.Radius, Tolerance);
+            Assert.AreEqual(DBCurveType.Arc, entry.CurveType);
+            Assert.AreEqual(DBArcDirection.Left, entry.ArcDirection);
+            Assert.AreEqual(id, entry.Id);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void PropertyTableEntry_ByArc_InvalidDirectionThrows()
+        {
+            Assert.Throws<ArgumentException>(
+                () => PropertyTableEntry.ByArc(40.0, 0.0, 30.0, "Sideways"));
+            Assert.Throws<ArgumentNullException>(
+                () => PropertyTableEntry.ByArc(40.0, 0.0, 30.0, null));
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void PropertyTableEntry_ByValues_RoundTripsValues()
+        {
+            const double distance = 60.0;
+            const double bearing = Math.PI;
+            const double radius = 35.0;
+
+            var entry = PropertyTableEntry.ByValues(
+                distance, bearing, DBCurveType.Arc, radius, DBArcDirection.Right, id: 3);
+
+            Assert.AreEqual(distance, entry.Distance, Tolerance);
+            Assert.AreEqual(bearing, entry.Bearing, Tolerance);
+            Assert.AreEqual(radius, entry.Radius, Tolerance);
+            Assert.AreEqual(DBCurveType.Arc, entry.CurveType);
+            Assert.AreEqual(DBArcDirection.Right, entry.ArcDirection);
+            Assert.AreEqual(3, entry.Id);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void PropertyTableEntry_IsValid_RejectsArcWithRadiusBelowHalfDistance()
+        {
+            // Arc radius must exceed half the chord distance; 5 < 50/2.
+            Assert.IsFalse(PropertyTableEntry.IsValid(
+                distance: 50.0,
+                bearing: 0.0,
+                curveType: DBCurveType.Arc,
+                arcRadius: 5.0,
+                arcDirection: DBArcDirection.Right));
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void ConvertToTable_OnSketchBasedPropertyLine_TurnsItTableBased()
+        {
+            var outline = MakeSquareOutline();
+            var propertyLine = PropertyLine.ByCurveLoops(outline);
+
+            Assume.That(propertyLine.IsSketchBased, Is.True);
+            Assume.That(propertyLine.IsValidToConvert, Is.True);
+
+            propertyLine.ConvertToTable();
+
+            Assert.IsFalse(propertyLine.IsSketchBased);
+            Assert.IsTrue(propertyLine.PropertyTable.Length > 0);
+        }
+    }
+}


### PR DESCRIPTION
Wraps the new Revit 2027 PropertyLine and PropertyTableEntry APIs as Dynamo nodes so that site boundaries can be authored from a graph.

* PropertyLine.ByPolyCurves / ByCurveLoops creates a sketch-based PropertyLine from horizontal PolyCurve outlines; ByPropertyTableEntries creates a table-based one. IsValidBoundary / IsValidPropertyTable expose the matching API validators.
* PropertyLine instance properties surface Boundary, Start, PropertyTable, Area, IsClosedLoop, IsSketchBased, IsValidToConvert, and Sketch. Mutators cover SetBoundary, SetStart, SetPropertyTable, and ConvertToTable.
* PropertyTableEntry exposes ByLine / ByArc convenience factories alongside a generic ByValues factory for callers that want to drive the raw curve-type and arc-direction enums, plus an IsValid validator and the read-only Distance / Bearing / Radius / CurveType / ArcDirection / Id properties.
* ElementWrapper.Wrap learns to round-trip a Revit PropertyLine into the new wrapper so existing element-selection nodes return PropertyLine instances.
* Adds the wrappers to the embedded LayoutSpecs.json so they appear under Revit > Elements in the Dynamo library tree, and adds the corresponding localized error strings to Resources.resx / Resources.en-US.resx / Resources.Designer.cs.
* Adds RevitNodesTests.Elements.PropertyLineTests covering creation, validation, getters, and the sketch-to-table conversion workflow.

# PropertyLine Nodes
<img width="406" height="647" alt="image" src="https://github.com/user-attachments/assets/b73c1165-19ba-497f-a345-d3dcc0a52af1" />

* Data creation: 
<img width="685" height="285" alt="image" src="https://github.com/user-attachments/assets/9aa1f8e8-bda4-4623-9d04-bffda6e1ae23" />

* Action: 
<img width="792" height="578" alt="image" src="https://github.com/user-attachments/assets/2c330af6-30a0-4cda-a56d-c6d83b0b299f" />

* Data query: 
<img width="599" height="509" alt="image" src="https://github.com/user-attachments/assets/9eba7943-ea87-4063-be5b-2cd19001aea0" />

# PropertyTableEntry Nodes
<img width="324" height="407" alt="image" src="https://github.com/user-attachments/assets/62ceff05-6b07-4854-87b7-65090728c715" />

* Data creation & Action: 
<img width="592" height="268" alt="image" src="https://github.com/user-attachments/assets/dc0b4fe2-3e14-45d6-a8ff-d6e9941d2f27" />

* Data query: 
<img width="839" height="436" alt="image" src="https://github.com/user-attachments/assets/cfbcba2a-0da7-4621-8baa-b9690bad49d7" />

Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference 
to the tracking task that it is part or all of the solution for.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
