### PR TITLE
REVIT-251132 (#3415)

### DIFF
--- a/src/DynamoRevit/DynamoRevit.cs
+++ b/src/DynamoRevit/DynamoRevit.cs
@@ -1114,6 +1114,13 @@ namespace Dynamo.Applications
 
             // Once Dynamo is closed, we want to set the current UI culture back to the default thread culture.
             System.Globalization.CultureInfo.CurrentUICulture = System.Globalization.CultureInfo.DefaultThreadCurrentCulture;
+
+            // REVIT-251132: forcefully close splash screen when closing Dynamo if during journal play and if it wasn't already closed
+            if (Journaling.IsJournalReplaying() && splashScreen != null)
+            {
+                splashScreen.Close();
+                splashScreen = null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
* forcefully close splash screen when closing Dynamo if during play of journal and it was still opened.

