### PR TITLE
Revert Dynamo 4.2.0-beta5666 bump (#3423)

### DIFF
--- a/src/Config/packages_versions.props
+++ b/src/Config/packages_versions.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <!-- 3rd party package versions -->
-        <DYNAMOCORE_VERSION>4.2.0-beta5666</DYNAMOCORE_VERSION>
+        <DYNAMOCORE_VERSION>4.1.1.5050</DYNAMOCORE_VERSION>
 
         <DYNAMOWPFUI_VERSION Condition="'$(DYNAMOWPFUI_VERSION)' == ''">$(DYNAMOCORE_VERSION)</DYNAMOWPFUI_VERSION>
         <DYNAMOCORENODES_VERSION Condition="'$(DYNAMOCORENODES_VERSION)' == ''">$(DYNAMOCORE_VERSION)</DYNAMOCORENODES_VERSION>


### PR DESCRIPTION
Reverts e10934b — bump was too early per Vlad. Restores DYNAMOCORE_VERSION to 4.1.1.5050.