### PR TITLE
REVIT-220855: gitignore Revit SDK lib/ and test/RTFWorkDir/ build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,12 @@ $RECYCLE.BIN/
 # Mac crap
 .DS_Store
 
+# Revit SDK binaries (37MB+ — checked out separately, not committed)
+lib/
+
+# RTF test working directory (build artifacts, Revit journals — not committed)
+test/RTFWorkDir/
+
 
 #############
 ## Python


### PR DESCRIPTION
Prevents accidental commits of:
- `lib/` - 37 MB Revit SDK DLLs (fetched from Azure/NetworkShare by CI)
- `test/RTFWorkDir/` - 347 MB RTF build artifacts and Revit journals

Part of [REVIT-220855](https://autodesk.atlassian.net/browse/REVIT-220855) CI/CD cleanup.