### PR TITLE
Revert DYNAMOCORE_VERSION to 4.1.1.5050 (pull back 4.1.2)

### DIFF
--- a/src/Config/packages_versions.props
+++ b/src/Config/packages_versions.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <!-- 3rd party package versions -->
-        <DYNAMOCORE_VERSION>4.1.2.5356</DYNAMOCORE_VERSION>
+        <DYNAMOCORE_VERSION>4.1.1.5050</DYNAMOCORE_VERSION>
 
         <DYNAMOWPFUI_VERSION Condition="'$(DYNAMOWPFUI_VERSION)' == ''">$(DYNAMOCORE_VERSION)</DYNAMOWPFUI_VERSION>
         <DYNAMOCORENODES_VERSION Condition="'$(DYNAMOCORENODES_VERSION)' == ''">$(DYNAMOCORE_VERSION)</DYNAMOCORENODES_VERSION>


### PR DESCRIPTION
## Summary
- Pull back DC **4.1.2.5356** integration from **Revit2027** (reverts #3418)
- Restore \DYNAMOCORE_VERSION\ to **4.1.1.5050** (#3413), the version Revit will ship with
- DC 4.1.2 will not be delivered due to **LibG regressions** (see REVIT-252739 / Jason Stratton decision)

## Context
AnalyticalAutomation regressions traced to LibG v5334 in DC 4.1.2. Revit proceeds with **4.1.1**; fix targeted for DC 4.2.

## Test plan
- [ ] Jenkins CI green on Revit2027 after merge
- [ ] Confirm NuGet restore resolves DynamoCore **4.1.1.5050** packages