### PR TITLE
Add Sketch node

### DIFF
--- a/src/DynamoRevit/Resources/LayoutSpecs.json
+++ b/src/DynamoRevit/Resources/LayoutSpecs.json
@@ -242,6 +242,9 @@
                   "path": "RevitNodes.Revit.Elements.Room"
                 },
                 {
+                  "path": "RevitNodes.Revit.Elements.Sketch"
+                },
+                {
                   "path": "RevitNodes.Revit.Elements.SketchPlane"
                 },
                 {

--- a/src/Libraries/RevitNodes/Elements/PropertyLine.cs
+++ b/src/Libraries/RevitNodes/Elements/PropertyLine.cs
@@ -164,7 +164,7 @@ namespace Revit.Elements
         /// <summary>
         /// The Sketch element backing a sketch-based PropertyLine, or null for a table-based one.
         /// </summary>
-        public Element Sketch
+        public Sketch Sketch
         {
             get
             {
@@ -174,8 +174,8 @@ namespace Revit.Elements
                     return null;
                 }
 
-                Autodesk.Revit.DB.Element revitElement = Document.GetElement(sketchId);
-                return revitElement?.ToDSType(true) as Element;
+                var revitSketch = Document.GetElement(sketchId) as Autodesk.Revit.DB.Sketch;
+                return revitSketch == null ? null : Sketch.FromExisting(revitSketch, true);
             }
         }
 

