### PR TITLE
Revert DYNAMOCORE_VERSION from 4.1.2 to 4.1.1 (pull back 4.1.2)

### DIFF
--- a/src/Config/packages_versions.props
+++ b/src/Config/packages_versions.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <!-- 3rd party package versions -->
-        <DYNAMOCORE_VERSION>4.1.2.5356</DYNAMOCORE_VERSION>
+        <DYNAMOCORE_VERSION>4.1.1.5050</DYNAMOCORE_VERSION>
 
         <DYNAMOWPFUI_VERSION Condition="'$(DYNAMOWPFUI_VERSION)' == ''">$(DYNAMOCORE_VERSION)</DYNAMOWPFUI_VERSION>
         <DYNAMOCORENODES_VERSION Condition="'$(DYNAMOCORENODES_VERSION)' == ''">$(DYNAMOCORE_VERSION)</DYNAMOCORENODES_VERSION>


### PR DESCRIPTION
## Summary
- Pull back DC **4.1.2.5356** integration from **master** (reverts #3417)
- Set `DYNAMOCORE_VERSION` to **4.1.1.5050** to align with Revit shipping version
- DC 4.1.2 will not be delivered due to **LibG regressions** (REVIT-252739)

## Notes
Master previously jumped **4.1.0 -> 4.1.2** (#3417); this lands master on **4.1.1** instead of restoring **4.1.0**, matching the Revit2027 release decision.

## Test plan
- [ ] Jenkins CI green on master after merge