### PR TITLE
Upgrade Dynamo Core 4.1.0.4676 -> 4.1.1.5050

### DIFF
--- a/src/Config/packages_versions.props
+++ b/src/Config/packages_versions.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <!-- 3rd party package versions -->
-        <DYNAMOCORE_VERSION>4.1.0.4676</DYNAMOCORE_VERSION>
+        <DYNAMOCORE_VERSION>4.1.1.5050</DYNAMOCORE_VERSION>
 
         <DYNAMOWPFUI_VERSION Condition="'$(DYNAMOWPFUI_VERSION)' == ''">$(DYNAMOCORE_VERSION)</DYNAMOWPFUI_VERSION>
         <DYNAMOCORENODES_VERSION Condition="'$(DYNAMOCORENODES_VERSION)' == ''">$(DYNAMOCORE_VERSION)</DYNAMOCORENODES_VERSION>


### PR DESCRIPTION
Fixes REVIT-250592 (3 regression test failures in dev/2028):
- DYN-10436: UV scaling fix for degenerate surfaces (Tesselation_2)
- DYN-10440: Satellite assemblies leaking into pt-BR (PackageDllTest)

Part of REVIT-250927: Integrate Dynamo Core 4.1.1 in Revit 2028/master