--- a/src/Libraries/RevitNodes/Elements/Sketch.cs
+++ b/src/Libraries/RevitNodes/Elements/Sketch.cs
@@ -1,0 +1,194 @@
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.DesignScript.Geometry;
+using Autodesk.DesignScript.Runtime;
+using Autodesk.Revit.DB;
+using Revit.GeometryConversion;
+using Curve = Autodesk.DesignScript.Geometry.Curve;
+using DBCurve = Autodesk.Revit.DB.Curve;
+using DBSketch = Autodesk.Revit.DB.Sketch;
+
+namespace Revit.Elements
+{
+    /// <summary>
+    /// A Revit Sketch element. Sketches hold the model curves, reference planes
+    /// and dimensions that define the 2-dimensional profile of a sketch-based
+    /// element such as a Floor, Roof, or PropertyLine.
+    /// </summary>
+    public class Sketch : Element
+    {
+        #region Internal properties
+
+        /// <summary>
+        /// Internal handle on the Revit Sketch.
+        /// </summary>
+        internal DBSketch InternalSketch { get; private set; }
+
+        /// <summary>
+        /// Reference to the wrapped element.
+        /// </summary>
+        [SupressImportIntoVM]
+        public override Autodesk.Revit.DB.Element InternalElement
+        {
+            get { return InternalSketch; }
+        }
+
+        #endregion
+
+        #region Private constructors
+
+        private Sketch(DBSketch sketch)
+        {
+            SafeInit(() => InitSketch(sketch), true);
+        }
+
+        #endregion
+
+        #region Helpers for private constructors
+
+        private void InitSketch(DBSketch sketch)
+        {
+            InternalSetSketch(sketch);
+        }
+
+        #endregion
+
+        #region Private mutators
+
+        private void InternalSetSketch(DBSketch sketch)
+        {
+            InternalSketch = sketch;
+            InternalElementId = sketch.Id;
+            InternalUniqueId = sketch.UniqueId;
+        }
+
+        #endregion
+
+        #region Public properties
+
+        /// <summary>
+        /// The SketchPlane that this Sketch lies on.
+        /// </summary>
+        public SketchPlane SketchPlane
+        {
+            get
+            {
+                Autodesk.Revit.DB.SketchPlane revitSketchPlane = InternalSketch.SketchPlane;
+                return revitSketchPlane == null
+                    ? null
+                    : Revit.Elements.SketchPlane.FromExisting(revitSketchPlane, true);
+            }
+        }
+
+        /// <summary>
+        /// The element that owns this Sketch (for example the PropertyLine, Floor,
+        /// or Roof hosting it). Returns null when the Sketch is not yet attached
+        /// to an owning element.
+        /// </summary>
+        public Element Owner
+        {
+            get
+            {
+                ElementId ownerId = InternalSketch.OwnerId;
+                if (ownerId == null || ownerId == ElementId.InvalidElementId)
+                {
+                    return null;
+                }
+
+                Autodesk.Revit.DB.Element revitElement = Document.GetElement(ownerId);
+                return revitElement?.ToDSType(true) as Element;
+            }
+        }
+
+        /// <summary>
+        /// All elements that belong to this Sketch (typically model curves,
+        /// reference planes, and dimensions).
+        /// </summary>
+        public Element[] Elements
+        {
+            get
+            {
+                IList<ElementId> elementIds = InternalSketch.GetAllElements();
+                if (elementIds == null || elementIds.Count == 0)
+                {
+                    return new Element[0];
+                }
+
+                return elementIds
+                    .Select(id => Document.GetElement(id)?.ToDSType(true) as Element)
+                    .Where(e => e != null)
+                    .ToArray();
+            }
+        }
+
+        /// <summary>
+        /// The Sketch profile as one PolyCurve per closed loop.
+        /// </summary>
+        public PolyCurve[] Profile
+        {
+            get
+            {
+                var loops = new List<PolyCurve>();
+                CurveArrArray curveArrArray = InternalSketch.Profile;
+                if (curveArrArray == null)
+                {
+                    return loops.ToArray();
+                }
+
+                foreach (CurveArray curveArray in curveArrArray)
+                {
+                    if (curveArray == null || curveArray.Size == 0)
+                    {
+                        continue;
+                    }
+
+                    var protoCurves = new List<Curve>(curveArray.Size);
+                    foreach (DBCurve revitCurve in curveArray)
+                    {
+                        Curve protoCurve = revitCurve?.ToProtoType(true);
+                        if (protoCurve != null)
+                        {
+                            protoCurves.Add(protoCurve);
+                        }
+                    }
+
+                    if (protoCurves.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        loops.Add(PolyCurve.ByJoinedCurves(protoCurves.ToArray(), 0.001, false));
+                    }
+                    finally
+                    {
+                        foreach (Curve c in protoCurves)
+                        {
+                            c.Dispose();
+                        }
+                    }
+                }
+
+                return loops.ToArray();
+            }
+        }
+
+        #endregion
+
+        #region Internal static constructors
+
+        /// <summary>
+        /// Wraps a Revit-owned Sketch in the Dynamo Sketch wrapper.
+        /// </summary>
+        internal static Sketch FromExisting(DBSketch sketch, bool isRevitOwned)
+        {
+            return new Sketch(sketch)
+            {
+                IsRevitOwned = isRevitOwned
+            };
+        }
+
+        #endregion
+    }
+}

