### PR TITLE
REVIT-250403: Update DynamoForRevit net8.0 references to net10.0 (Revit2025)

### DIFF
--- a/src/DynamoRevit/DynamoRevit.csproj
+++ b/src/DynamoRevit/DynamoRevit.csproj
@@ -61,11 +61,11 @@
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="Greg">
-			<HintPath>$(PACKAGESPATH)\Greg\lib\net8.0\Greg.dll</HintPath>
+			<HintPath>$(PACKAGESPATH)\Greg\lib\net10.0\Greg.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="GregRevitAuth">
-			<HintPath>$(PACKAGESPATH)\GregRevitAuth\lib\net8.0\GregRevitAuth.dll</HintPath>
+			<HintPath>$(PACKAGESPATH)\GregRevitAuth\lib\net10.0\GregRevitAuth.dll</HintPath>
 			<Private>True</Private>
 		</Reference>
 		<Reference Include="Microsoft.Dynamic">


### PR DESCRIPTION
## Summary

Update remaining net8.0 references to net10.0 to ensure DynamoForRevit resource DLLs are built with .NET 10, as requested by the Translation team.

## Changes

- **DynamoRevit.csproj**: Updated Greg and GregRevitAuth HintPaths from `lib/net8.0` to `lib/net10.0`

## Context

JIRA: REVIT-250403
Similar fix for LocationSelector: REVIT-244697

The Translation team reports that having resources in different .NET versions in one database causes issues with the translation tool. These changes align all DynamoForRevit package references with the .NET 10 target framework already set in CS_SDK.props.

Companion PR for DynamoRevitUtils (Revit2025): https://git.autodesk.com/Dynamo/DynamoRevitUtils/compare/Revit2025...fusneif/REVIT-250403/update-net8-refs-to-net10