--- a/test/Libraries/RevitNodesTests/Elements/SketchTests.cs
+++ b/test/Libraries/RevitNodesTests/Elements/SketchTests.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using Autodesk.DesignScript.Geometry;
+using NUnit.Framework;
+using Revit.Elements;
+using RevitTestServices;
+using RTF.Framework;
+
+namespace RevitNodesTests.Elements
+{
+    [TestFixture]
+    public class SketchTests : RevitNodeTestBase
+    {
+        private static PolyCurve MakeSquareOutline(double size = 100)
+        {
+            var lines = new[]
+            {
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, 0, 0), Point.ByCoordinates(size, 0, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(size, 0, 0), Point.ByCoordinates(size, size, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(size, size, 0), Point.ByCoordinates(0, size, 0)),
+                Line.ByStartPointEndPoint(Point.ByCoordinates(0, size, 0), Point.ByCoordinates(0, 0, 0))
+            };
+            return PolyCurve.ByJoinedCurves(lines, 0.001, false);
+        }
+
+        private static Sketch MakeSketchFromPropertyLine(double size = 100)
+        {
+            var propertyLine = PropertyLine.ByCurveLoops(MakeSquareOutline(size));
+            Assume.That(propertyLine, Is.Not.Null, "PropertyLine should be created.");
+            Assume.That(propertyLine.IsSketchBased, Is.True, "PropertyLine should be sketch-based.");
+            return propertyLine.Sketch;
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void PropertyLineSketch_ReturnsTypedSketchWrapper()
+        {
+            var propertyLine = PropertyLine.ByCurveLoops(MakeSquareOutline());
+
+            Sketch sketch = propertyLine.Sketch;
+
+            Assert.NotNull(sketch);
+            Assert.IsInstanceOf<Sketch>(sketch);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void Sketch_SketchPlane_ReturnsValidSketchPlane()
+        {
+            var sketch = MakeSketchFromPropertyLine();
+
+            SketchPlane sketchPlane = sketch.SketchPlane;
+
+            Assert.NotNull(sketchPlane);
+            Assert.NotNull(sketchPlane.Plane);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void Sketch_Owner_ReturnsHostingPropertyLine()
+        {
+            var propertyLine = PropertyLine.ByCurveLoops(MakeSquareOutline());
+
+            var owner = propertyLine.Sketch.Owner;
+
+            Assert.NotNull(owner);
+            Assert.AreEqual(propertyLine.InternalElement.Id, owner.InternalElement.Id);
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void Sketch_Elements_ReturnsAtLeastOneSketchElement()
+        {
+            var sketch = MakeSketchFromPropertyLine();
+
+            var elements = sketch.Elements;
+
+            Assert.NotNull(elements);
+            Assert.IsTrue(elements.Length > 0,
+                "A sketch backing a closed-loop PropertyLine should contain at least one model curve.");
+            Assert.IsTrue(elements.All(e => e != null));
+        }
+
+        [Test]
+        [TestModel(@".\Empty.rvt")]
+        public void Sketch_Profile_ReturnsAtLeastOneClosedLoop()
+        {
+            var sketch = MakeSketchFromPropertyLine();
+
+            PolyCurve[] profile = sketch.Profile;
+
+            Assert.NotNull(profile);
+            Assert.IsTrue(profile.Length > 0, "Profile should contain at least one curve loop.");
+            Assert.IsTrue(profile.All(p => p != null));
+            Assert.IsTrue(profile[0].IsClosed,
+                "The boundary loop of a closed-square PropertyLine should be closed.");
+        }
+    }
+}


### PR DESCRIPTION
Wraps Autodesk.Revit.DB.Sketch as a read-only Dynamo node so graphs can inspect the sketch backing a sketch-based element (for example the Sketch returned by PropertyLine.Sketch on the new PropertyLine nodes).

* New Revit.Elements.Sketch wrapper exposes the Revit 2027 public_api surface from Sketch.ridl: SketchPlane (property sketchPlane), Owner (property OwnerId, resolved to the wrapped Element), and Elements (func getAllElements). The Profile getter (PolyCurve[] per closed loop) wraps the handwritten Profile property declared in APISketchHandwritten.h. No factories are exposed -- Sketches are obtainable only via host elements -- and no mutators, since none of them are public_api.
* PropertyLine.Sketch now returns the new Sketch wrapper instead of the generic Element, so PropertyLine -> Sketch -> SketchPlane / Owner / Elements / Profile chains compile without manual casts.
* Adds the new node to LayoutSpecs.json so it appears under Revit > Elements > Sketch in the Dynamo library tree (placed alphabetically between Room and SketchPlane).
* Adds RevitNodesTests.Elements.SketchTests covering the SketchPlane, Owner, Elements, and Profile getters by driving them through a PropertyLine-backed sketch.


<img width="298" height="204" alt="image" src="https://github.com/user-attachments/assets/df5cfc9d-dda1-4245-b88c-a8168dc86ee3" />

<img width="567" height="303" alt="image" src="https://github.com/user-attachments/assets/a3996cfa-d34f-4fda-81ef-de7f5e006b2c" />

Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.

### Purpose

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference 
to the tracking task that it is part or all of the solution for.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
